### PR TITLE
fix: surface silent errors, centralize constants, guard test helpers

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -7,7 +7,7 @@ body:
     attributes:
       label: AirMCP Version
       description: "Run `npx airmcp --help` to check"
-      placeholder: "2.7.0"
+      placeholder: "2.7.1"
     validations:
       required: true
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,45 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.7.1] - 2026-04-11
+
+### Fixed
+- **Silent error swallowing in usage tracker** — `loadFromDisk`/`flush`/`flushSync`/timer all surfaced via `console.error` instead of empty `catch`. ENOENT on first run is still silenced; everything else (corrupt JSON, ENOSPC, EACCES) now reaches stderr so disk-full / permission issues no longer hide for weeks.
+- **Audit flush timer fire-and-forget** — Added top-level `.catch` logging to cover unforeseen rejections outside the inner retry path (e.g. ESM dynamic import failure during the swap window).
+
+### Changed
+- **Hardcoded constants centralized in `shared/constants.ts`**:
+  - `API.OLLAMA` (was inline default in `local-llm.ts`) — env override `AIRMCP_OLLAMA_URL`
+  - `EXT_APPS.CDN_URL` (was hardcoded `esm.sh` URL in two places in `apps/tools.ts`) — derived `EXT_APPS_ORIGIN` keeps the CSP `resourceDomains` list in sync with the import URL automatically
+  - `BUFFER.SWIFT_LINE_MAX` (was magic `1_048_576` literal in `swift.ts`)
+  - `PATHS.TEMP_DIR` (was hardcoded `/tmp/` in `screen/scripts.ts` and `shortcuts/scripts.ts`) — uses `os.tmpdir()` by default, env override `AIRMCP_TEMP_DIR`. Sandboxed runtimes can now redirect intermediate captures.
+  - `AUDIT.MAX_ARG_LENGTH` / `MAX_ENTRY_SIZE` / `MAX_FILE_SIZE` / `MAX_FLUSH_FAILURES` / `FLUSH_INTERVAL` (was module-local in `audit.ts`)
+
+### Security
+- **Test-only helpers refuse to run in production** — `audit._testReset()` and `toolRegistry.reset()` now throw unless `NODE_ENV=test` or `AIRMCP_TEST_MODE=1` is set. Without this guard, any caller importing the production module could wipe in-memory audit entries before flush, or clear every registered MCP tool/prompt at runtime. Verified at runtime in addition to unit tests.
+
+### Documentation
+- Restored CHANGELOG entries for v2.7.0 and the four follow-up fixes (#49–#52) that landed on main without being recorded.
+
+## [2.7.0] - 2026-04-09
+
+### Added
+- **Claude Managed Agents compatibility** — prefix-match `"claude"` covers all Anthropic clients (Desktop, Code, Cowork, Managed Agents) — no more exact-match maintenance
+- **`AIRMCP_MANAGED_CLIENTS` env var** for third-party managed clients in enterprise deployments
+- **Server card** — `.well-known/mcp.json` exposes `authorization: { type: "bearer" }` when token is configured, enabling Managed Agents auto-discovery
+- **OpenTelemetry instrumentation (optional)** — `@opentelemetry/api` peer dependency, zero overhead when not installed
+  - **Tool execution spans**: `tool.{name}` with `mcp.tool.name`, `mcp.tool.arg_count`
+  - **HITL approval spans**: `tool.approval` with `mcp.approval.{decision,channel,destructive,managed_client}` — correlates with Enterprise Compliance API for SIEM platforms (Splunk, Cribl)
+  - Enable with `AIRMCP_TELEMETRY=true` or `config.json → features.telemetry: true`
+- +16 new tests (874 total): managed client prefix match, telemetry no-op path, approval spans, config telemetry flag
+
+### Fixed
+- **Skip elicitation for Claude Desktop/Cowork** (`claude-ai` client) — fixes silent timeout causing tool denial in agentic contexts (issue #28)
+- **iWork PDF export path guarding** (#52) — mark destructive, validate output path against guard list
+- **Audit redaction for location/health tools** (#51) — fully redact args for `get_current_location`, `get_location_permission`, `health_*` instead of relying on key-name patterns
+- **`cross/prompts.ts` user input quoting** (#50) — wrap user inputs in `q()` consistently to prevent prompt-injection drift
+- **Comprehensive security audit across 35 modules** (#49) — input validation, command injection guards, path traversal protection
+
 ## [2.6.4] - 2026-04-03
 
 ### Fixed

--- a/app/Sources/AirMCPApp/UpdateManager.swift
+++ b/app/Sources/AirMCPApp/UpdateManager.swift
@@ -10,7 +10,7 @@ final class UpdateManager {
 
     private var timer: Timer?
     private static let checkInterval: TimeInterval = 3600 // 1 hour
-    private let currentVersion = "2.7.0"
+    private let currentVersion = "2.7.1"
 
     var currentVersionString: String { currentVersion }
 

--- a/docs/PRIVACY_POLICY.md
+++ b/docs/PRIVACY_POLICY.md
@@ -1,6 +1,6 @@
 # Privacy Policy
 
-**AirMCP v2.7.0** — MCP Server for the Apple Ecosystem on macOS
+**AirMCP v2.7.1** — MCP Server for the Apple Ecosystem on macOS
 Last updated: 2026-03-28
 
 ## Overview

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "airmcp",
-  "version": "2.7.0",
+  "version": "2.7.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "airmcp",
-      "version": "2.7.0",
+      "version": "2.7.1",
       "license": "MIT",
       "os": [
         "darwin"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "airmcp",
-  "version": "2.7.0",
+  "version": "2.7.1",
   "description": "MCP server for the entire Apple ecosystem — Notes, Reminders, Calendar, Contacts, Mail, Messages, Music, Finder, Safari, System, Photos, Shortcuts, Apple Intelligence, TV, Screen Capture, Maps, and Podcasts. Connect any AI to your Mac.",
   "keywords": [
     "mcp",

--- a/scripts/bundle-app.sh
+++ b/scripts/bundle-app.sh
@@ -63,7 +63,7 @@ fi
 /usr/libexec/PlistBuddy -c "Delete :CFBundlePackageType" "$PLIST" 2>/dev/null || true
 /usr/libexec/PlistBuddy -c "Add :CFBundlePackageType string APPL" "$PLIST"
 /usr/libexec/PlistBuddy -c "Delete :CFBundleShortVersionString" "$PLIST" 2>/dev/null || true
-/usr/libexec/PlistBuddy -c "Add :CFBundleShortVersionString string 2.7.0" "$PLIST"
+/usr/libexec/PlistBuddy -c "Add :CFBundleShortVersionString string 2.7.1" "$PLIST"
 /usr/libexec/PlistBuddy -c "Delete :LSUIElement" "$PLIST" 2>/dev/null || true
 /usr/libexec/PlistBuddy -c "Add :LSUIElement bool true" "$PLIST"
 /usr/libexec/PlistBuddy -c "Delete :NSMicrophoneUsageDescription" "$PLIST" 2>/dev/null || true

--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.heznpc/airmcp",
   "description": "MCP server for the entire Apple ecosystem — 262 tools, 32 prompts across 27 modules. macOS only.",
-  "version": "2.7.0",
+  "version": "2.7.1",
   "websiteUrl": "https://github.com/heznpc/AirMCP",
   "repository": {
     "url": "https://github.com/heznpc/AirMCP",
@@ -12,7 +12,7 @@
     {
       "registryType": "npm",
       "identifier": "airmcp",
-      "version": "2.7.0",
+      "version": "2.7.1",
       "transport": {
         "type": "stdio"
       }
@@ -20,7 +20,7 @@
     {
       "registryType": "npm",
       "identifier": "airmcp",
-      "version": "2.7.0",
+      "version": "2.7.1",
       "transport": {
         "type": "http",
         "args": [

--- a/src/apps/tools.ts
+++ b/src/apps/tools.ts
@@ -4,8 +4,14 @@ import type { McpServer } from "../shared/mcp.js";
 import { z } from "zod";
 import { registerAppTool, registerAppResource, RESOURCE_MIME_TYPE } from "@modelcontextprotocol/ext-apps/server";
 import { runJxa } from "../shared/jxa.js";
+import { EXT_APPS } from "../shared/constants.js";
 import { listEventsScript } from "../calendar/scripts.js";
 import { nowPlayingScript } from "../music/scripts.js";
+
+// Derived once at module load — keeps the CSP origin in sync with the import URL.
+// If the CDN constant changes (e.g. local mirror), both the <script> import and
+// the CSP allowlist update together instead of drifting apart.
+const EXT_APPS_ORIGIN = new URL(EXT_APPS.CDN_URL).origin;
 
 const CALENDAR_WEEK_HTML = `<!DOCTYPE html>
 <html><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
@@ -25,7 +31,7 @@ body{font-family:var(--font-sans,system-ui,-apple-system,sans-serif);background:
 <div class="header" id="hdr">Calendar</div>
 <div id="content"><div class="loading">Loading events\u2026</div></div>
 <script type="module">
-import{App}from"https://esm.sh/@modelcontextprotocol/ext-apps@1.5.0";
+import{App}from"${EXT_APPS.CDN_URL}";
 const app=new App({name:"AirMCP Calendar",version:"1.0.0"});
 app.onhostcontextchanged=ctx=>{
   if(ctx.styles?.variables)Object.entries(ctx.styles.variables).forEach(([k,v])=>document.documentElement.style.setProperty(k,v));
@@ -69,7 +75,7 @@ body{font-family:var(--font-sans,system-ui,-apple-system,sans-serif);background:
 </style></head><body>
 <div class="player" id="p"><div class="stopped">No track playing</div></div>
 <script type="module">
-import{App}from"https://esm.sh/@modelcontextprotocol/ext-apps@1.5.0";
+import{App}from"${EXT_APPS.CDN_URL}";
 const app=new App({name:"AirMCP Music",version:"1.0.0"});
 app.onhostcontextchanged=ctx=>{
   if(ctx.styles?.variables)Object.entries(ctx.styles.variables).forEach(([k,v])=>document.documentElement.style.setProperty(k,v));
@@ -159,7 +165,7 @@ export function registerApps(server: McpServer, opts: { calendar: boolean; music
             uri: "ui://airmcp/calendar-week",
             mimeType: RESOURCE_MIME_TYPE,
             text: CALENDAR_WEEK_HTML,
-            _meta: { ui: { csp: { resourceDomains: ["https://esm.sh"] } } },
+            _meta: { ui: { csp: { resourceDomains: [EXT_APPS_ORIGIN] } } },
           },
         ],
       }),
@@ -202,7 +208,7 @@ export function registerApps(server: McpServer, opts: { calendar: boolean; music
             uri: "ui://airmcp/music-player",
             mimeType: RESOURCE_MIME_TYPE,
             text: MUSIC_PLAYER_HTML,
-            _meta: { ui: { csp: { resourceDomains: ["https://esm.sh"] } } },
+            _meta: { ui: { csp: { resourceDomains: [EXT_APPS_ORIGIN] } } },
           },
         ],
       }),

--- a/src/screen/scripts.ts
+++ b/src/screen/scripts.ts
@@ -1,13 +1,16 @@
 // Scripts and shell command helpers for macOS screen capture and window enumeration.
 
+import { join } from "node:path";
 import { esc } from "../shared/esc.js";
+import { PATHS } from "../shared/constants.js";
 
 /**
  * Build a temp file path for a screenshot.
- * Uses a timestamp to avoid collisions.
+ * Uses a timestamp to avoid collisions. Honors AIRMCP_TEMP_DIR (PATHS.TEMP_DIR)
+ * so sandboxed runtimes can redirect intermediate captures off /tmp.
  */
 function tempScreenshotPath(): string {
-  return `/tmp/airmcp-screenshot-${Date.now()}.png`;
+  return join(PATHS.TEMP_DIR, `airmcp-screenshot-${Date.now()}.png`);
 }
 
 /**
@@ -64,7 +67,7 @@ export function captureWindowScript(appName?: string): string {
  */
 export function recordScreenScript(duration: number, display?: number): string {
   const safeDuration = Math.min(Math.max(Math.floor(duration), 1), 60);
-  const filePath = `/tmp/airmcp-recording-${Date.now()}.mov`;
+  const filePath = join(PATHS.TEMP_DIR, `airmcp-recording-${Date.now()}.mov`);
   const displayFlag = display !== undefined ? ` -D ${Math.floor(display)}` : "";
   return `
     const app = Application.currentApplication();

--- a/src/shared/audit.ts
+++ b/src/shared/audit.ts
@@ -1,22 +1,8 @@
 import { appendFile, chmod, mkdir, stat, rename } from "node:fs/promises";
 import { join } from "node:path";
-import { PATHS } from "./constants.js";
+import { AUDIT, PATHS } from "./constants.js";
 
 const AUDIT_PATH = join(PATHS.VECTOR_STORE, "audit.jsonl");
-const MAX_ARG_LENGTH = 500;
-const MAX_ENTRY_SIZE = 10_000;
-const MAX_FILE_SIZE = 10 * 1024 * 1024; // 10MB — rotate after this
-const DEFAULT_FLUSH_INTERVAL = 30_000; // flush buffer every 30s
-
-/** Read lazily so config.ts can set the env var before first use. */
-function getFlushInterval(): number {
-  const env = process.env.AIRMCP_AUDIT_FLUSH_INTERVAL;
-  if (env !== undefined) {
-    const parsed = parseInt(env, 10);
-    if (Number.isFinite(parsed) && parsed > 0) return parsed;
-  }
-  return DEFAULT_FLUSH_INTERVAL;
-}
 
 interface AuditEntry {
   timestamp: string;
@@ -59,8 +45,12 @@ export function auditLog(entry: AuditEntry): void {
     sanitized = sanitizeArgs(entry.args);
   }
   let line = JSON.stringify({ ...entry, args: sanitized });
-  if (line.length > MAX_ENTRY_SIZE) {
-    line = JSON.stringify({ ...entry, args: { _truncated: true }, _note: "entry exceeded 10KB limit" });
+  if (line.length > AUDIT.MAX_ENTRY_SIZE) {
+    line = JSON.stringify({
+      ...entry,
+      args: { _truncated: true },
+      _note: `entry exceeded ${AUDIT.MAX_ENTRY_SIZE} char limit`,
+    });
   }
   buffer.push(line);
   ensureFlushTimer();
@@ -69,16 +59,21 @@ export function auditLog(entry: AuditEntry): void {
 function ensureFlushTimer(): void {
   if (flushTimer) return;
   flushTimer = setTimeout(() => {
-    flushBuffer().catch(() => {});
+    flushBuffer().catch((err) => {
+      // Surface flush errors so silent data loss is impossible.
+      // flushBuffer() already logs at line 102 on retry-failure, but the
+      // top-level promise rejection path here covers any unforeseen throw
+      // (e.g. ENOSPC during the swap, ESM/dynamic import failure, etc).
+      console.error(`[AirMCP Audit] flush timer error: ${err instanceof Error ? err.message : String(err)}`);
+    });
     flushTimer = null;
-  }, getFlushInterval());
+  }, AUDIT.FLUSH_INTERVAL);
   if (flushTimer.unref) flushTimer.unref();
 }
 
 let flushing = false;
 let consecutiveFlushFailures = 0;
 let auditDisabled = false;
-const MAX_FLUSH_FAILURES = 5;
 
 async function flushBuffer(): Promise<void> {
   if (buffer.length === 0 || flushing || auditDisabled) return;
@@ -99,8 +94,10 @@ async function flushBuffer(): Promise<void> {
       consecutiveFlushFailures = 0;
     } catch (retryErr) {
       consecutiveFlushFailures++;
-      console.error(`[AirMCP Audit] flush failed (${consecutiveFlushFailures}/${MAX_FLUSH_FAILURES}): ${retryErr}`);
-      if (consecutiveFlushFailures >= MAX_FLUSH_FAILURES) {
+      console.error(
+        `[AirMCP Audit] flush failed (${consecutiveFlushFailures}/${AUDIT.MAX_FLUSH_FAILURES}): ${retryErr}`,
+      );
+      if (consecutiveFlushFailures >= AUDIT.MAX_FLUSH_FAILURES) {
         auditDisabled = true;
         if (flushTimer) {
           clearTimeout(flushTimer);
@@ -119,7 +116,7 @@ async function rotateIfNeeded(): Promise<void> {
     const s = await stat(AUDIT_PATH);
     // Ensure owner-only permissions on existing file
     if ((s.mode & 0o777) !== 0o600) await chmod(AUDIT_PATH, 0o600);
-    if (s.size > MAX_FILE_SIZE) {
+    if (s.size > AUDIT.MAX_FILE_SIZE) {
       const rotated = AUDIT_PATH.replace(".jsonl", `.${Date.now()}.jsonl`);
       await rename(AUDIT_PATH, rotated);
     }
@@ -137,8 +134,8 @@ export function sanitizeArgs(args: Record<string, unknown>, depth = 0): Record<s
       result[key] = "[REDACTED]";
       continue;
     }
-    if (typeof value === "string" && value.length > MAX_ARG_LENGTH) {
-      result[key] = value.slice(0, MAX_ARG_LENGTH) + `... (${value.length} chars)`;
+    if (typeof value === "string" && value.length > AUDIT.MAX_ARG_LENGTH) {
+      result[key] = value.slice(0, AUDIT.MAX_ARG_LENGTH) + `... (${value.length} chars)`;
     } else if (value !== null && typeof value === "object" && !Array.isArray(value)) {
       result[key] = sanitizeArgs(value as Record<string, unknown>, depth + 1);
     } else {
@@ -148,8 +145,17 @@ export function sanitizeArgs(args: Record<string, unknown>, depth = 0): Record<s
   return result;
 }
 
-/** Reset all module-level state and return buffered entries. For testing only. */
+/**
+ * Reset all module-level state and return buffered entries. For testing only.
+ *
+ * Refuses to run unless `NODE_ENV === "test"` (set automatically by Jest) or
+ * `AIRMCP_TEST_MODE=1` is exported. Without this guard, an attacker who could
+ * import the production module could wipe in-memory audit entries before flush.
+ */
 export function _testReset(): string[] {
+  if (process.env.NODE_ENV !== "test" && process.env.AIRMCP_TEST_MODE !== "1") {
+    throw new Error("_testReset() is only callable when NODE_ENV=test or AIRMCP_TEST_MODE=1");
+  }
   const snapshot = [...buffer];
   buffer = [];
   if (flushTimer) {

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -8,6 +8,7 @@
  */
 
 import { join } from "node:path";
+import { tmpdir } from "node:os";
 
 // ── Helper ───────────────────────────────────────────────────────────
 
@@ -41,6 +42,21 @@ export const API = {
   REVERSE_GEOCODE: envStr("AIRMCP_REVERSE_GEOCODE_API_URL", "https://nominatim.openstreetmap.org/reverse"),
   /** Gemini embedding API base */
   GEMINI_BASE: envStr("AIRMCP_GEMINI_API_URL", "https://generativelanguage.googleapis.com/v1beta/models"),
+  /** Local Ollama HTTP API */
+  OLLAMA: envStr("AIRMCP_OLLAMA_URL", "http://localhost:11434"),
+} as const;
+
+// ══════════════════════════════════════════════════════════════════════
+// EXTERNAL CDN DEPENDENCIES — pin versions here, change in one place
+// ══════════════════════════════════════════════════════════════════════
+
+export const EXT_APPS = {
+  /**
+   * CDN URL for the @modelcontextprotocol/ext-apps client library used by
+   * MCP Apps HTML templates. Keep version aligned with the npm dependency
+   * declared in package.json (currently 1.5.0).
+   */
+  CDN_URL: envStr("AIRMCP_EXT_APPS_CDN", "https://esm.sh/@modelcontextprotocol/ext-apps@1.5.0"),
 } as const;
 
 // ══════════════════════════════════════════════════════════════════════
@@ -98,6 +114,8 @@ export const BUFFER = {
   JXA: envInt("AIRMCP_BUFFER_JXA", 10 * 1024 * 1024),
   /** Swift bridge max stdout */
   SWIFT: envInt("AIRMCP_BUFFER_SWIFT", 10 * 1024 * 1024),
+  /** Swift bridge max single response line (NDJSON) — guards against malformed/oversized rows */
+  SWIFT_LINE_MAX: envInt("AIRMCP_BUFFER_SWIFT_LINE", 1024 * 1024),
   /** GWS CLI max stdout */
   GWS: 10 * 1024 * 1024,
   /** Clipboard content max chars */
@@ -190,4 +208,27 @@ export const PATHS = {
   VECTOR_STORE: join(HOME, ".airmcp"),
   /** Usage profile */
   USAGE_PROFILE: join(HOME, ".airmcp", "profile.json"),
+  /** Temp directory for screenshots, recordings, intermediate exports */
+  TEMP_DIR: envStr("AIRMCP_TEMP_DIR", tmpdir()),
 } as const;
+
+// ══════════════════════════════════════════════════════════════════════
+// AUDIT LOG
+// ══════════════════════════════════════════════════════════════════════
+
+let _auditFlushInterval: number | undefined;
+
+export const AUDIT = {
+  /** Max length of a single argument value before truncation in audit log */
+  MAX_ARG_LENGTH: 500,
+  /** Max size of a single audit entry (JSON line) before placeholder substitution */
+  MAX_ENTRY_SIZE: 10_000,
+  /** Max audit log file size before rotation */
+  MAX_FILE_SIZE: 10 * 1024 * 1024,
+  /** Max consecutive flush failures before disabling audit */
+  MAX_FLUSH_FAILURES: 5,
+  /** Buffer flush interval (ms) — lazy-once so config.ts can set env before first read */
+  get FLUSH_INTERVAL() {
+    return (_auditFlushInterval ??= envInt("AIRMCP_AUDIT_FLUSH_INTERVAL", 30_000));
+  },
+};

--- a/src/shared/local-llm.ts
+++ b/src/shared/local-llm.ts
@@ -1,4 +1,6 @@
-const OLLAMA_BASE = process.env.AIRMCP_OLLAMA_URL || "http://localhost:11434";
+import { API } from "./constants.js";
+
+const OLLAMA_BASE = API.OLLAMA;
 try {
   const parsedUrl = new URL(OLLAMA_BASE);
   const LOCAL_HOSTS = new Set(["localhost", "127.0.0.1", "::1"]);

--- a/src/shared/swift.ts
+++ b/src/shared/swift.ts
@@ -145,8 +145,8 @@ function ensureProcess(): Promise<void> {
         const trimmed = line.trim();
         if (!trimmed) continue;
         // Per-line size guard — reject abnormally large single responses
-        if (trimmed.length > 1_048_576) {
-          console.error("[AirMCP Swift] Dropping oversized response line (>1MB)");
+        if (trimmed.length > BUFFER.SWIFT_LINE_MAX) {
+          console.error(`[AirMCP Swift] Dropping oversized response line (>${BUFFER.SWIFT_LINE_MAX} bytes)`);
           continue;
         }
         try {

--- a/src/shared/tool-registry.ts
+++ b/src/shared/tool-registry.ts
@@ -156,8 +156,17 @@ class ToolRegistry {
     this.interceptPromptRegistration(server);
   }
 
-  /** Reset the registry. For test isolation only. */
+  /**
+   * Reset the registry. For test isolation only.
+   *
+   * Refuses to run unless `NODE_ENV === "test"` (set automatically by Jest) or
+   * `AIRMCP_TEST_MODE=1` is set. Without this guard, any code with a reference
+   * to the singleton could wipe every registered tool/prompt at runtime.
+   */
   reset(): void {
+    if (process.env.NODE_ENV !== "test" && process.env.AIRMCP_TEST_MODE !== "1") {
+      throw new Error("ToolRegistry.reset() is only callable when NODE_ENV=test or AIRMCP_TEST_MODE=1");
+    }
     this.tools.clear();
     this.prompts.clear();
   }

--- a/src/shared/usage-tracker.ts
+++ b/src/shared/usage-tracker.ts
@@ -111,8 +111,10 @@ class UsageTracker {
       await mkdir(dirname(PATHS.USAGE_PROFILE), { recursive: true });
       await writeFile(PATHS.USAGE_PROFILE, JSON.stringify(this.profile, null, 2), "utf-8");
       this.dirty = false;
-    } catch {
-      // Non-critical — silently ignore write failures
+    } catch (e) {
+      // Non-critical — log so users can diagnose disk-full / permission issues
+      // instead of wondering why next-tool suggestions stop improving over time.
+      console.error(`[AirMCP UsageTracker] flush failed: ${e instanceof Error ? e.message : String(e)}`);
     }
   }
 
@@ -124,8 +126,8 @@ class UsageTracker {
       mkdirSync(dirname(PATHS.USAGE_PROFILE), { recursive: true });
       writeFileSync(PATHS.USAGE_PROFILE, JSON.stringify(this.profile, null, 2), "utf-8");
       this.dirty = false;
-    } catch {
-      // Non-critical
+    } catch (e) {
+      console.error(`[AirMCP UsageTracker] flushSync failed: ${e instanceof Error ? e.message : String(e)}`);
     }
   }
 
@@ -140,43 +142,55 @@ class UsageTracker {
   private loadSync(): void {
     this.profile = { version: 1, frequency: {}, sequences: {}, hourly: {}, updatedAt: "" };
     this.loaded = this.loadFromDisk()
-      .catch(() => {})
+      .catch((e) => {
+        // loadFromDisk() already swallows ENOENT internally; this catch surfaces
+        // anything else (corrupted JSON, permission errors, etc.) so we know why
+        // the merged history is missing instead of silently starting from zero.
+        console.error(`[AirMCP UsageTracker] load failed: ${e instanceof Error ? e.message : String(e)}`);
+      })
       .then(() => {
         this.loaded = null;
       });
   }
 
   private async loadFromDisk(): Promise<void> {
+    let data: string;
     try {
-      const data = await readFile(PATHS.USAGE_PROFILE, "utf-8");
-      const loaded = JSON.parse(data) as UsageProfile;
-      if (loaded.version === 1 && this.profile) {
-        // Merge disk data with in-memory (in-memory wins for current session)
-        for (const [k, v] of Object.entries(loaded.frequency)) {
-          this.profile.frequency[k] = (this.profile.frequency[k] || 0) + v;
-        }
-        for (const [k, v] of Object.entries(loaded.sequences)) {
-          this.profile.sequences[k] = (this.profile.sequences[k] || 0) + v;
-        }
-        for (const [k, v] of Object.entries(loaded.hourly)) {
-          if (!this.profile.hourly[k]) {
-            this.profile.hourly[k] = [...v];
-          } else {
-            for (let i = 0; i < 24; i++) {
-              this.profile.hourly[k]![i]! += v[i] || 0;
-            }
+      data = await readFile(PATHS.USAGE_PROFILE, "utf-8");
+    } catch (e) {
+      // ENOENT is the expected first-run state — keep silent. Surface anything else.
+      if ((e as NodeJS.ErrnoException).code === "ENOENT") return;
+      throw e;
+    }
+    const loaded = JSON.parse(data) as UsageProfile;
+    if (loaded.version === 1 && this.profile) {
+      // Merge disk data with in-memory (in-memory wins for current session)
+      for (const [k, v] of Object.entries(loaded.frequency)) {
+        this.profile.frequency[k] = (this.profile.frequency[k] || 0) + v;
+      }
+      for (const [k, v] of Object.entries(loaded.sequences)) {
+        this.profile.sequences[k] = (this.profile.sequences[k] || 0) + v;
+      }
+      for (const [k, v] of Object.entries(loaded.hourly)) {
+        if (!this.profile.hourly[k]) {
+          this.profile.hourly[k] = [...v];
+        } else {
+          for (let i = 0; i < 24; i++) {
+            this.profile.hourly[k]![i]! += v[i] || 0;
           }
         }
       }
-    } catch {
-      // File doesn't exist yet — that's fine
     }
   }
 
   private ensureFlushTimer(): void {
     if (this.flushTimer) return;
     this.flushTimer = setTimeout(() => {
-      this.flush().catch(() => {});
+      this.flush().catch((e) => {
+        // flush() already logs internally, but cover the unexpected throw path
+        // (rejection from outside the inner try, e.g. profile mutation race).
+        console.error(`[AirMCP UsageTracker] flush timer error: ${e instanceof Error ? e.message : String(e)}`);
+      });
       this.flushTimer = null;
     }, FLUSH_INTERVAL);
     // Don't prevent process exit

--- a/src/shortcuts/scripts.ts
+++ b/src/shortcuts/scripts.ts
@@ -1,6 +1,8 @@
 // JXA scripts for macOS Shortcuts automation.
 
+import { join } from "node:path";
 import { esc, escJxaShell } from "../shared/esc.js";
+import { PATHS } from "../shared/constants.js";
 
 export function listShortcutsScript(): string {
   return `
@@ -77,11 +79,14 @@ export function importShortcutScript(filePath: string): string {
 
 export function duplicateShortcutScript(name: string, newName: string): string {
   const safeName = escJxaShell(newName).replace(/[^a-zA-Z0-9_-]/g, "_");
+  // Inline a unique temp file path so concurrent duplicates don't collide and
+  // sandboxed runtimes can redirect via AIRMCP_TEMP_DIR.
+  const tempFile = join(PATHS.TEMP_DIR, `${safeName}-${Date.now()}.shortcut`);
   return `
     const app = Application.currentApplication();
     app.includeStandardAdditions = true;
-    app.doShellScript('shortcuts export "${escJxaShell(name)}" -o "/tmp/${safeName}.shortcut" && shortcuts import "/tmp/${safeName}.shortcut"');
-    app.doShellScript('rm -f "/tmp/${safeName}.shortcut"');
+    app.doShellScript('shortcuts export "${escJxaShell(name)}" -o "${tempFile}" && shortcuts import "${tempFile}"');
+    app.doShellScript('rm -f "${tempFile}"');
     JSON.stringify({original: '${esc(name)}', duplicate: '${esc(newName)}', success: true});
   `;
 }

--- a/src/shortcuts/tools.ts
+++ b/src/shortcuts/tools.ts
@@ -302,6 +302,9 @@ export async function registerDynamicShortcutTools(server: McpServer): Promise<n
       },
     );
 
+    // NOTE: console.error (stderr), not console.log — MCP stdio transport reserves
+    // stdout for protocol traffic. This is an informational message, not an error;
+    // all server-side logging must go to stderr to avoid corrupting the channel.
     console.error(`[AirMCP] Registered dynamic shortcut: ${name}`);
     count++;
   }

--- a/tests/audit.test.js
+++ b/tests/audit.test.js
@@ -83,7 +83,8 @@ describe('auditLog()', () => {
 
     const parsed = JSON.parse(buf[0]);
     expect(parsed.args._truncated).toBe(true);
-    expect(parsed._note).toContain('10KB');
+    // _note now reports the dynamic AUDIT.MAX_ENTRY_SIZE limit (10000 chars)
+    expect(parsed._note).toContain('10000 char limit');
     // The truncated entry should be well under 10KB
     expect(buf[0].length).toBeLessThan(10_000);
   });

--- a/tests/screen-scripts.test.js
+++ b/tests/screen-scripts.test.js
@@ -12,7 +12,8 @@ describe('screen script generators', () => {
   test('captureScreenScript generates screencapture command', () => {
     const script = captureScreenScript();
     expect(script).toContain('screencapture -x -t png');
-    expect(script).toContain('/tmp/airmcp-screenshot-');
+    // Path is now derived from os.tmpdir() / PATHS.TEMP_DIR — match the filename only
+    expect(script).toContain('airmcp-screenshot-');
     expect(script).toContain('.png');
     expect(script).toContain('JSON.stringify');
     expect(script).toContain('doShellScript');
@@ -44,7 +45,7 @@ describe('screen script generators', () => {
   test('captureWindowScript captures frontmost window by default', () => {
     const script = captureWindowScript();
     expect(script).toContain('screencapture -x -t png -l');
-    expect(script).toContain('/tmp/airmcp-screenshot-');
+    expect(script).toContain('airmcp-screenshot-');
     expect(script).toContain('JSON.stringify');
     expect(script).toContain('CGWindowListCopyWindowInfo');
   });
@@ -71,7 +72,7 @@ describe('screen script generators', () => {
     const script = captureAreaScript(100, 200, 300, 400);
     expect(script).toContain('-R 100,200,300,400');
     expect(script).toContain('screencapture -x -t png');
-    expect(script).toContain('/tmp/airmcp-screenshot-');
+    expect(script).toContain('airmcp-screenshot-');
   });
 
   test('captureAreaScript floors coordinate values', () => {


### PR DESCRIPTION
## Summary

Structural audit caught three categories of issues across `shared/`, `apps/`, `screen/`, and `shortcuts/`. All fixes verified at runtime in addition to the 880-test suite.

## Changes

### Silent error swallowing (the dangerous one)
- **`usage-tracker.ts`** — `loadFromDisk` / `flush` / `flushSync` / timer all had `catch {}` that swallowed everything. ENOENT on first run is still silent (expected); corrupt JSON, ENOSPC, EACCES now reach stderr so disk-full / permission issues stop hiding for weeks.
- **`audit.ts:62`** — `flushBuffer().catch(() => {})` in the timer path now logs unforeseen rejections. The inner retry block already covered expected I/O failures, but the top-level promise had no listener.

### Hardcoded constants centralized in `shared/constants.ts`
| Was | Now |
|---|---|
| Inline `"http://localhost:11434"` in `local-llm.ts` | `API.OLLAMA` |
| `"https://esm.sh/@modelcontextprotocol/ext-apps@1.5.0"` in two places in `apps/tools.ts` | `EXT_APPS.CDN_URL` + derived `EXT_APPS_ORIGIN` so the CSP `resourceDomains` list stays in sync automatically |
| `1_048_576` magic literal in `swift.ts` | `BUFFER.SWIFT_LINE_MAX` |
| `/tmp/airmcp-screenshot-...` in `screen/scripts.ts` (3x) and `shortcuts/scripts.ts` (1x) | `PATHS.TEMP_DIR` (defaults to `os.tmpdir()`, env override `AIRMCP_TEMP_DIR`) — sandboxed runtimes can now redirect intermediate captures |
| `MAX_ARG_LENGTH` / `MAX_ENTRY_SIZE` / `MAX_FILE_SIZE` / `MAX_FLUSH_FAILURES` / `DEFAULT_FLUSH_INTERVAL` module-locals in `audit.ts` | `AUDIT.*` block (FLUSH_INTERVAL is a lazy getter so config can set env first) |

### Test helpers refuse to run in production
- `audit._testReset()` and `toolRegistry.reset()` now `throw` unless `NODE_ENV=test` or `AIRMCP_TEST_MODE=1` is set.
- Without this guard, any caller importing the production module could wipe in-memory audit entries before flush, or clear every registered MCP tool/prompt at runtime.
- Verified at runtime in addition to the unit tests.

### Misc
- `shortcuts/tools.ts:305` — added a comment explaining the `console.error` for "Registered dynamic shortcut" is **intentional**: MCP stdio transport reserves stdout for protocol traffic, so all server-side logging goes to stderr regardless of severity.
- `CHANGELOG.md` — restored the v2.7.0 entry and the four follow-up fixes (#49–#52) that landed on `main` without being recorded.
- Bumped to **2.7.1** via `npm run version:patch` (sync-version + count-stats both clean).

## Test plan
- [x] `npm run typecheck` — passes
- [x] `npm run build` — passes
- [x] `npm run lint` — passes
- [x] `npm test` — **880/880 passing** (audit and screen-scripts tests updated to match the new error message wording and dynamic tmpdir paths)
- [x] `node scripts/sync-version.mjs --check` — all 6 files at 2.7.1
- [x] `node scripts/count-stats.mjs --check` — 262 tools / 32 prompts / 27 modules in sync
- [x] `node scripts/check-i18n.mjs` — 9 locales × 164 keys
- [x] Runtime contracts verified outside the test suite:
  - `_testReset()` throws in production, succeeds when `NODE_ENV=test`, succeeds when `AIRMCP_TEST_MODE=1`
  - `toolRegistry.reset()` throws in production, succeeds in test mode
  - `captureScreenScript()` emits a path under `os.tmpdir()`, never literal `/tmp/`
  - `apps/tools.js` loads cleanly (validates the parsed CDN URL → origin path)
  - All new constants exposed at the expected names

🤖 Generated with [Claude Code](https://claude.com/claude-code)