### PR TITLE
fix(ci): pass --repo to gh workflow run in auto-release

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -55,7 +55,9 @@ jobs:
       actions: write
     steps:
       - name: Dispatch CD workflow
-        run: |
-          gh workflow run cd.yml --ref main
+        # Pass --repo explicitly so `gh` doesn't try to discover the repo from
+        # a non-existent local git checkout (this job has no actions/checkout
+        # by design — it only needs to fire a workflow_dispatch).
+        run: gh workflow run cd.yml --ref main --repo "$GITHUB_REPOSITORY"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

`auto-release.yml` failed for v2.7.1 because the `trigger-cd` job has no `actions/checkout` step (intentionally — it only fires a `workflow_dispatch`, no source needed). Without a `.git` directory, `gh workflow run cd.yml --ref main` errored out:

> failed to run git: fatal: not a git repository (or any of the parent directories): .git

`gh` tries to auto-discover the repo from the local working directory. Passing `--repo "\$GITHUB_REPOSITORY"` makes the repo explicit from the workflow env, so the dispatch succeeds without needing a checkout.

## Why this matters

For v2.7.1 the CD workflow had to be dispatched manually after the release commit landed. With this fix, future `chore: release v*` commits trigger the publish pipeline end-to-end without intervention.

## Test plan
- [x] Workflow YAML lint (no syntax error)
- [ ] Real-world verification will happen on the next release commit (v2.7.2 or later) — at that point we should see `auto-release.yml` complete both jobs and `cd.yml` start automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)