### PR TITLE
fix: skip elicitation for claude desktop/cowork clients

### DIFF
--- a/src/shared/hitl-guard.ts
+++ b/src/shared/hitl-guard.ts
@@ -11,12 +11,15 @@ interface ToolAnnotations {
 }
 
 /**
- * Clients whose harness already enforces tool-call permissions.
- * When one of these clients is detected, skip MCP elicitation to avoid
- * double-approval UX (harness prompt + elicitation prompt).
+ * Clients where MCP elicitation should be skipped.
+ *
+ * "claude code" / "claude-code" — harness enforces permissions; elicitation = double-approval.
+ * "claude-ai" — Claude Desktop / Cowork / claude.ai; elicitation prompt does not surface
+ *               in agentic contexts (issue #28), causing silent timeout → denial.
+ *
  * Socket-based HITL remains active as it's a separate, explicit channel.
  */
-const MANAGED_CLIENT_NAMES: ReadonlySet<string> = new Set(["claude code", "claude-code"]);
+const MANAGED_CLIENT_NAMES: ReadonlySet<string> = new Set(["claude code", "claude-code", "claude-ai"]);
 
 /**
  * Returns true if the connected MCP client has its own permission management,


### PR DESCRIPTION
## Summary

- Add `"claude-ai"` to `MANAGED_CLIENT_NAMES` in hitl-guard.ts
- Claude Desktop and Cowork send `clientInfo.name: "claude-ai"` during MCP handshake
- Elicitation prompts don't surface in agentic contexts (issue #28), causing silent timeout → tool denial
- These clients now fall through directly to socket-based HITL

## Context

With Cowork GA (all paid plans), this silent failure affects significantly more users. Previously only caught by one reporter who diagnosed it manually (`hitl.level: "off"` workaround).

## Test plan

- [x] 858/858 tests pass
- [x] Build + lint pass
- [x] `clientInfo.name: "claude-ai"` confirmed via [GitHub issue #36818](https://github.com/anthropics/claude-code/issues/36818) MCP init logs