### PR TITLE
fix(audit): fully redact args for location and health tools

### DIFF
--- a/src/shared/audit.ts
+++ b/src/shared/audit.ts
@@ -26,6 +26,19 @@ interface AuditEntry {
   durationMs?: number;
 }
 
+/**
+ * Tools whose args carry sensitive PII that must NEVER reach the audit log,
+ * even truncated. Matching tool calls get their args replaced with a single
+ * `_redacted` marker. The audit log already lives behind 0600 permissions,
+ * but defense-in-depth: a single accidental share of audit.jsonl shouldn't
+ * leak the user's location coordinates or health metrics.
+ */
+const SENSITIVE_TOOL_PATTERNS: RegExp[] = [/^get_current_location$/, /^get_location_permission$/, /^health_/];
+
+function isSensitiveTool(name: string): boolean {
+  return SENSITIVE_TOOL_PATTERNS.some((re) => re.test(name));
+}
+
 let initialized = false;
 let buffer: string[] = [];
 let flushTimer: ReturnType<typeof setTimeout> | null = null;
@@ -39,7 +52,12 @@ async function ensureDir(): Promise<void> {
 /** Log a tool call to the audit log. Buffered — flushes every 30s (override via AIRMCP_AUDIT_FLUSH_INTERVAL). */
 export function auditLog(entry: AuditEntry): void {
   if (auditDisabled) return;
-  const sanitized = entry.args ? sanitizeArgs(entry.args) : undefined;
+  let sanitized: Record<string, unknown> | undefined;
+  if (isSensitiveTool(entry.tool)) {
+    sanitized = entry.args ? { _redacted: "sensitive_tool" } : undefined;
+  } else if (entry.args) {
+    sanitized = sanitizeArgs(entry.args);
+  }
   let line = JSON.stringify({ ...entry, args: sanitized });
   if (line.length > MAX_ENTRY_SIZE) {
     line = JSON.stringify({ ...entry, args: { _truncated: true }, _note: "entry exceeded 10KB limit" });

--- a/tests/audit.test.js
+++ b/tests/audit.test.js
@@ -283,6 +283,93 @@ describe('auditLog() sanitization integration', () => {
 });
 
 /* ================================================================== */
+/*  auditLog() sensitive-tool full redaction                          */
+/* ================================================================== */
+
+describe('auditLog() sensitive-tool redaction', () => {
+  test('get_current_location args are fully redacted', () => {
+    auditLog({
+      timestamp: 'T1',
+      tool: 'get_current_location',
+      args: { precision: 'high' },
+      status: 'ok',
+    });
+
+    const buf = _testReset();
+    const parsed = JSON.parse(buf[0]);
+    expect(parsed.args).toEqual({ _redacted: 'sensitive_tool' });
+    expect(parsed.tool).toBe('get_current_location');
+  });
+
+  test('get_location_permission args are fully redacted', () => {
+    auditLog({
+      timestamp: 'T1',
+      tool: 'get_location_permission',
+      args: {},
+      status: 'ok',
+    });
+
+    const buf = _testReset();
+    const parsed = JSON.parse(buf[0]);
+    expect(parsed.args).toEqual({ _redacted: 'sensitive_tool' });
+  });
+
+  test('health_* tool args are fully redacted', () => {
+    auditLog({
+      timestamp: 'T1',
+      tool: 'health_sleep',
+      args: { date: '2026-04-11', includeStages: true },
+      status: 'ok',
+    });
+
+    const buf = _testReset();
+    const parsed = JSON.parse(buf[0]);
+    expect(parsed.args).toEqual({ _redacted: 'sensitive_tool' });
+    expect(parsed.tool).toBe('health_sleep');
+  });
+
+  test('other health_ prefixed tools are redacted', () => {
+    auditLog({
+      timestamp: 'T1',
+      tool: 'health_summary',
+      args: { period: '7d' },
+      status: 'ok',
+    });
+
+    const buf = _testReset();
+    const parsed = JSON.parse(buf[0]);
+    expect(parsed.args).toEqual({ _redacted: 'sensitive_tool' });
+  });
+
+  test('non-sensitive tools still get sanitizeArgs treatment', () => {
+    auditLog({
+      timestamp: 'T1',
+      tool: 'list_notes',
+      args: { folder: 'Work', password: 'should_redact' },
+      status: 'ok',
+    });
+
+    const buf = _testReset();
+    const parsed = JSON.parse(buf[0]);
+    expect(parsed.args.folder).toBe('Work');
+    expect(parsed.args.password).toBe('[REDACTED]');
+    expect(parsed.args._redacted).toBeUndefined();
+  });
+
+  test('sensitive tool without args produces undefined args', () => {
+    auditLog({
+      timestamp: 'T1',
+      tool: 'get_current_location',
+      status: 'ok',
+    });
+
+    const buf = _testReset();
+    const parsed = JSON.parse(buf[0]);
+    expect(parsed.args).toBeUndefined();
+  });
+});
+
+/* ================================================================== */
 /*  Timer behavior — event-driven (setTimeout not setInterval)        */
 /* ================================================================== */
 


### PR DESCRIPTION
## Summary

The audit log buffer (\`~/.airmcp/audit.jsonl\`, mode 0600) records every tool call's args via \`sanitizeArgs\`, which only masks well-known credential keys (password/token/secret/api_key/auth_token/credential). Health metrics (date ranges, activity values), location coordinates, and the location permission state were captured verbatim — defense-in-depth gap if the audit file is ever shared or exfiltrated.

Add a \`SENSITIVE_TOOL_PATTERNS\` list and replace args with a single \`{ _redacted: \"sensitive_tool\" }\` marker for any tool whose name matches:

- \`get_current_location\`
- \`get_location_permission\`
- \`health_*\`

Other tools are unaffected and still go through the existing \`sanitizeArgs\` path (truncation + credential-key masking).

## Test plan

- [x] 6 new tests covering matching tools fully redacted, non-matching tools still pass through sanitizeArgs, and sensitive tools called without args produce no args entry
- [x] \`npm run lint\`
- [x] \`npm run typecheck\`
- [x] \`npm test\` — 880 passed (was 874)