### PR TITLE
fix(iwork): guard PDF export paths and mark destructive

### DIFF
--- a/src/keynote/tools.ts
+++ b/src/keynote/tools.ts
@@ -3,7 +3,7 @@ import { z } from "zod";
 import { runJxa } from "../shared/jxa.js";
 import type { AirMcpConfig } from "../shared/config.js";
 import { ok, okUntrusted, toolError } from "../shared/result.js";
-import { zFilePath } from "../shared/validate.js";
+import { zFilePath, resolveAndGuard } from "../shared/validate.js";
 import {
   listDocumentsScript,
   createDocumentScript,
@@ -134,15 +134,16 @@ export function registerKeynoteTools(server: McpServer, _config: AirMcpConfig): 
     "keynote_export_pdf",
     {
       title: "Export Keynote to PDF",
-      description: "Export a Keynote presentation to PDF.",
+      description: "Export a Keynote presentation to PDF. Will overwrite an existing file at the same path.",
       inputSchema: {
         document: z.string().max(500).describe("Document name"),
         outputPath: zFilePath.describe("Absolute output path for the PDF file"),
       },
-      annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: true },
+      annotations: { readOnlyHint: false, destructiveHint: true, idempotentHint: false, openWorldHint: true },
     },
     async ({ document, outputPath }) => {
       try {
+        resolveAndGuard(outputPath);
         return ok(await runJxa(exportPdfScript(document, outputPath)));
       } catch (e) {
         return toolError("export Keynote to PDF", e);

--- a/src/numbers/tools.ts
+++ b/src/numbers/tools.ts
@@ -3,7 +3,7 @@ import { z } from "zod";
 import { runJxa } from "../shared/jxa.js";
 import type { AirMcpConfig } from "../shared/config.js";
 import { ok, toolError } from "../shared/result.js";
-import { zFilePath } from "../shared/validate.js";
+import { zFilePath, resolveAndGuard } from "../shared/validate.js";
 import {
   listDocumentsScript,
   createDocumentScript,
@@ -161,15 +161,16 @@ export function registerNumbersTools(server: McpServer, _config: AirMcpConfig): 
     "numbers_export_pdf",
     {
       title: "Export Numbers to PDF",
-      description: "Export a Numbers spreadsheet to PDF.",
+      description: "Export a Numbers spreadsheet to PDF. Will overwrite an existing file at the same path.",
       inputSchema: {
         document: z.string().max(500).describe("Document name"),
         outputPath: zFilePath.describe("Absolute output path for the PDF file"),
       },
-      annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: true },
+      annotations: { readOnlyHint: false, destructiveHint: true, idempotentHint: false, openWorldHint: true },
     },
     async ({ document, outputPath }) => {
       try {
+        resolveAndGuard(outputPath);
         return ok(await runJxa(exportPdfScript(document, outputPath)));
       } catch (e) {
         return toolError("export Numbers to PDF", e);

--- a/src/pages/tools.ts
+++ b/src/pages/tools.ts
@@ -3,7 +3,7 @@ import { z } from "zod";
 import { runJxa } from "../shared/jxa.js";
 import type { AirMcpConfig } from "../shared/config.js";
 import { ok, okUntrusted, toolError } from "../shared/result.js";
-import { zFilePath } from "../shared/validate.js";
+import { zFilePath, resolveAndGuard } from "../shared/validate.js";
 import {
   listDocumentsScript,
   openDocumentScript,
@@ -111,15 +111,16 @@ export function registerPagesTools(server: McpServer, _config: AirMcpConfig): vo
     "pages_export_pdf",
     {
       title: "Export Pages to PDF",
-      description: "Export an open Pages document to PDF.",
+      description: "Export an open Pages document to PDF. Will overwrite an existing file at the same path.",
       inputSchema: {
         document: z.string().max(500).describe("Document name"),
         outputPath: zFilePath.describe("Absolute output path for the PDF file"),
       },
-      annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: true },
+      annotations: { readOnlyHint: false, destructiveHint: true, idempotentHint: false, openWorldHint: true },
     },
     async ({ document, outputPath }) => {
       try {
+        resolveAndGuard(outputPath);
         return ok(await runJxa(exportPdfScript(document, outputPath)));
       } catch (e) {
         return toolError("export Pages to PDF", e);


### PR DESCRIPTION
## Summary

\`pages_export_pdf\`, \`keynote_export_pdf\`, and \`numbers_export_pdf\` accepted a \`zFilePath\` outputPath but never called \`resolveAndGuard\`, so a symlink in the user's home directory could redirect the write outside the safe prefix. They were also marked \`destructiveHint:false\` despite overwriting any existing file at the target path, so HITL would not prompt under the destructive-only policy.

- Add \`resolveAndGuard(outputPath)\` to all three handlers
- Switch annotation to \`destructiveHint:true\`
- Update descriptions to note overwrite behavior

## Test plan

- [x] \`npm run lint\`
- [x] \`npm run typecheck\`
- [x] \`npm test\` — 880 passed