### PR TITLE
fix: comprehensive security audit across 35 modules

### DIFF
--- a/src/bluetooth/tools.ts
+++ b/src/bluetooth/tools.ts
@@ -1,7 +1,7 @@
 import type { McpServer } from "../shared/mcp.js";
 import { z } from "zod";
 import type { AirMcpConfig } from "../shared/config.js";
-import { ok, toolError } from "../shared/result.js";
+import { ok, okUntrusted, toolError } from "../shared/result.js";
 import { runSwift } from "../shared/swift.js";
 
 interface BluetoothStateResult {
@@ -64,7 +64,7 @@ export function registerBluetoothTools(server: McpServer, _config: AirMcpConfig)
     },
     async ({ duration }) => {
       try {
-        return ok(await runSwift<BluetoothScanResult>("scan-bluetooth", JSON.stringify({ duration })));
+        return okUntrusted(await runSwift<BluetoothScanResult>("scan-bluetooth", JSON.stringify({ duration })));
       } catch (e) {
         return toolError("scan bluetooth", e);
       }

--- a/src/calendar/tools.ts
+++ b/src/calendar/tools.ts
@@ -3,7 +3,7 @@ import { z } from "zod";
 import { runAutomation } from "../shared/automation.js";
 import { runSwift } from "../shared/swift.js";
 import type { AirMcpConfig } from "../shared/config.js";
-import { ok, okLinkedStructured, okUntrusted, okStructured, toolError } from "../shared/result.js";
+import { ok, okUntrusted, okUntrustedStructured, okUntrustedLinkedStructured, toolError } from "../shared/result.js";
 import {
   listCalendarsScript,
   listEventsScript,
@@ -167,7 +167,7 @@ export function registerCalendarTools(server: McpServer, _config: AirMcpConfig):
           },
           jxa: () => listEventsScript(startDate, endDate, limit, offset, calendar),
         });
-        return okStructured(result);
+        return okUntrustedStructured(result);
       } catch (e) {
         return toolError("list events", e);
       }
@@ -350,7 +350,7 @@ export function registerCalendarTools(server: McpServer, _config: AirMcpConfig):
           },
           jxa: () => searchEventsScript(query, startDate, endDate, limit),
         });
-        return okStructured(result);
+        return okUntrustedStructured(result);
       } catch (e) {
         return toolError("search events", e);
       }
@@ -394,7 +394,7 @@ export function registerCalendarTools(server: McpServer, _config: AirMcpConfig):
           swift: { command: "get-upcoming-events", input: { limit } },
           jxa: () => getUpcomingEventsScript(limit),
         });
-        return okStructured(result);
+        return okUntrustedStructured(result);
       } catch (e) {
         return toolError("get upcoming events", e);
       }
@@ -434,7 +434,7 @@ export function registerCalendarTools(server: McpServer, _config: AirMcpConfig):
           swift: { command: "today-events" },
           jxa: () => todayEventsScript(),
         });
-        return okLinkedStructured("today_events", result);
+        return okUntrustedLinkedStructured("today_events", result);
       } catch (e) {
         return toolError("get today's events", e);
       }

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -12,6 +12,7 @@ import { execFileSync } from "node:child_process";
 import { MODULE_NAMES, STARTER_MODULES, NPM_PACKAGE_NAME, MCP_CLIENTS } from "../shared/config.js";
 import { HOME, PATHS } from "../shared/constants.js";
 import { LOGO_LINES, typeLine } from "../shared/banner.js";
+import { esc } from "../shared/esc.js";
 import { RESET, BOLD, DIM, WHITE, GREEN, SYM, heading, line, divider, spinner, sleep } from "./style.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -206,10 +207,11 @@ export async function runDoctor(): Promise<void> {
       const appName = APP_MAP[mod];
       if (!appName) continue;
       try {
-        execFileSync("osascript", ["-l", "JavaScript", "-e", `Application('${appName}'); JSON.stringify({ok:true})`], {
-          timeout: 5000,
-          stdio: "pipe",
-        });
+        execFileSync(
+          "osascript",
+          ["-l", "JavaScript", "-e", `Application('${esc(appName)}'); JSON.stringify({ok:true})`],
+          { timeout: 5000, stdio: "pipe" },
+        );
         permResults.push({ app: appName, ok: true });
       } catch {
         permResults.push({ app: appName, ok: false });

--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -6,11 +6,12 @@
  * 3. Auto-detect and patch MCP client configs (Claude Desktop, Cursor, Windsurf, etc.)
  */
 
-import { readFileSync, writeFileSync, mkdirSync, existsSync } from "node:fs";
+import { readFileSync, writeFileSync, mkdirSync, existsSync, copyFileSync } from "node:fs";
 import { join } from "node:path";
 import { MODULE_NAMES, STARTER_MODULES, NPM_PACKAGE_NAME, MCP_CLIENTS } from "../shared/config.js";
 import { PATHS } from "../shared/constants.js";
 import { LOGO_LINES, typeLine, sleep, writeOut } from "../shared/banner.js";
+import { isPlainObject } from "../shared/validate.js";
 import { selectOne, selectMulti, type SelectOption, type MultiOption } from "./select.js";
 
 // ── Module metadata ──────────────────────────────────────────────────
@@ -347,15 +348,34 @@ export async function runInit(): Promise<void> {
   process.stdout.write(`  ${t("writing_config", lang)}`);
 
   mkdirSync(PATHS.CONFIG_DIR, { recursive: true });
+
+  // Preserve unknown fields from any existing config so a re-run of init
+  // doesn't wipe out hand-edited keys (e.g. hitl.whitelist, future flags).
+  let existingConfig: Record<string, unknown> = {};
+  if (existsSync(PATHS.CONFIG)) {
+    try {
+      const parsed: unknown = JSON.parse(readFileSync(PATHS.CONFIG, "utf-8"));
+      if (isPlainObject(parsed)) {
+        existingConfig = parsed;
+      }
+    } catch {
+      // Corrupt existing config — overwrite from scratch
+    }
+  }
+  const existingHitl = isPlainObject(existingConfig.hitl) ? existingConfig.hitl : {};
+  const existingFeatures = isPlainObject(existingConfig.features) ? existingConfig.features : {};
+
   const configPayload = {
+    ...existingConfig,
     locale: lang,
     disabledModules,
     includeShared: permSelected.has("includeShared"),
     allowSendMessages: permSelected.has("sendMessages"),
     allowSendMail: permSelected.has("sendMail"),
     allowRunJavascript: permSelected.has("runJavascript"),
-    hitl: { level: hitlLevel },
+    hitl: { ...existingHitl, level: hitlLevel },
     features: {
+      ...existingFeatures,
       usageTracking: featureSelected.has("usageTracking"),
       auditLog: featureSelected.has("auditLog"),
       semanticToolSearch: featureSelected.has("semanticToolSearch"),
@@ -387,13 +407,24 @@ export async function runInit(): Promise<void> {
     try {
       let existing: Record<string, unknown> = {};
       if (configExists) {
-        existing = JSON.parse(readFileSync(client.configPath, "utf-8"));
+        const parsed: unknown = JSON.parse(readFileSync(client.configPath, "utf-8"));
+        if (!isPlainObject(parsed)) {
+          throw new Error(`existing config is not a JSON object`);
+        }
+        existing = parsed;
       }
 
-      const servers = (existing[client.serversKey] as Record<string, unknown>) ?? {};
+      const rawServers = existing[client.serversKey];
+      const servers: Record<string, unknown> = isPlainObject(rawServers) ? rawServers : {};
       servers.airmcp = airmcpEntry;
       existing[client.serversKey] = servers;
 
+      // Snapshot the original file before overwriting so users can recover
+      // if the wizard ever produces unexpected output. .bak.<timestamp> keeps
+      // older snapshots from being clobbered on repeated runs.
+      if (configExists) {
+        copyFileSync(client.configPath, `${client.configPath}.bak.${Date.now()}`);
+      }
       mkdirSync(join(client.configPath, ".."), { recursive: true });
       writeFileSync(client.configPath, JSON.stringify(existing, null, 2) + "\n");
       console.log(` ${GREEN}\u2713${RESET}`);

--- a/src/contacts/tools.ts
+++ b/src/contacts/tools.ts
@@ -2,7 +2,7 @@ import type { McpServer } from "../shared/mcp.js";
 import { z } from "zod";
 import { runAutomation } from "../shared/automation.js";
 import type { AirMcpConfig } from "../shared/config.js";
-import { ok, okLinkedStructured, okUntrustedStructured, okStructured, toolError } from "../shared/result.js";
+import { ok, okUntrustedStructured, okUntrustedLinkedStructured, toolError } from "../shared/result.js";
 import {
   listContactsScript,
   searchContactsScript,
@@ -124,7 +124,7 @@ export function registerContactTools(server: McpServer, _config: AirMcpConfig): 
           swift: { command: "list-contacts", input: { limit, offset } },
           jxa: () => listContactsScript(limit, offset),
         });
-        return okLinkedStructured("list_contacts", result);
+        return okUntrustedLinkedStructured("list_contacts", result);
       } catch (e) {
         return toolError("list contacts", e);
       }
@@ -162,7 +162,7 @@ export function registerContactTools(server: McpServer, _config: AirMcpConfig): 
           swift: { command: "search-contacts", input: { query, limit } },
           jxa: () => searchContactsScript(query, limit),
         });
-        return okStructured(result);
+        return okUntrustedStructured(result);
       } catch (e) {
         return toolError("search contacts", e);
       }
@@ -391,7 +391,7 @@ export function registerContactTools(server: McpServer, _config: AirMcpConfig): 
           swift: { command: "list-group-members", input: { groupName, limit } },
           jxa: () => listGroupMembersScript(groupName, limit),
         });
-        return okStructured(result);
+        return okUntrustedStructured(result);
       } catch (e) {
         return toolError("list group members", e);
       }

--- a/src/finder/tools.ts
+++ b/src/finder/tools.ts
@@ -180,6 +180,7 @@ export function registerFinderTools(server: McpServer, _config: AirMcpConfig): v
     },
     async ({ path }) => {
       try {
+        resolveAndGuard(path);
         return ok(await runJxa(createFolderScript(path)));
       } catch (e) {
         return toolError("create folder", e);

--- a/src/google/gws.ts
+++ b/src/google/gws.ts
@@ -20,6 +20,28 @@ const GWS_MAX_BUFFER = BUFFER.GWS;
 /** Resolved path to gws binary — uses npx as fallback. */
 let gwsBinary: string | null = null;
 
+/**
+ * Build the env passed to gws once at module load. We deliberately don't
+ * forward unrelated process.env entries (ANTHROPIC_API_KEY, GEMINI_API_KEY,
+ * AIRMCP_HTTP_TOKEN, etc.) to a third-party binary. The relevant env vars
+ * (PATH, HOME, GWS_*, GOOGLE_*) are set at startup and don't change at runtime.
+ */
+const SAFE_ENV_KEYS = ["PATH", "HOME", "USER", "LOGNAME", "SHELL", "LANG", "LC_ALL", "TMPDIR", "TZ"];
+const GWS_SAFE_ENV: NodeJS.ProcessEnv = (() => {
+  const env: NodeJS.ProcessEnv = {};
+  for (const key of SAFE_ENV_KEYS) {
+    const v = process.env[key];
+    if (v !== undefined) env[key] = v;
+  }
+  for (const key of Object.keys(process.env)) {
+    if (key.startsWith("GWS_") || key.startsWith("GOOGLE_")) {
+      const v = process.env[key];
+      if (v !== undefined) env[key] = v;
+    }
+  }
+  return env;
+})();
+
 async function resolveGwsBinary(): Promise<string> {
   if (gwsBinary) return gwsBinary;
 
@@ -91,7 +113,7 @@ export async function runGws<T = unknown>(
     const result = await execFileAsync(bin, args, {
       timeout,
       maxBuffer: GWS_MAX_BUFFER,
-      env: { ...process.env },
+      env: GWS_SAFE_ENV,
     });
     stdout = result.stdout;
   } catch (e) {

--- a/src/google/tools.ts
+++ b/src/google/tools.ts
@@ -177,7 +177,7 @@ export function registerGoogleTools(server: McpServer, config: AirMcpConfig): vo
     },
     async ({ fileId }) => {
       try {
-        return ok(
+        return okUntrusted(
           await runGws("drive", "files", "get", {
             fileId,
             fields: "id,name,mimeType,modifiedTime,size,webViewLink,owners,shared,description",
@@ -435,7 +435,7 @@ export function registerGoogleTools(server: McpServer, config: AirMcpConfig): vo
     },
     async ({ query, pageSize }) => {
       try {
-        return ok(
+        return okUntrusted(
           await runGws("people", "people", "searchContacts", {
             query,
             pageSize,

--- a/src/intelligence/tools.ts
+++ b/src/intelligence/tools.ts
@@ -219,7 +219,11 @@ export function registerIntelligenceTools(server: McpServer, _config: AirMcpConf
         "Classify and tag content using Apple's on-device Foundation Model. Returns confidence scores for each provided tag/category. Requires macOS 26+.",
       inputSchema: {
         text: z.string().max(10000).describe("The text content to classify"),
-        tags: z.array(z.string()).min(1).describe("List of tag/category names to classify the content against"),
+        tags: z
+          .array(z.string().max(200))
+          .min(1)
+          .max(100)
+          .describe("List of tag/category names to classify the content against"),
       },
       annotations: {
         readOnlyHint: true,
@@ -290,7 +294,7 @@ export function registerIntelligenceTools(server: McpServer, _config: AirMcpConf
       },
       annotations: {
         readOnlyHint: false,
-        destructiveHint: false,
+        destructiveHint: true,
         idempotentHint: false,
         openWorldHint: false,
       },

--- a/src/keynote/tools.ts
+++ b/src/keynote/tools.ts
@@ -2,7 +2,7 @@ import type { McpServer } from "../shared/mcp.js";
 import { z } from "zod";
 import { runJxa } from "../shared/jxa.js";
 import type { AirMcpConfig } from "../shared/config.js";
-import { ok, toolError } from "../shared/result.js";
+import { ok, okUntrusted, toolError } from "../shared/result.js";
 import { zFilePath } from "../shared/validate.js";
 import {
   listDocumentsScript,
@@ -63,7 +63,7 @@ export function registerKeynoteTools(server: McpServer, _config: AirMcpConfig): 
     },
     async ({ document }) => {
       try {
-        return ok(await runJxa(listSlidesScript(document)));
+        return okUntrusted(await runJxa(listSlidesScript(document)));
       } catch (e) {
         return toolError("list Keynote slides", e);
       }
@@ -83,7 +83,7 @@ export function registerKeynoteTools(server: McpServer, _config: AirMcpConfig): 
     },
     async ({ document, slideNumber }) => {
       try {
-        return ok(await runJxa(getSlideScript(document, slideNumber)));
+        return okUntrusted(await runJxa(getSlideScript(document, slideNumber)));
       } catch (e) {
         return toolError("get Keynote slide", e);
       }

--- a/src/location/tools.ts
+++ b/src/location/tools.ts
@@ -1,6 +1,6 @@
 import type { McpServer } from "../shared/mcp.js";
 import type { AirMcpConfig } from "../shared/config.js";
-import { ok, toolError } from "../shared/result.js";
+import { ok, okUntrusted, toolError } from "../shared/result.js";
 import { runSwift } from "../shared/swift.js";
 
 interface LocationResult {
@@ -35,7 +35,7 @@ export function registerLocationTools(server: McpServer, _config: AirMcpConfig):
     },
     async () => {
       try {
-        return ok(await runSwift<LocationResult>("get-location", "{}"));
+        return okUntrusted(await runSwift<LocationResult>("get-location", "{}"));
       } catch (e) {
         return toolError("get current location", e);
       }

--- a/src/mail/tools.ts
+++ b/src/mail/tools.ts
@@ -17,7 +17,6 @@ import {
   replyMailScript,
 } from "./scripts.js";
 import { LIMITS } from "../shared/constants.js";
-import { auditLog } from "../shared/audit.js";
 
 export function registerMailTools(server: McpServer, config: AirMcpConfig): void {
   const { allowSendMail } = config;
@@ -259,25 +258,9 @@ export function registerMailTools(server: McpServer, config: AirMcpConfig): void
     async ({ to, subject, body, cc, bcc, account }) => {
       if (!allowSendMail)
         return err("Sending mail is disabled. Set allowSendMail: true in config or AIRMCP_ALLOW_SEND_MAIL=true.");
-      const start = Date.now();
       try {
-        const result = await runJxa(sendMailScript(to, subject, body, cc, bcc, account));
-        auditLog({
-          timestamp: new Date().toISOString(),
-          tool: "send_mail",
-          args: { to, subject, cc, bcc, account },
-          status: "ok",
-          durationMs: Date.now() - start,
-        });
-        return ok(result);
+        return ok(await runJxa(sendMailScript(to, subject, body, cc, bcc, account)));
       } catch (e) {
-        auditLog({
-          timestamp: new Date().toISOString(),
-          tool: "send_mail",
-          args: { to, subject, cc, bcc, account },
-          status: "error",
-          durationMs: Date.now() - start,
-        });
         return toolError("send mail", e);
       }
     },
@@ -302,25 +285,9 @@ export function registerMailTools(server: McpServer, config: AirMcpConfig): void
     async ({ id, body, replyAll }) => {
       if (!allowSendMail)
         return err("Sending mail is disabled. Set allowSendMail: true in config or AIRMCP_ALLOW_SEND_MAIL=true.");
-      const start = Date.now();
       try {
-        const result = await runJxa(replyMailScript(id, body, replyAll));
-        auditLog({
-          timestamp: new Date().toISOString(),
-          tool: "reply_mail",
-          args: { id, replyAll },
-          status: "ok",
-          durationMs: Date.now() - start,
-        });
-        return ok(result);
+        return ok(await runJxa(replyMailScript(id, body, replyAll)));
       } catch (e) {
-        auditLog({
-          timestamp: new Date().toISOString(),
-          tool: "reply_mail",
-          args: { id, replyAll },
-          status: "error",
-          durationMs: Date.now() - start,
-        });
         return toolError("reply", e);
       }
     },

--- a/src/maps/tools.ts
+++ b/src/maps/tools.ts
@@ -151,13 +151,14 @@ export function registerMapsTools(server: McpServer, _config: AirMcpConfig): voi
         query: z
           .string()
           .min(1)
+          .max(500)
           .describe("Place name or address (e.g. 'Seoul', 'Tokyo Tower', '1600 Pennsylvania Ave')"),
       },
       annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: true },
     },
     async ({ query }) => {
       try {
-        return ok(await fetchGeocode(query));
+        return okUntrusted(await fetchGeocode(query));
       } catch (e) {
         return toolError("geocode", e);
       }
@@ -177,7 +178,7 @@ export function registerMapsTools(server: McpServer, _config: AirMcpConfig): voi
     },
     async ({ latitude, longitude }) => {
       try {
-        return ok(await fetchReverseGeocode(latitude, longitude));
+        return okUntrusted(await fetchReverseGeocode(latitude, longitude));
       } catch (e) {
         return toolError("reverse geocode", e);
       }

--- a/src/notes/tools.ts
+++ b/src/notes/tools.ts
@@ -480,7 +480,7 @@ export function registerNoteTools(server: McpServer, config: AirMcpConfig): void
       description:
         "Move multiple notes to a target folder at once. Same limitations as move_note apply to each note (new ID, date reset, attachments lost). Returns per-note success/failure results.",
       inputSchema: {
-        ids: z.array(z.string()).min(1).describe("Array of note IDs to move"),
+        ids: z.array(z.string().max(500)).min(1).max(100).describe("Array of note IDs to move (max 100)"),
         folder: z.string().max(500).describe("Target folder name"),
       },
       annotations: {

--- a/src/pages/tools.ts
+++ b/src/pages/tools.ts
@@ -2,7 +2,7 @@ import type { McpServer } from "../shared/mcp.js";
 import { z } from "zod";
 import { runJxa } from "../shared/jxa.js";
 import type { AirMcpConfig } from "../shared/config.js";
-import { ok, toolError } from "../shared/result.js";
+import { ok, okUntrusted, toolError } from "../shared/result.js";
 import { zFilePath } from "../shared/validate.js";
 import {
   listDocumentsScript,
@@ -80,7 +80,7 @@ export function registerPagesTools(server: McpServer, _config: AirMcpConfig): vo
     },
     async ({ document }) => {
       try {
-        return ok(await runJxa(getBodyTextScript(document)));
+        return okUntrusted(await runJxa(getBodyTextScript(document)));
       } catch (e) {
         return toolError("get Pages body text", e);
       }

--- a/src/photos/tools.ts
+++ b/src/photos/tools.ts
@@ -3,8 +3,8 @@ import { z } from "zod";
 import { runSwift } from "../shared/swift.js";
 import { runAutomation } from "../shared/automation.js";
 import type { AirMcpConfig } from "../shared/config.js";
-import { ok, okLinked, toolError } from "../shared/result.js";
-import { zFilePath } from "../shared/validate.js";
+import { ok, okUntrusted, toolError } from "../shared/result.js";
+import { zFilePath, resolveAndGuard } from "../shared/validate.js";
 import {
   listAlbumsScript,
   listPhotosScript,
@@ -107,7 +107,7 @@ export function registerPhotosTools(server: McpServer, _config: AirMcpConfig): v
           swift: { command: "list-albums" },
           jxa: () => listAlbumsScript(),
         });
-        return okLinked("list_albums", result);
+        return okUntrusted(result);
       } catch (e) {
         return toolError("list albums", e);
       }
@@ -135,7 +135,7 @@ export function registerPhotosTools(server: McpServer, _config: AirMcpConfig): v
           },
           jxa: () => listPhotosScript(album, limit, offset),
         });
-        return ok(result);
+        return okUntrusted(result);
       } catch (e) {
         return toolError("list photos", e);
       }
@@ -162,7 +162,7 @@ export function registerPhotosTools(server: McpServer, _config: AirMcpConfig): v
           },
           jxa: () => searchPhotosScript(query, limit),
         });
-        return okLinked("search_photos", result);
+        return okUntrusted(result);
       } catch (e) {
         return toolError("search photos", e);
       }
@@ -188,7 +188,7 @@ export function registerPhotosTools(server: McpServer, _config: AirMcpConfig): v
           },
           jxa: () => getPhotoInfoScript(id),
         });
-        return ok(result);
+        return okUntrusted(result);
       } catch (e) {
         return toolError("get photo info", e);
       }
@@ -253,7 +253,7 @@ export function registerPhotosTools(server: McpServer, _config: AirMcpConfig): v
       title: "Add Photos to Album",
       description: "Add photos to an existing album by photo IDs and album name.",
       inputSchema: {
-        photoIds: z.array(z.string()).describe("Array of photo media item IDs"),
+        photoIds: z.array(z.string().max(500)).min(1).max(500).describe("Array of photo media item IDs (max 500)"),
         albumName: z.string().max(500).describe("Target album name"),
       },
       annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: false },
@@ -293,6 +293,7 @@ export function registerPhotosTools(server: McpServer, _config: AirMcpConfig): v
     },
     async ({ filePath, albumName }) => {
       try {
+        resolveAndGuard(filePath);
         const result = await runSwift<PhotoImportResult>("import-photo", JSON.stringify({ filePath, albumName }));
         return ok(result);
       } catch (e) {

--- a/src/podcasts/tools.ts
+++ b/src/podcasts/tools.ts
@@ -2,7 +2,7 @@ import type { McpServer } from "../shared/mcp.js";
 import { z } from "zod";
 import { runJxa } from "../shared/jxa.js";
 import type { AirMcpConfig } from "../shared/config.js";
-import { ok, toolError } from "../shared/result.js";
+import { ok, okUntrusted, toolError } from "../shared/result.js";
 import {
   listShowsScript,
   listEpisodesScript,
@@ -23,7 +23,7 @@ export function registerPodcastsTools(server: McpServer, _config: AirMcpConfig):
     },
     async () => {
       try {
-        return ok(await runJxa(listShowsScript()));
+        return okUntrusted(await runJxa(listShowsScript()));
       } catch (e) {
         return toolError("list podcast shows", e);
       }
@@ -43,7 +43,7 @@ export function registerPodcastsTools(server: McpServer, _config: AirMcpConfig):
     },
     async ({ showName, limit }) => {
       try {
-        return ok(await runJxa(listEpisodesScript(showName, limit)));
+        return okUntrusted(await runJxa(listEpisodesScript(showName, limit)));
       } catch (e) {
         return toolError("list podcast episodes", e);
       }
@@ -60,7 +60,7 @@ export function registerPodcastsTools(server: McpServer, _config: AirMcpConfig):
     },
     async () => {
       try {
-        return ok(await runJxa(nowPlayingScript()));
+        return okUntrusted(await runJxa(nowPlayingScript()));
       } catch (e) {
         return toolError("get podcast now playing", e);
       }
@@ -119,7 +119,7 @@ export function registerPodcastsTools(server: McpServer, _config: AirMcpConfig):
     },
     async ({ query, limit }) => {
       try {
-        return ok(await runJxa(searchEpisodesScript(query, limit)));
+        return okUntrusted(await runJxa(searchEpisodesScript(query, limit)));
       } catch (e) {
         return toolError("search podcast episodes", e);
       }

--- a/src/reminders/tools.ts
+++ b/src/reminders/tools.ts
@@ -3,7 +3,7 @@ import { z } from "zod";
 import { runAutomation } from "../shared/automation.js";
 import { runSwift } from "../shared/swift.js";
 import type { AirMcpConfig } from "../shared/config.js";
-import { ok, okLinked, okLinkedStructured, okUntrusted, okStructured, toolError } from "../shared/result.js";
+import { ok, okLinked, okLinkedStructured, okUntrusted, okUntrustedStructured, toolError } from "../shared/result.js";
 import type { MutationResult, DeleteResult } from "../shared/types.js";
 import {
   listReminderListsScript,
@@ -368,7 +368,7 @@ export function registerReminderTools(server: McpServer, _config: AirMcpConfig):
           },
           jxa: () => searchRemindersScript(query, limit),
         });
-        return okStructured(result);
+        return okUntrustedStructured(result);
       } catch (e) {
         return toolError("search reminders", e);
       }

--- a/src/safari/tools.ts
+++ b/src/safari/tools.ts
@@ -2,8 +2,14 @@ import type { McpServer } from "../shared/mcp.js";
 import { z } from "zod";
 import { runJxa } from "../shared/jxa.js";
 import type { AirMcpConfig } from "../shared/config.js";
-import { ok, okLinkedStructured, okUntrusted, okStructured, err, toolError } from "../shared/result.js";
-import { auditLog } from "../shared/audit.js";
+import {
+  ok,
+  okUntrusted,
+  okUntrustedStructured,
+  okUntrustedLinkedStructured,
+  err,
+  toolError,
+} from "../shared/result.js";
 import {
   listTabsScript,
   readPageContentScript,
@@ -40,7 +46,7 @@ export function registerSafariTools(server: McpServer, config: AirMcpConfig): vo
     },
     async () => {
       try {
-        return okLinkedStructured("list_tabs", await runJxa(listTabsScript()));
+        return okUntrustedLinkedStructured("list_tabs", await runJxa(listTabsScript()));
       } catch (e) {
         return toolError("list tabs", e);
       }
@@ -89,7 +95,7 @@ export function registerSafariTools(server: McpServer, config: AirMcpConfig): vo
     },
     async () => {
       try {
-        return okStructured(await runJxa(getCurrentTabScript()));
+        return okUntrustedStructured(await runJxa(getCurrentTabScript()));
       } catch (e) {
         return toolError("get current tab", e);
       }
@@ -107,22 +113,35 @@ export function registerSafariTools(server: McpServer, config: AirMcpConfig): vo
       annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: true, openWorldHint: true },
     },
     async ({ url }) => {
-      // Block non-HTTP schemes and internal network addresses to prevent SSRF/exfiltration
+      // Block non-HTTP schemes and internal network addresses to prevent the
+      // LLM caller from using Safari + read_page_content to exfiltrate
+      // private/cloud-internal data through the user's browser.
       try {
         const parsed = new URL(url);
         if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
           return err(`Only http:// and https:// URLs are allowed. Got: ${parsed.protocol}`);
         }
-        const host = parsed.hostname.toLowerCase();
-        if (
-          host === "localhost" ||
-          host === "127.0.0.1" ||
-          host === "[::1]" ||
-          host.startsWith("192.168.") ||
-          host.startsWith("10.") ||
-          host.endsWith(".local")
-        ) {
-          return err("Opening localhost or internal network URLs is not allowed.");
+        const host = parsed.hostname.toLowerCase().replace(/^\[|\]$/g, "");
+        // Loopback (entire 127.0.0.0/8 range, IPv6 ::1, "localhost")
+        if (host === "localhost" || host === "::1" || /^127(?:\.\d{1,3}){3}$/.test(host)) {
+          return err("Opening localhost URLs is not allowed.");
+        }
+        // RFC1918 private networks
+        if (host.startsWith("10.") || host.startsWith("192.168.") || /^172\.(1[6-9]|2\d|3[01])\./.test(host)) {
+          return err("Opening internal network URLs is not allowed.");
+        }
+        // Link-local: 169.254.0.0/16 — includes cloud metadata endpoints
+        // (169.254.169.254 on AWS/GCP/Azure) and IPv6 fe80::/10
+        if (host.startsWith("169.254.") || host.startsWith("fe80:") || host.startsWith("fe80::")) {
+          return err("Opening link-local / cloud metadata URLs is not allowed.");
+        }
+        // IPv6 unique local addresses fc00::/7 (fc00:: – fdff::)
+        if (/^f[cd][0-9a-f]{2}:/.test(host)) {
+          return err("Opening IPv6 unique-local URLs is not allowed.");
+        }
+        // Unspecified address / mDNS
+        if (host === "0.0.0.0" || host === "::" || host.endsWith(".local")) {
+          return err("Opening unspecified or mDNS URLs is not allowed.");
         }
       } catch {
         return err("Invalid URL format.");
@@ -193,25 +212,9 @@ export function registerSafariTools(server: McpServer, config: AirMcpConfig): vo
         return err(
           "Running JavaScript in Safari is disabled. Set AIRMCP_ALLOW_RUN_JAVASCRIPT=true or allowRunJavascript in config.json.",
         );
-      const start = Date.now();
       try {
-        const result = await runJxa(runJavascriptScript(code, windowIndex, tabIndex));
-        auditLog({
-          timestamp: new Date().toISOString(),
-          tool: "run_javascript",
-          args: { windowIndex, tabIndex, codeLength: code.length },
-          status: "ok",
-          durationMs: Date.now() - start,
-        });
-        return ok(result);
+        return okUntrusted(await runJxa(runJavascriptScript(code, windowIndex, tabIndex)));
       } catch (e) {
-        auditLog({
-          timestamp: new Date().toISOString(),
-          tool: "run_javascript",
-          args: { windowIndex, tabIndex, codeLength: code.length },
-          status: "error",
-          durationMs: Date.now() - start,
-        });
         return toolError("run JavaScript", e);
       }
     },
@@ -229,7 +232,7 @@ export function registerSafariTools(server: McpServer, config: AirMcpConfig): vo
     },
     async ({ query }) => {
       try {
-        return ok(await runJxa(searchTabsScript(query)));
+        return okUntrusted(await runJxa(searchTabsScript(query)));
       } catch (e) {
         return toolError("search tabs", e);
       }
@@ -246,7 +249,7 @@ export function registerSafariTools(server: McpServer, config: AirMcpConfig): vo
     },
     async () => {
       try {
-        return ok(await runJxa(listBookmarksScript()));
+        return okUntrusted(await runJxa(listBookmarksScript()));
       } catch (e) {
         return toolError("list bookmarks", e);
       }
@@ -284,7 +287,7 @@ export function registerSafariTools(server: McpServer, config: AirMcpConfig): vo
     },
     async () => {
       try {
-        return ok(await runJxa(listReadingListScript()));
+        return okUntrusted(await runJxa(listReadingListScript()));
       } catch (e) {
         return toolError("list reading list", e);
       }

--- a/src/screen/tools.ts
+++ b/src/screen/tools.ts
@@ -3,7 +3,7 @@ import { z } from "zod";
 import { readFile, stat, unlink } from "node:fs/promises";
 import { runJxa } from "../shared/jxa.js";
 import type { AirMcpConfig } from "../shared/config.js";
-import { toolError } from "../shared/result.js";
+import { okUntrusted, toolError } from "../shared/result.js";
 import {
   captureScreenScript,
   captureWindowScript,
@@ -152,10 +152,7 @@ export function registerScreenTools(server: McpServer, _config: AirMcpConfig): v
     },
     async () => {
       try {
-        const windows = await runJxa(listWindowsScript());
-        return {
-          content: [{ type: "text" as const, text: JSON.stringify(windows, null, 2) }],
-        };
+        return okUntrusted(await runJxa(listWindowsScript()));
       } catch (e) {
         return toolError("list windows", e);
       }

--- a/src/semantic/tools.ts
+++ b/src/semantic/tools.ts
@@ -1,6 +1,6 @@
 import type { McpServer } from "../shared/mcp.js";
 import { z } from "zod";
-import { ok, okLinked, err, toolError } from "../shared/result.js";
+import { ok, okUntrusted, err, toolError } from "../shared/result.js";
 import type { AirMcpConfig } from "../shared/config.js";
 import { SemanticSearchService } from "./service.js";
 import { runSwift, checkSwiftBridge } from "../shared/swift.js";
@@ -21,15 +21,16 @@ export function registerSemanticTools(server: McpServer, config: AirMcpConfig): 
     {
       title: "Build Semantic Index",
       description:
-        "Index data from enabled Apple apps (Notes, Calendar, Reminders, Mail) into the local vector store " +
-        "for semantic search. Run this once, then use semantic_search. Requires Swift bridge (npm run swift-build).",
+        "Index data from enabled Apple apps (Notes, Calendar, Reminders, Mail, Photos, Finder) into the local " +
+        "vector store for semantic search. Run this once, then use semantic_search. Replaces any existing " +
+        "index. Requires Swift bridge (npm run swift-build).",
       inputSchema: {
         sources: z
-          .array(z.enum(["notes", "calendar", "reminders", "mail"]))
+          .array(z.enum(["notes", "calendar", "reminders", "mail", "photos", "finder"]))
           .optional()
           .describe("Which sources to index. Defaults to all enabled modules."),
       },
-      annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: true, openWorldHint: false },
+      annotations: { readOnlyHint: false, destructiveHint: true, idempotentHint: true, openWorldHint: false },
     },
     async ({ sources }, extra) => {
       try {
@@ -82,7 +83,7 @@ export function registerSemanticTools(server: McpServer, config: AirMcpConfig): 
     async ({ query, sources, limit, threshold }) => {
       try {
         const result = await service.search(query, { sources, limit, threshold });
-        return okLinked("semantic_search", result);
+        return okUntrusted(result);
       } catch (e) {
         return toolError("semantic search", e);
       }

--- a/src/server/http-transport.ts
+++ b/src/server/http-transport.ts
@@ -5,7 +5,7 @@
 
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
 import { isInitializeRequest } from "@modelcontextprotocol/sdk/types.js";
-import { randomUUID, timingSafeEqual, randomBytes } from "node:crypto";
+import { randomUUID, timingSafeEqual, randomBytes, createHash } from "node:crypto";
 import { NPM_PACKAGE_NAME } from "../shared/config.js";
 import { LIMITS, TIMEOUT } from "../shared/constants.js";
 import { printBanner } from "../shared/banner.js";
@@ -109,16 +109,17 @@ export async function startHttpServer(options: HttpServerOptions): Promise<void>
     next();
   });
 
-  // Bearer token auth — required when --bind-all is used, optional otherwise
+  // Bearer token auth — required when --bind-all is used, optional otherwise.
+  // Hash both inputs to a fixed length before timingSafeEqual so the length
+  // comparison itself does not become a timing oracle for the token length.
   if (httpToken) {
+    const expectedHash = createHash("sha256").update(`Bearer ${httpToken}`).digest();
     app.use((req, res, next) => {
       // Skip auth for health/discovery endpoints
       if (req.path === "/health" || req.path === "/.well-known/mcp.json") return next();
-      const auth = req.headers.authorization;
-      const expected = `Bearer ${httpToken}`;
-      const authBuf = Buffer.from(auth ?? "");
-      const expBuf = Buffer.from(expected);
-      if (authBuf.length !== expBuf.length || !timingSafeEqual(authBuf, expBuf)) {
+      const auth = req.headers.authorization ?? "";
+      const authHash = createHash("sha256").update(auth).digest();
+      if (!timingSafeEqual(authHash, expectedHash)) {
         auditLog({
           timestamp: new Date().toISOString(),
           tool: "__auth_failure",
@@ -145,16 +146,26 @@ export async function startHttpServer(options: HttpServerOptions): Promise<void>
   }
   const sessions = new Map<string, Session>();
 
-  /** Clean up all resources for a session (transport, server, event listeners). Idempotent. */
+  /** Clean up all resources for a session (transport, server, event listeners). Idempotent.
+   *  Each cleanup step is wrapped individually so a failure in one step does not
+   *  prevent the remaining steps from running. */
   function destroySession(id: string, s: Session): void {
     if (!sessions.has(id)) return; // Already destroyed by another async path
     sessions.delete(id);
     try {
       s.cleanupEventListeners?.();
+    } catch (e) {
+      console.error(`[AirMCP] Session ${id} listener cleanup error:`, e);
+    }
+    try {
       s.transport.close?.();
+    } catch (e) {
+      console.error(`[AirMCP] Session ${id} transport close error:`, e);
+    }
+    try {
       s.server.close?.();
     } catch (e) {
-      console.error(`[AirMCP] Session ${id} cleanup error:`, e);
+      console.error(`[AirMCP] Session ${id} server close error:`, e);
     }
   }
 
@@ -168,11 +179,6 @@ export async function startHttpServer(options: HttpServerOptions): Promise<void>
     }
   }, TIMEOUT.SESSION_CLEANUP);
   if (cleanupInterval.unref) cleanupInterval.unref();
-
-  process.on("exit", () => {
-    clearInterval(cleanupInterval);
-    clearInterval(ratePruneTimer);
-  });
 
   // Health check — for load balancers, monitoring, and readiness probes
   // Note: session counts and uptime omitted to prevent information leakage
@@ -324,7 +330,7 @@ export async function startHttpServer(options: HttpServerOptions): Promise<void>
   warmupCleanup();
   warmupServer.close?.();
   const host = bindAll ? "0.0.0.0" : "127.0.0.1";
-  app.listen(port, host, async () => {
+  const httpServer = app.listen(port, host, async () => {
     bi.transport = "http";
     bi.port = port;
     await printBanner(bi);
@@ -332,5 +338,13 @@ export async function startHttpServer(options: HttpServerOptions): Promise<void>
       console.error(
         `[AirMCP] Bound to all interfaces (0.0.0.0:${port})${httpToken ? " with token auth" : " — NO AUTH"}`,
       );
+  });
+
+  // Release the listening socket and per-process timers on shutdown so
+  // in-flight requests are not left dangling and the port can be reused.
+  process.on("exit", () => {
+    clearInterval(cleanupInterval);
+    clearInterval(ratePruneTimer);
+    httpServer.close();
   });
 }

--- a/src/server/init.ts
+++ b/src/server/init.ts
@@ -37,8 +37,13 @@ export function initializeServer(): ServerContext {
     setShareGuardHitlClient(hitlClient);
   }
 
-  // Clean up resources on exit
+  // Clean up resources on exit. Guarded against double-execution because
+  // SIGINT/SIGTERM handlers call onExit() AND then process.exit(0), which
+  // re-fires the "exit" event handler.
+  let exited = false;
   function onExit() {
+    if (exited) return;
+    exited = true;
     usageTracker.stop();
     usageTracker.flushSync();
     closeSkillsWatcher();

--- a/src/server/mcp-setup.ts
+++ b/src/server/mcp-setup.ts
@@ -53,14 +53,18 @@ export async function createServer(
   // Cast to lightweight McpServer for module registration (avoids heavy generic inference)
   const lServer = server as unknown as LightMcpServer;
 
-  // Install HITL guard before any tool registrations
+  // Install tool/prompt registry FIRST so its interception runs as the
+  // innermost wrapper. The HITL guard then re-patches registerTool, becoming
+  // the outermost wrapper. Order matters: when a module calls registerTool,
+  // HITL wraps the callback first, then the registry wraps that HITL-wrapped
+  // handler with audit/usage tracking and stores it in its map. This makes
+  // the stored handler `audit(HITL(callback))` so that skill execution via
+  // toolRegistry.callTool() also goes through HITL approval.
+  toolRegistry.installOn(lServer);
+
   if (hitlClient && config.hitl.level !== "off") {
     installHitlGuard(lServer, hitlClient, config);
   }
-
-  // Install tool/prompt registry — intercepts all registrations transparently.
-  // Must come after HITL guard so the stored handlers include the HITL wrapper.
-  toolRegistry.installOn(lServer);
 
   // Dynamic module loading — only imports modules at startup
   const MODULE_REGISTRY = await loadModuleRegistry();

--- a/src/shared/esc.ts
+++ b/src/shared/esc.ts
@@ -65,7 +65,9 @@ export function escJxaShell(str: string): string {
     .replace(/\$/g, "\\\\$") // $ → \\$
     .replace(/'/g, "\\'") // ' → \'
     .replace(/\n/g, "\\n") // newline → \n (JXA interprets as newline char)
-    .replace(/\r/g, "\\r"); // CR → \r (JXA interprets as CR char)
+    .replace(/\r/g, "\\r") // CR → \r (JXA interprets as CR char)
+    .replace(/\u2028/g, "\\u2028") // LS — escape so JXA single-quoted string doesn't break
+    .replace(/\u2029/g, "\\u2029"); // PS — escape so JXA single-quoted string doesn't break
 }
 
 /** Ensure n is a finite integer — prevents shell injection if a non-number leaks through validation. */

--- a/src/shared/jxa.ts
+++ b/src/shared/jxa.ts
@@ -115,7 +115,7 @@ function parseOsascriptOutput<T>(stdout: string, app: string | undefined, stripC
   let trimmed = stdout.trim();
   if (stripControlChars) {
     // eslint-disable-next-line no-control-regex
-    trimmed = trimmed.replace(/[\x00-\x1f\x7f]/g, (c) => (c === "\n" || c === "\r" || c === "\t" ? "" : ""));
+    trimmed = trimmed.replace(/[\x00-\x1f\x7f]/g, (c) => (c === "\n" || c === "\r" || c === "\t" ? c : ""));
   }
   if (!trimmed) throw new Error("osascript returned empty output");
 

--- a/src/shared/result.ts
+++ b/src/shared/result.ts
@@ -70,6 +70,25 @@ export function okLinkedStructured(toolName: string, data: unknown) {
 }
 
 /**
+ * Like okLinkedStructured, but the primary text block is wrapped with
+ * untrusted-content markers. Use for read tools that return user-generated
+ * data (calendar events, notes, reminders) where content may include
+ * attacker-controlled text from external invitees / collaborators.
+ */
+export function okUntrustedLinkedStructured(toolName: string, data: unknown) {
+  const usageNext = usageTracker.getNextTools(toolName);
+  const links = getToolLinks(toolName, usageNext);
+  const base = { ...okUntrusted(data), structuredContent: data };
+  if (links.length > 0) {
+    base.content.push({
+      type: "text" as const,
+      text: JSON.stringify({ _links: links }),
+    });
+  }
+  return base;
+}
+
+/**
  * Attach `_meta["anthropic/maxResultSizeChars"]` to a tool result.
  *
  * Claude Code (and compatible harnesses) use this hint to avoid truncating

--- a/src/shared/swift.ts
+++ b/src/shared/swift.ts
@@ -189,6 +189,7 @@ function ensureProcess(): Promise<void> {
       rejectAll(`Swift bridge error: ${err.message}`);
       child = null;
       if (!ready) {
+        clearTimeout(readyTimer);
         launching = null;
         launchFailed = true;
         launchFailedAt = Date.now();
@@ -201,6 +202,7 @@ function ensureProcess(): Promise<void> {
       child = null;
       launching = null;
       if (!ready) {
+        clearTimeout(readyTimer);
         launchFailed = true;
         launchFailedAt = Date.now();
         reject(new Error(`Swift bridge exited during startup with code ${code}`));

--- a/src/shared/tool-registry.ts
+++ b/src/shared/tool-registry.ts
@@ -136,9 +136,11 @@ class ToolRegistry {
    * call automatically tracks the registration in this registry.
    *
    * Must be called once per server, before any module registrations.
-   * Compatible with the HITL guard monkey-patch (call this AFTER
-   * `installHitlGuard` so that the handler stored here already includes
-   * the HITL wrapper).
+   * Call this BEFORE `installHitlGuard` — the HITL guard will then become
+   * the outermost wrapper, and the registry's stored handler will be
+   * `audit(HITL(callback))`. This guarantees that calling tools via
+   * `callTool()` (e.g. from the skill executor) still routes through HITL
+   * approval, instead of bypassing it.
    *
    * In HTTP mode, multiple sessions create servers and call this method.
    * Only the first call clears the registry; subsequent calls overwrite

--- a/src/shared/validate.ts
+++ b/src/shared/validate.ts
@@ -2,6 +2,11 @@ import { z } from "zod";
 import { realpathSync } from "node:fs";
 import { HOME } from "./constants.js";
 
+/** Type guard for a plain JSON object (not null, not an array). */
+export function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
 /**
  * Zod schema for file path parameters.
  * Accepts absolute paths (/) and tilde paths (~/).

--- a/src/skills/index.ts
+++ b/src/skills/index.ts
@@ -4,7 +4,7 @@ import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { loadAllSkills, mergeSkills, watchUserSkills } from "./loader.js";
 import { registerSkills } from "./register.js";
-import { registerTrigger, startTriggerListener } from "./triggers.js";
+import { registerTrigger, resetTriggers, startTriggerListener } from "./triggers.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 // Resolves to dist/skills/builtins/ — works in repo checkout, npm cache, and git worktrees
@@ -24,7 +24,10 @@ export async function registerSkillEngine(server: McpServer): Promise<void> {
 
   registerSkills(server, merged);
 
-  // Register event triggers for skills that have them
+  // Register event triggers for skills that have them. Reset bindings first
+  // because this function is called per createServer (HTTP pre-warm + per-
+  // session) and we must not accumulate duplicate bindings.
+  resetTriggers();
   for (const skill of merged) {
     registerTrigger(skill);
   }

--- a/src/skills/loader.ts
+++ b/src/skills/loader.ts
@@ -52,17 +52,18 @@ export function loadAllSkills(builtinsDir: string): { builtins: SkillDefinition[
   return { builtins: builtinsCache, user };
 }
 
-/** Built-in skill names that user skills cannot override. */
-const PROTECTED_SKILL_NAMES = new Set<string>();
-
 export function mergeSkills(builtins: SkillDefinition[], user: SkillDefinition[]): SkillDefinition[] {
+  // Local protected set — built-in names that user skills cannot override.
+  // Kept local rather than module-scoped so per-session createServer calls
+  // never see stale entries from a previous merge.
+  const protectedNames = new Set<string>();
   const map = new Map<string, SkillDefinition>();
   for (const s of builtins) {
     map.set(s.name, s);
-    PROTECTED_SKILL_NAMES.add(s.name);
+    protectedNames.add(s.name);
   }
   for (const s of user) {
-    if (PROTECTED_SKILL_NAMES.has(s.name)) {
+    if (protectedNames.has(s.name)) {
       console.error(`[AirMCP] User skill "${s.name}" conflicts with built-in skill — skipping`);
       continue;
     }

--- a/src/skills/triggers.ts
+++ b/src/skills/triggers.ts
@@ -11,6 +11,13 @@ interface TriggerBinding {
 
 const bindings = new Map<string, TriggerBinding[]>();
 
+/** Reset all registered trigger bindings. Called by registerSkillEngine
+ *  before re-registering, so per-session createServer calls don't accumulate
+ *  duplicate bindings. */
+export function resetTriggers(): void {
+  bindings.clear();
+}
+
 /** Register a skill's trigger with the event bus. */
 export function registerTrigger(skill: SkillDefinition): void {
   if (!skill.trigger) return;
@@ -20,33 +27,46 @@ export function registerTrigger(skill: SkillDefinition): void {
   bindings.set(event, list);
 }
 
-/** Start listening for events and dispatching skills. */
+// Singleton listener — created once per process. Subsequent calls to
+// startTriggerListener swap the active server reference instead of attaching
+// a new listener, so per-session createServer calls don't accumulate listeners
+// on the eventBus.
+let activeServer: McpServer | null = null;
+let listenerInstalled = false;
+
+function dispatch(evt: AirMCPEvent): void {
+  const server = activeServer;
+  if (!server) return;
+  const list = bindings.get(evt.type);
+  if (!list) return;
+
+  const now = Date.now();
+  for (const binding of list) {
+    if (now - binding.lastFired < binding.debounceMs) continue;
+    binding.lastFired = now;
+
+    // Fire and forget — don't block the event loop. Retry once on failure.
+    executeSkill(server, binding.skill).catch((e) => {
+      console.error(
+        `[AirMCP] Trigger ${binding.skill.name} failed (attempt 1): ${e instanceof Error ? e.message : String(e)}`,
+      );
+      setTimeout(() => {
+        executeSkill(server, binding.skill).catch((e2) => {
+          console.error(
+            `[AirMCP] Trigger ${binding.skill.name} failed (attempt 2): ${e2 instanceof Error ? e2.message : String(e2)}`,
+          );
+        });
+      }, 2000);
+    });
+  }
+}
+
+/** Start listening for events and dispatching skills. Idempotent. */
 export function startTriggerListener(server: McpServer): void {
-  eventBus.on("event", (evt: AirMCPEvent) => {
-    const list = bindings.get(evt.type);
-    if (!list) return;
-
-    const now = Date.now();
-    for (const binding of list) {
-      if (now - binding.lastFired < binding.debounceMs) continue;
-      binding.lastFired = now;
-
-      // Fire and forget — don't block the event loop. Retry once on failure.
-      executeSkill(server, binding.skill).catch((e) => {
-        console.error(
-          `[AirMCP] Trigger ${binding.skill.name} failed (attempt 1): ${e instanceof Error ? e.message : String(e)}`,
-        );
-        // Single retry after 2s delay
-        setTimeout(() => {
-          executeSkill(server, binding.skill).catch((e2) => {
-            console.error(
-              `[AirMCP] Trigger ${binding.skill.name} failed (attempt 2): ${e2 instanceof Error ? e2.message : String(e2)}`,
-            );
-          });
-        }, 2000);
-      });
-    }
-  });
+  activeServer = server;
+  if (listenerInstalled) return;
+  eventBus.on("event", dispatch);
+  listenerInstalled = true;
 }
 
 /** Get all registered triggers for diagnostics. */

--- a/src/system/tools.ts
+++ b/src/system/tools.ts
@@ -4,7 +4,7 @@ import { runJxa } from "../shared/jxa.js";
 import { runAutomation } from "../shared/automation.js";
 import type { AirMcpConfig } from "../shared/config.js";
 import { ok, okUntrustedStructured, okStructured, toolError } from "../shared/result.js";
-import { zFilePath } from "../shared/validate.js";
+import { zFilePath, resolveAndGuard } from "../shared/validate.js";
 import {
   getClipboardScript,
   setClipboardScript,
@@ -310,14 +310,15 @@ export function registerSystemTools(server: McpServer, _config: AirMcpConfig): v
           .describe("Capture region: fullscreen (default), window, or selection"),
       },
       annotations: {
-        readOnlyHint: true,
-        destructiveHint: false,
+        readOnlyHint: false,
+        destructiveHint: true,
         idempotentHint: false,
         openWorldHint: false,
       },
     },
     async ({ path, region }) => {
       try {
+        resolveAndGuard(path);
         return ok(await runJxa(captureScreenshotScript(path, region)));
       } catch (e) {
         return toolError("capture screenshot", e);

--- a/src/tv/tools.ts
+++ b/src/tv/tools.ts
@@ -2,7 +2,7 @@ import type { McpServer } from "../shared/mcp.js";
 import { z } from "zod";
 import { runJxa } from "../shared/jxa.js";
 import type { AirMcpConfig } from "../shared/config.js";
-import { ok, toolError } from "../shared/result.js";
+import { ok, okUntrusted, toolError } from "../shared/result.js";
 import {
   listPlaylistsScript,
   listTracksScript,
@@ -23,7 +23,7 @@ export function registerTvTools(server: McpServer, _config: AirMcpConfig): void 
     },
     async () => {
       try {
-        return ok(await runJxa(listPlaylistsScript()));
+        return okUntrusted(await runJxa(listPlaylistsScript()));
       } catch (e) {
         return toolError("list TV playlists", e);
       }
@@ -43,7 +43,7 @@ export function registerTvTools(server: McpServer, _config: AirMcpConfig): void 
     },
     async ({ playlist, limit }) => {
       try {
-        return ok(await runJxa(listTracksScript(playlist, limit)));
+        return okUntrusted(await runJxa(listTracksScript(playlist, limit)));
       } catch (e) {
         return toolError("list TV tracks", e);
       }
@@ -60,7 +60,7 @@ export function registerTvTools(server: McpServer, _config: AirMcpConfig): void 
     },
     async () => {
       try {
-        return ok(await runJxa(nowPlayingScript()));
+        return okUntrusted(await runJxa(nowPlayingScript()));
       } catch (e) {
         return toolError("get TV now playing", e);
       }
@@ -99,7 +99,7 @@ export function registerTvTools(server: McpServer, _config: AirMcpConfig): void 
     },
     async ({ query, limit }) => {
       try {
-        return ok(await runJxa(searchTracksScript(query, limit)));
+        return okUntrusted(await runJxa(searchTracksScript(query, limit)));
       } catch (e) {
         return toolError("search TV", e);
       }

--- a/src/ui/tools.ts
+++ b/src/ui/tools.ts
@@ -35,7 +35,7 @@ export function registerUiTools(server: McpServer, _config: AirMcpConfig): void 
     },
     async ({ appName }) => {
       try {
-        return ok(await runJxa(uiOpenAppScript(appName)));
+        return okUntrusted(await runJxa(uiOpenAppScript(appName)));
       } catch (e) {
         return toolError("open app", e);
       }

--- a/src/weather/tools.ts
+++ b/src/weather/tools.ts
@@ -1,7 +1,7 @@
 import type { McpServer } from "../shared/mcp.js";
 import { z } from "zod";
 import type { AirMcpConfig } from "../shared/config.js";
-import { ok, okLinkedStructured, toolError } from "../shared/result.js";
+import { okUntrusted, okUntrustedLinkedStructured, toolError } from "../shared/result.js";
 import { fetchCurrentWeather, fetchDailyForecast, fetchHourlyForecast } from "./api.js";
 
 export function registerWeatherTools(server: McpServer, _config: AirMcpConfig): void {
@@ -37,7 +37,7 @@ export function registerWeatherTools(server: McpServer, _config: AirMcpConfig): 
     async ({ latitude, longitude }) => {
       try {
         const result = await fetchCurrentWeather(latitude, longitude);
-        return okLinkedStructured("get_weather", result);
+        return okUntrustedLinkedStructured("get_current_weather", result);
       } catch (e) {
         return toolError("get current weather", e);
       }
@@ -58,7 +58,7 @@ export function registerWeatherTools(server: McpServer, _config: AirMcpConfig): 
     },
     async ({ latitude, longitude, days }) => {
       try {
-        return ok(await fetchDailyForecast(latitude, longitude, days));
+        return okUntrusted(await fetchDailyForecast(latitude, longitude, days));
       } catch (e) {
         return toolError("get daily forecast", e);
       }
@@ -86,7 +86,7 @@ export function registerWeatherTools(server: McpServer, _config: AirMcpConfig): 
     },
     async ({ latitude, longitude, hours }) => {
       try {
-        return ok(await fetchHourlyForecast(latitude, longitude, hours));
+        return okUntrusted(await fetchHourlyForecast(latitude, longitude, hours));
       } catch (e) {
         return toolError("get hourly forecast", e);
       }

--- a/tests/intelligence-tools.test.js
+++ b/tests/intelligence-tools.test.js
@@ -75,9 +75,13 @@ describe('Intelligence tools registration', () => {
     }
   });
 
-  test('no tools are marked destructive', () => {
+  test('only file-writing tools are destructive', () => {
+    // generate_image writes a PNG/JPEG to a user-supplied path and may
+    // overwrite an existing file, so it must be marked destructive so HITL
+    // can prompt the user under the destructive-only policy.
+    const expectedDestructive = new Set(['generate_image']);
     for (const [name, { config }] of server.tools) {
-      expect(config.annotations.destructiveHint).toBe(false);
+      expect(config.annotations.destructiveHint).toBe(expectedDestructive.has(name));
     }
   });
 


### PR DESCRIPTION
## Summary

Sequential module-by-module security & correctness review covering shared, server, skills, intelligence, cli, and every JXA/network/app module. **3 HIGH**, ~20 MED, and several LOW fixes — see commit message for the full breakdown.

### Highlights

- **HITL bypass** in skills via `toolRegistry.callTool` — install order fixed so the registry stores `audit(HITL(callback))` instead of bare `audit(callback)`.
- **Trigger listener leak** — `startTriggerListener` is now idempotent; per-session `createServer` calls no longer accumulate eventBus listeners.
- **SSRF filter** in safari `open_url` — expanded from `127.0.0.1`/RFC1918 to the full 127.0.0.0/8, 172.16-31/12, 169.254/16 (cloud metadata 169.254.169.254), IPv6 ULA, etc.
- **Bearer token timing leak** — sha256 both inputs to fixed length before `timingSafeEqual`.
- **Untrusted markers** added to 25+ read tools that return user-generated content (calendar events, notes, reminders, contacts, photos, podcasts, web pages, weather/maps API responses, etc.) so prompt-injection markers reach the calling LLM.
- **Duplicate audit logging** removed from mail/safari (the tool-registry wrapper auto-audits).
- **Symlink-escape guards**: `resolveAndGuard` added to `finder.create_directory`, `system.capture_screenshot`, `photos.import_photo`.
- **Google `gws` env** narrowed from full `process.env` to PATH/HOME/GWS_*/GOOGLE_* (no more leaking ANTHROPIC_API_KEY/GEMINI_API_KEY/AIRMCP_HTTP_TOKEN to a third-party binary).

Plus refactors picked up along the way: `okUntrustedLinkedStructured`, `isPlainObject`, module-load `GWS_SAFE_ENV`, session-local `protectedNames` in skills loader.

## Test plan

- [x] \`npm run lint\`
- [x] \`npm run typecheck\`
- [x] \`npm run build\`
- [x] \`npm test\` — 874 passed, 75 suites