### PR TITLE
fix: claude code harness compat, http session leaks, worktree paths

### DIFF
--- a/src/apps/tools.ts
+++ b/src/apps/tools.ts
@@ -25,7 +25,7 @@ body{font-family:var(--font-sans,system-ui,-apple-system,sans-serif);background:
 <div class="header" id="hdr">Calendar</div>
 <div id="content"><div class="loading">Loading events\u2026</div></div>
 <script type="module">
-import{App}from"https://esm.sh/@modelcontextprotocol/ext-apps@1.2.2";
+import{App}from"https://esm.sh/@modelcontextprotocol/ext-apps@1.5.0";
 const app=new App({name:"AirMCP Calendar",version:"1.0.0"});
 app.onhostcontextchanged=ctx=>{
   if(ctx.styles?.variables)Object.entries(ctx.styles.variables).forEach(([k,v])=>document.documentElement.style.setProperty(k,v));
@@ -69,7 +69,7 @@ body{font-family:var(--font-sans,system-ui,-apple-system,sans-serif);background:
 </style></head><body>
 <div class="player" id="p"><div class="stopped">No track playing</div></div>
 <script type="module">
-import{App}from"https://esm.sh/@modelcontextprotocol/ext-apps@1.2.2";
+import{App}from"https://esm.sh/@modelcontextprotocol/ext-apps@1.5.0";
 const app=new App({name:"AirMCP Music",version:"1.0.0"});
 app.onhostcontextchanged=ctx=>{
   if(ctx.styles?.variables)Object.entries(ctx.styles.variables).forEach(([k,v])=>document.documentElement.style.setProperty(k,v));

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -6,12 +6,17 @@
  */
 
 import { readFileSync, existsSync } from "node:fs";
-import { join } from "node:path";
+import { join, dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 import { execFileSync } from "node:child_process";
 import { MODULE_NAMES, STARTER_MODULES, NPM_PACKAGE_NAME, MCP_CLIENTS } from "../shared/config.js";
 import { HOME, PATHS } from "../shared/constants.js";
 import { LOGO_LINES, typeLine } from "../shared/banner.js";
 import { RESET, BOLD, DIM, WHITE, GREEN, SYM, heading, line, divider, spinner, sleep } from "./style.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+/** Package root — works in repo checkout, npm cache, and git worktrees. */
+const PKG_ROOT = resolve(__dirname, "..", "..");
 
 interface FileConfig {
   locale?: string;
@@ -80,7 +85,7 @@ export async function runDoctor(): Promise<void> {
       encoding: "utf8",
       timeout: 5000,
     }).trim();
-    const pkgPath = join(__dirname, "..", "package.json");
+    const pkgPath = join(PKG_ROOT, "package.json");
     let current = "unknown";
     try {
       current = JSON.parse(readFileSync(pkgPath, "utf-8")).version;
@@ -222,7 +227,7 @@ export async function runDoctor(): Promise<void> {
   // ── Swift Bridge ───────────────────────────────────────────────────
   console.log(heading("Optional"));
 
-  const swiftBridgePath = join(process.cwd(), "swift", ".build", "release", "AirMcpBridge");
+  const swiftBridgePath = join(PKG_ROOT, "swift", ".build", "release", "AirMcpBridge");
   if (existsSync(swiftBridgePath)) {
     ok("Swift bridge", "built");
   } else {

--- a/src/server/http-transport.ts
+++ b/src/server/http-transport.ts
@@ -141,27 +141,38 @@ export async function startHttpServer(options: HttpServerOptions): Promise<void>
     transport: StreamableHTTPServerTransport;
     server: import("@modelcontextprotocol/sdk/server/mcp.js").McpServer;
     lastActive: number;
+    cleanupEventListeners?: () => void;
   }
   const sessions = new Map<string, Session>();
+
+  /** Clean up all resources for a session (transport, server, event listeners). Idempotent. */
+  function destroySession(id: string, s: Session): void {
+    if (!sessions.has(id)) return; // Already destroyed by another async path
+    sessions.delete(id);
+    try {
+      s.cleanupEventListeners?.();
+      s.transport.close?.();
+      s.server.close?.();
+    } catch (e) {
+      console.error(`[AirMCP] Session ${id} cleanup error:`, e);
+    }
+  }
 
   const cleanupInterval = setInterval(() => {
     const now = Date.now();
     for (const id of [...sessions.keys()]) {
       const s = sessions.get(id);
       if (s && now - s.lastActive > TIMEOUT.SESSION_IDLE) {
-        try {
-          s.transport.close?.();
-          s.server.close?.();
-        } catch (e) {
-          console.error(`[AirMCP] Session ${id} cleanup error:`, e);
-        }
-        sessions.delete(id);
+        destroySession(id, s);
       }
     }
   }, TIMEOUT.SESSION_CLEANUP);
   if (cleanupInterval.unref) cleanupInterval.unref();
 
-  process.on("exit", () => clearInterval(cleanupInterval));
+  process.on("exit", () => {
+    clearInterval(cleanupInterval);
+    clearInterval(ratePruneTimer);
+  });
 
   // Health check — for load balancers, monitoring, and readiness probes
   // Note: session counts and uptime omitted to prevent information leakage
@@ -225,22 +236,18 @@ export async function startHttpServer(options: HttpServerOptions): Promise<void>
         return;
       }
 
-      const { server } = await createServer(serverOptions);
+      const { server, cleanupEventListeners } = await createServer(serverOptions);
       let assignedSessionId: string | undefined;
 
       const transport = new StreamableHTTPServerTransport({
         sessionIdGenerator: () => randomUUID(),
         onsessioninitialized: (id) => {
           assignedSessionId = id;
-          sessions.set(id, { transport, server, lastActive: Date.now() });
+          sessions.set(id, { transport, server, lastActive: Date.now(), cleanupEventListeners });
         },
         onsessionclosed: (id) => {
           const s = sessions.get(id);
-          if (s) {
-            s.transport.close?.();
-            s.server.close?.();
-          }
-          sessions.delete(id);
+          if (s) destroySession(id, s);
         },
       });
 
@@ -248,8 +255,7 @@ export async function startHttpServer(options: HttpServerOptions): Promise<void>
       transport.onclose = () => {
         if (assignedSessionId) {
           const s = sessions.get(assignedSessionId);
-          if (s) s.server.close?.();
-          sessions.delete(assignedSessionId);
+          if (s) destroySession(assignedSessionId, s);
         }
       };
 
@@ -258,6 +264,7 @@ export async function startHttpServer(options: HttpServerOptions): Promise<void>
 
       // If session was never initialized (transport rejected), clean up
       if (!assignedSessionId) {
+        transport.onclose = undefined;
         server.close?.();
       }
     } catch (err) {
@@ -286,6 +293,18 @@ export async function startHttpServer(options: HttpServerOptions): Promise<void>
         return;
       }
       s.lastActive = Date.now();
+
+      // For SSE GET streams: clean up immediately when the client disconnects
+      // (don't wait for the 60s cleanup interval). Without this, abrupt disconnects
+      // leave transport buffers + ReadableStream controllers in memory until idle timeout.
+      if (method === "GET" && sessionId) {
+        const sid = sessionId;
+        res.on("close", () => {
+          const entry = sessions.get(sid);
+          if (entry) destroySession(sid, entry);
+        });
+      }
+
       await s.transport.handleRequest(req, res);
     } catch (err) {
       console.error(`${method} /mcp error:`, err);
@@ -296,7 +315,12 @@ export async function startHttpServer(options: HttpServerOptions): Promise<void>
   app.delete("/mcp", (req, res) => handleSessionRequest(req, res, "DELETE"));
 
   // Pre-warm module registry + shortcuts cache (avoids per-session subprocess)
-  const { bannerInfo: bi, server: warmupServer } = await createServer(serverOptions);
+  const {
+    bannerInfo: bi,
+    server: warmupServer,
+    cleanupEventListeners: warmupCleanup,
+  } = await createServer(serverOptions);
+  warmupCleanup();
   warmupServer.close?.();
   const host = bindAll ? "0.0.0.0" : "127.0.0.1";
   app.listen(port, host, async () => {

--- a/src/server/mcp-setup.ts
+++ b/src/server/mcp-setup.ts
@@ -40,7 +40,7 @@ export interface CreateServerOptions {
 
 export async function createServer(
   options: CreateServerOptions,
-): Promise<{ server: SdkMcpServer; bannerInfo: BannerInfo }> {
+): Promise<{ server: SdkMcpServer; bannerInfo: BannerInfo; cleanupEventListeners: () => void }> {
   const { config, hitlClient, osVersion, pkg } = options;
 
   const server = new SdkMcpServer({
@@ -260,6 +260,23 @@ export async function createServer(
       },
     );
 
+  // Named event handlers — stored so they can be removed when the server closes
+  // (prevents listener accumulation across HTTP sessions).
+  const SNAPSHOT_KEYS = ["snapshot:standard", "snapshot:brief", "snapshot:full"];
+
+  function invalidateAndNotify(keys: string[]): void {
+    for (const k of keys) resourceCache.delete(k);
+    try {
+      server.sendResourceListChanged();
+    } catch {
+      /* client may not support notifications */
+    }
+  }
+
+  const onCalendarChanged = () => invalidateAndNotify(["calendar:today", "calendar:upcoming", ...SNAPSHOT_KEYS]);
+  const onRemindersChanged = () => invalidateAndNotify(["reminders:due", "reminders:today", ...SNAPSHOT_KEYS]);
+  const onPasteboardChanged = () => invalidateAndNotify(["system:clipboard"]);
+
   // event_subscribe: start real-time event observation
   lServer.registerTool(
     "event_subscribe",
@@ -280,45 +297,15 @@ export async function createServer(
         }
         await runSwift("start-observer", "{}");
         // Remove any existing listeners before re-attaching (idempotent)
-        eventBus.removeAllListeners("calendar_changed");
-        eventBus.removeAllListeners("reminders_changed");
-        eventBus.removeAllListeners("pasteboard_changed");
+        eventBus.off("calendar_changed", onCalendarChanged);
+        eventBus.off("reminders_changed", onRemindersChanged);
+        eventBus.off("pasteboard_changed", onPasteboardChanged);
         eventBus.start();
 
         // Connect events to MCP resource notifications
-        eventBus.on("calendar_changed", () => {
-          resourceCache.delete("calendar:today");
-          resourceCache.delete("calendar:upcoming");
-          resourceCache.delete("snapshot:standard");
-          resourceCache.delete("snapshot:brief");
-          resourceCache.delete("snapshot:full");
-          // Notify MCP clients that resources changed
-          try {
-            server.sendResourceListChanged();
-          } catch {
-            /* client may not support notifications */
-          }
-        });
-        eventBus.on("reminders_changed", () => {
-          resourceCache.delete("reminders:due");
-          resourceCache.delete("reminders:today");
-          resourceCache.delete("snapshot:standard");
-          resourceCache.delete("snapshot:brief");
-          resourceCache.delete("snapshot:full");
-          try {
-            server.sendResourceListChanged();
-          } catch {
-            /* client may not support notifications */
-          }
-        });
-        eventBus.on("pasteboard_changed", () => {
-          resourceCache.delete("system:clipboard");
-          try {
-            server.sendResourceListChanged();
-          } catch {
-            /* client may not support notifications */
-          }
-        });
+        eventBus.on("calendar_changed", onCalendarChanged);
+        eventBus.on("reminders_changed", onRemindersChanged);
+        eventBus.on("pasteboard_changed", onPasteboardChanged);
 
         return ok({ status: "started", monitoring: ["calendar", "reminders", "pasteboard"] });
       } catch (e) {
@@ -438,5 +425,12 @@ export async function createServer(
     compactTools: isCompactMode(),
   };
 
-  return { server, bannerInfo };
+  /** Remove this server's eventBus listeners. Call on session close to prevent listener accumulation. */
+  const cleanupEventListeners = () => {
+    eventBus.off("calendar_changed", onCalendarChanged);
+    eventBus.off("reminders_changed", onRemindersChanged);
+    eventBus.off("pasteboard_changed", onPasteboardChanged);
+  };
+
+  return { server, bannerInfo, cleanupEventListeners };
 }

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -190,6 +190,4 @@ export const PATHS = {
   VECTOR_STORE: join(HOME, ".airmcp"),
   /** Usage profile */
   USAGE_PROFILE: join(HOME, ".airmcp", "profile.json"),
-  /** Swift bridge binary (relative to project root) */
-  SWIFT_BRIDGE: "../../swift/.build/release/AirMcpBridge",
 } as const;

--- a/src/shared/hitl-guard.ts
+++ b/src/shared/hitl-guard.ts
@@ -10,6 +10,29 @@ interface ToolAnnotations {
   openWorldHint?: boolean;
 }
 
+/**
+ * Clients whose harness already enforces tool-call permissions.
+ * When one of these clients is detected, skip MCP elicitation to avoid
+ * double-approval UX (harness prompt + elicitation prompt).
+ * Socket-based HITL remains active as it's a separate, explicit channel.
+ */
+const MANAGED_CLIENT_NAMES: ReadonlySet<string> = new Set(["claude code", "claude-code"]);
+
+/**
+ * Returns true if the connected MCP client has its own permission management,
+ * making MCP elicitation redundant (would cause double-approval).
+ * Checks `clientInfo.name` provided during MCP initialization handshake.
+ */
+function isManagedClient(server: McpServer): boolean {
+  try {
+    const info = server.server?.getClientVersion?.();
+    if (!info?.name) return false;
+    return MANAGED_CLIENT_NAMES.has(info.name.toLowerCase());
+  } catch {
+    return false;
+  }
+}
+
 function shouldRequireApproval(
   level: HitlLevel,
   annotations: ToolAnnotations,
@@ -97,16 +120,19 @@ export function installHitlGuard(server: McpServer, hitlClient: HitlClient, conf
       const toolArgs = (args[0] ?? {}) as Record<string, unknown>;
       const destructive = annotations.destructiveHint ?? false;
 
-      // Try MCP Elicitation first (protocol-native, works everywhere)
-      const elicitResult = await tryElicitApproval(server, name, toolArgs, destructive);
-      if (elicitResult !== undefined) {
-        if (!elicitResult) {
-          return err(`Action denied: "${name}" was rejected via MCP elicitation.`);
+      // Skip MCP elicitation for clients with their own permission system
+      // (e.g. Claude Code) to avoid double-approval UX.
+      if (!isManagedClient(server)) {
+        const elicitResult = await tryElicitApproval(server, name, toolArgs, destructive);
+        if (elicitResult !== undefined) {
+          if (!elicitResult) {
+            return err(`Action denied: "${name}" was rejected via MCP elicitation.`);
+          }
+          return (callback as (...a: unknown[]) => unknown)(...args);
         }
-        return (callback as (...a: unknown[]) => unknown)(...args);
       }
 
-      // Fallback: socket-based HITL
+      // Fallback: socket-based HITL (separate channel — always available)
       const approved = await hitlClient.requestApproval(
         name,
         toolArgs,

--- a/src/shared/result.ts
+++ b/src/shared/result.ts
@@ -69,6 +69,23 @@ export function okLinkedStructured(toolName: string, data: unknown) {
   return base;
 }
 
+/**
+ * Attach `_meta["anthropic/maxResultSizeChars"]` to a tool result.
+ *
+ * Claude Code (and compatible harnesses) use this hint to avoid truncating
+ * large MCP results. The hint is advisory — clients that don't recognise it
+ * simply ignore the field.
+ *
+ * @param maxChars  Maximum result size the client should accept (cap: 500 000).
+ */
+export function withResultSizeHint<T extends { content: unknown[]; _meta?: Record<string, unknown> }>(
+  result: T,
+  maxChars: number,
+): T {
+  const capped = Math.min(Math.max(maxChars, 0), 500_000);
+  return { ...result, _meta: { ...result._meta, "anthropic/maxResultSizeChars": capped } };
+}
+
 /** Return an MCP tool error response. */
 export function err(message: string) {
   return {

--- a/src/shared/swift.ts
+++ b/src/shared/swift.ts
@@ -3,10 +3,12 @@ import { access } from "node:fs/promises";
 import { resolve, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 import { randomUUID } from "node:crypto";
-import { TIMEOUT, BUFFER, PATHS } from "./constants.js";
+import { TIMEOUT, BUFFER } from "./constants.js";
 
+// Package root — works in repo checkout, npm cache, and git worktrees.
 const __dirname = dirname(fileURLToPath(import.meta.url));
-const BINARY_PATH = resolve(__dirname, PATHS.SWIFT_BRIDGE);
+const PKG_ROOT = resolve(__dirname, "..", "..");
+const BINARY_PATH = resolve(PKG_ROOT, "swift", ".build", "release", "AirMcpBridge");
 
 // ── Bridge availability check ────────────────────────────────────────
 

--- a/src/shared/tool-registry.ts
+++ b/src/shared/tool-registry.ts
@@ -18,6 +18,23 @@ import type { McpServer, AnyFn } from "./mcp.js";
 import { usageTracker } from "./usage-tracker.js";
 import { auditLog } from "./audit.js";
 import { compactDescription } from "./tool-filter.js";
+import { withResultSizeHint } from "./result.js";
+
+/** Threshold in characters above which we auto-attach a result size hint. */
+const SIZE_HINT_THRESHOLD = 10_000;
+
+/** If the tool result's text content exceeds SIZE_HINT_THRESHOLD, attach _meta size hint. */
+function autoSizeHint(result: unknown): unknown {
+  if (!result || typeof result !== "object") return result;
+  const r = result as { content?: Array<{ text?: string }>; _meta?: Record<string, unknown> };
+  if (!Array.isArray(r.content)) return result;
+  // Already has an explicit hint — don't override.
+  if (r._meta?.["anthropic/maxResultSizeChars"] !== undefined) return result;
+  const totalChars = r.content.reduce((sum, c) => sum + (c.text?.length ?? 0), 0);
+  if (totalChars <= SIZE_HINT_THRESHOLD) return result;
+  // Scale hint to 2× actual size (headroom for next call), capped at 500K.
+  return withResultSizeHint(r as Parameters<typeof withResultSizeHint>[0], totalChars * 2);
+}
 
 interface RegisteredToolEntry {
   handler: AnyFn;
@@ -117,15 +134,29 @@ class ToolRegistry {
    * `server.registerTool()`, `server.prompt()`, and `server.registerPrompt()`
    * call automatically tracks the registration in this registry.
    *
-   * Must be called once, before any module registrations. Compatible with
-   * the HITL guard monkey-patch (call this AFTER `installHitlGuard` so that
-   * the handler stored here already includes the HITL wrapper).
+   * Must be called once per server, before any module registrations.
+   * Compatible with the HITL guard monkey-patch (call this AFTER
+   * `installHitlGuard` so that the handler stored here already includes
+   * the HITL wrapper).
+   *
+   * In HTTP mode, multiple sessions create servers and call this method.
+   * Only the first call clears the registry; subsequent calls overwrite
+   * entries so concurrent sessions never see an empty registry during
+   * the async gap between clear and re-registration.
    */
   installOn(server: McpServer): void {
-    this.tools.clear();
-    this.prompts.clear();
+    if (this.tools.size === 0) {
+      this.tools.clear();
+      this.prompts.clear();
+    }
     this.interceptToolRegistration(server);
     this.interceptPromptRegistration(server);
+  }
+
+  /** Reset the registry. For test isolation only. */
+  reset(): void {
+    this.tools.clear();
+    this.prompts.clear();
   }
 
   /**
@@ -160,7 +191,7 @@ class ToolRegistry {
         if (process.env.AIRMCP_USAGE_TRACKING !== "false") usageTracker.record(name);
         const start = Date.now();
         try {
-          const result = await handler(...args);
+          let result = await handler(...args);
           if (process.env.AIRMCP_AUDIT_LOG !== "false") {
             auditLog({
               timestamp: new Date(start).toISOString(),
@@ -170,6 +201,10 @@ class ToolRegistry {
               durationMs: Date.now() - start,
             });
           }
+          // Auto-attach _meta size hint for large results (>10 KB).
+          // Prevents Claude Code (and compatible harnesses) from truncating
+          // data-heavy tool responses (list/search/read operations).
+          result = autoSizeHint(result);
           return result;
         } catch (e) {
           if (process.env.AIRMCP_AUDIT_LOG !== "false") {

--- a/src/skills/index.ts
+++ b/src/skills/index.ts
@@ -7,6 +7,8 @@ import { registerSkills } from "./register.js";
 import { registerTrigger, startTriggerListener } from "./triggers.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
+// Resolves to dist/skills/builtins/ — works in repo checkout, npm cache, and git worktrees
+// because builtins are copied into dist/ during build (scripts/build.mjs).
 const BUILTINS_DIR = join(__dirname, "builtins");
 
 let skillsWatcher: FSWatcher | null = null;

--- a/tests/tool-registry.test.js
+++ b/tests/tool-registry.test.js
@@ -45,6 +45,7 @@ describe('ToolRegistry (mock server)', () => {
   let server;
 
   beforeEach(() => {
+    toolRegistry.reset();
     server = createMockServer();
     toolRegistry.installOn(server);
   });
@@ -161,13 +162,20 @@ describe('ToolRegistry (mock server)', () => {
     expect(toolRegistry.getPromptCallback('nonexistent')).toBeUndefined();
   });
 
-  test('installOn clears previous registrations', () => {
+  test('installOn preserves entries when re-installed (HTTP multi-session safety)', () => {
     server.registerTool('old_tool', { title: 'Old' }, async () => ({}));
     expect(toolRegistry.getToolCount()).toBe(1);
 
-    // Re-install on a new server
+    // Re-install on a new server — entries preserved (no race window)
     const server2 = createMockServer();
     toolRegistry.installOn(server2);
+    expect(toolRegistry.getToolCount()).toBe(1);
+  });
+
+  test('reset() clears all registrations', () => {
+    server.registerTool('old_tool', { title: 'Old' }, async () => ({}));
+    expect(toolRegistry.getToolCount()).toBe(1);
+    toolRegistry.reset();
     expect(toolRegistry.getToolCount()).toBe(0);
   });
 });
@@ -184,6 +192,7 @@ describe('ToolRegistry monkey-patch on real McpServer (SDK integration)', () => 
   let server;
 
   beforeEach(() => {
+    toolRegistry.reset();
     server = new McpServer({ name: 'test-server', version: '0.0.1' });
     toolRegistry.installOn(server);
   });


### PR DESCRIPTION
## Summary

- **MCP result size hint**: auto-attach `_meta["anthropic/maxResultSizeChars"]` for tool results >10KB to prevent Claude Code from truncating data-heavy responses
- **HITL double-approval fix**: detect Claude Code via MCP `clientInfo` and skip elicitation (harness already enforces permissions)
- **HTTP session memory leaks**: add `res.on('close')` for SSE streams, extract idempotent `destroySession()`, clean up eventBus listeners on session teardown
- **Worktree compatibility**: resolve Swift bridge and doctor paths from `PKG_ROOT` instead of `process.cwd()` or fragile `__dirname` chains
- **Singleton registry race fix**: `toolRegistry.installOn()` no longer clears entries on re-install, preventing empty registry during async module loading in concurrent HTTP sessions
- **ext-apps CDN pin**: update from `@1.2.2` to `@1.5.0` to match npm dependency

## Test plan

- [x] 858/858 tests pass (74 suites)
- [x] Build passes (esbuild)
- [x] Lint + prettier hooks pass
- [x] No conflicts with PR #38 (simplify) or PR #39 (hardcoded stats)
- [x] Issue #28 fixes verified intact (outputSchema, HITL, reminder pagination)