### PR TITLE
refactor: extract formatError and assertTestMode to shared/errors.ts

### DIFF
--- a/src/shared/audit.ts
+++ b/src/shared/audit.ts
@@ -1,6 +1,7 @@
 import { appendFile, chmod, mkdir, stat, rename } from "node:fs/promises";
 import { join } from "node:path";
 import { AUDIT, PATHS } from "./constants.js";
+import { assertTestMode, formatError } from "./errors.js";
 
 const AUDIT_PATH = join(PATHS.VECTOR_STORE, "audit.jsonl");
 
@@ -59,12 +60,11 @@ export function auditLog(entry: AuditEntry): void {
 function ensureFlushTimer(): void {
   if (flushTimer) return;
   flushTimer = setTimeout(() => {
+    // flushBuffer() handles its own retry+logging; this catch only covers
+    // unexpected throws outside the inner try (e.g. ENOSPC during the buffer
+    // swap, ESM/dynamic import failure) so the rejection never goes silent.
     flushBuffer().catch((err) => {
-      // Surface flush errors so silent data loss is impossible.
-      // flushBuffer() already logs at line 102 on retry-failure, but the
-      // top-level promise rejection path here covers any unforeseen throw
-      // (e.g. ENOSPC during the swap, ESM/dynamic import failure, etc).
-      console.error(`[AirMCP Audit] flush timer error: ${err instanceof Error ? err.message : String(err)}`);
+      console.error(`[AirMCP Audit] flush timer error: ${formatError(err)}`);
     });
     flushTimer = null;
   }, AUDIT.FLUSH_INTERVAL);
@@ -147,15 +147,11 @@ export function sanitizeArgs(args: Record<string, unknown>, depth = 0): Record<s
 
 /**
  * Reset all module-level state and return buffered entries. For testing only.
- *
- * Refuses to run unless `NODE_ENV === "test"` (set automatically by Jest) or
- * `AIRMCP_TEST_MODE=1` is exported. Without this guard, an attacker who could
- * import the production module could wipe in-memory audit entries before flush.
+ * Guarded by `assertTestMode` so a production caller with module access cannot
+ * wipe in-memory audit entries before they reach disk.
  */
 export function _testReset(): string[] {
-  if (process.env.NODE_ENV !== "test" && process.env.AIRMCP_TEST_MODE !== "1") {
-    throw new Error("_testReset() is only callable when NODE_ENV=test or AIRMCP_TEST_MODE=1");
-  }
+  assertTestMode("_testReset()");
   const snapshot = [...buffer];
   buffer = [];
   if (flushTimer) {

--- a/src/shared/errors.ts
+++ b/src/shared/errors.ts
@@ -1,0 +1,34 @@
+/**
+ * Lightweight error and runtime-precondition helpers shared across modules.
+ *
+ * Kept dependency-free so it can be imported from any layer (audit, usage
+ * tracking, tool registry) without creating cycles.
+ */
+
+/**
+ * Extract a human-readable message from any thrown value.
+ *
+ * Avoids the `e instanceof Error ? e.message : String(e)` snippet that was
+ * scattered across audit/usage-tracker/etc. — single source of truth so the
+ * format never drifts between log lines.
+ */
+export function formatError(e: unknown): string {
+  return e instanceof Error ? e.message : String(e);
+}
+
+/**
+ * Throws unless we're in a test environment.
+ *
+ * Test environment is signaled by `NODE_ENV=test` (set automatically by Jest)
+ * or by `AIRMCP_TEST_MODE=1` for ad-hoc local runs. Used to gate test-only
+ * helpers (`audit._testReset`, `toolRegistry.reset`) so production callers
+ * with module access cannot wipe in-memory state at runtime.
+ *
+ * @param label  Human-readable name of the helper being guarded — included in
+ *               the thrown message so the offending caller can be located.
+ */
+export function assertTestMode(label: string): void {
+  if (process.env.NODE_ENV !== "test" && process.env.AIRMCP_TEST_MODE !== "1") {
+    throw new Error(`${label} is only callable when NODE_ENV=test or AIRMCP_TEST_MODE=1`);
+  }
+}

--- a/src/shared/tool-registry.ts
+++ b/src/shared/tool-registry.ts
@@ -20,6 +20,7 @@ import { auditLog } from "./audit.js";
 import { compactDescription } from "./tool-filter.js";
 import { withResultSizeHint } from "./result.js";
 import { traceToolCall } from "./telemetry.js";
+import { assertTestMode } from "./errors.js";
 
 /** Threshold in characters above which we auto-attach a result size hint. */
 const SIZE_HINT_THRESHOLD = 10_000;
@@ -157,16 +158,12 @@ class ToolRegistry {
   }
 
   /**
-   * Reset the registry. For test isolation only.
-   *
-   * Refuses to run unless `NODE_ENV === "test"` (set automatically by Jest) or
-   * `AIRMCP_TEST_MODE=1` is set. Without this guard, any code with a reference
-   * to the singleton could wipe every registered tool/prompt at runtime.
+   * Reset the registry. For test isolation only. Guarded by `assertTestMode`
+   * so a production caller with a reference to the singleton cannot wipe every
+   * registered tool/prompt at runtime.
    */
   reset(): void {
-    if (process.env.NODE_ENV !== "test" && process.env.AIRMCP_TEST_MODE !== "1") {
-      throw new Error("ToolRegistry.reset() is only callable when NODE_ENV=test or AIRMCP_TEST_MODE=1");
-    }
+    assertTestMode("ToolRegistry.reset()");
     this.tools.clear();
     this.prompts.clear();
   }

--- a/src/shared/usage-tracker.ts
+++ b/src/shared/usage-tracker.ts
@@ -2,6 +2,7 @@ import { readFile, writeFile, mkdir } from "node:fs/promises";
 import { writeFileSync, mkdirSync } from "node:fs";
 import { dirname } from "node:path";
 import { PATHS } from "./constants.js";
+import { formatError } from "./errors.js";
 
 interface UsageProfile {
   version: number;
@@ -112,9 +113,9 @@ class UsageTracker {
       await writeFile(PATHS.USAGE_PROFILE, JSON.stringify(this.profile, null, 2), "utf-8");
       this.dirty = false;
     } catch (e) {
-      // Non-critical — log so users can diagnose disk-full / permission issues
-      // instead of wondering why next-tool suggestions stop improving over time.
-      console.error(`[AirMCP UsageTracker] flush failed: ${e instanceof Error ? e.message : String(e)}`);
+      // Non-critical, but logged so disk-full / permission issues stop hiding
+      // for weeks behind a "why are next-tool suggestions stale" mystery.
+      logErr("flush", e);
     }
   }
 
@@ -127,7 +128,7 @@ class UsageTracker {
       writeFileSync(PATHS.USAGE_PROFILE, JSON.stringify(this.profile, null, 2), "utf-8");
       this.dirty = false;
     } catch (e) {
-      console.error(`[AirMCP UsageTracker] flushSync failed: ${e instanceof Error ? e.message : String(e)}`);
+      logErr("flushSync", e);
     }
   }
 
@@ -143,10 +144,10 @@ class UsageTracker {
     this.profile = { version: 1, frequency: {}, sequences: {}, hourly: {}, updatedAt: "" };
     this.loaded = this.loadFromDisk()
       .catch((e) => {
-        // loadFromDisk() already swallows ENOENT internally; this catch surfaces
-        // anything else (corrupted JSON, permission errors, etc.) so we know why
-        // the merged history is missing instead of silently starting from zero.
-        console.error(`[AirMCP UsageTracker] load failed: ${e instanceof Error ? e.message : String(e)}`);
+        // loadFromDisk swallows ENOENT (expected on first run); everything else
+        // — corrupt JSON, EACCES — reaches stderr so a missing merged history
+        // doesn't silently degrade next-tool suggestions.
+        logErr("load", e);
       })
       .then(() => {
         this.loaded = null;
@@ -158,11 +159,18 @@ class UsageTracker {
     try {
       data = await readFile(PATHS.USAGE_PROFILE, "utf-8");
     } catch (e) {
-      // ENOENT is the expected first-run state — keep silent. Surface anything else.
+      // ENOENT on first run is normal; rethrow anything else for the catch above.
       if ((e as NodeJS.ErrnoException).code === "ENOENT") return;
       throw e;
     }
-    const loaded = JSON.parse(data) as UsageProfile;
+    let loaded: UsageProfile;
+    try {
+      loaded = JSON.parse(data) as UsageProfile;
+    } catch (e) {
+      // Wrap with the file path so the log line points at the corrupt file
+      // instead of just printing "Unexpected token } in JSON at position …".
+      throw new Error(`Corrupt usage profile at ${PATHS.USAGE_PROFILE}: ${formatError(e)}`, { cause: e });
+    }
     if (loaded.version === 1 && this.profile) {
       // Merge disk data with in-memory (in-memory wins for current session)
       for (const [k, v] of Object.entries(loaded.frequency)) {
@@ -186,16 +194,18 @@ class UsageTracker {
   private ensureFlushTimer(): void {
     if (this.flushTimer) return;
     this.flushTimer = setTimeout(() => {
-      this.flush().catch((e) => {
-        // flush() already logs internally, but cover the unexpected throw path
-        // (rejection from outside the inner try, e.g. profile mutation race).
-        console.error(`[AirMCP UsageTracker] flush timer error: ${e instanceof Error ? e.message : String(e)}`);
-      });
+      // flush() handles its own logging; this catch only covers unexpected
+      // throws outside the inner try (e.g. profile mutation race).
+      this.flush().catch((e) => logErr("flush timer", e));
       this.flushTimer = null;
     }, FLUSH_INTERVAL);
     // Don't prevent process exit
     if (this.flushTimer.unref) this.flushTimer.unref();
   }
+}
+
+function logErr(context: string, e: unknown): void {
+  console.error(`[AirMCP UsageTracker] ${context} failed: ${formatError(e)}`);
 }
 
 export const usageTracker = new UsageTracker();


### PR DESCRIPTION
## Summary

Follow-up to #53 — code review caught two duplicated patterns across `audit` / `usage-tracker` / `tool-registry`, plus a corrupt-JSON path in `usage-tracker` that lost the source file context. This PR extracts the helpers into a new `src/shared/errors.ts` and tightens the parse error.

## Changes

### `src/shared/errors.ts` (new, 36 lines)
- **`formatError(e: unknown): string`** — replaces the \`e instanceof Error ? e.message : String(e)\` snippet that was scattered across `audit.ts` (1x) and `usage-tracker.ts` (4x). Single source of truth so log-line format never drifts.
- **`assertTestMode(label: string): void`** — replaces the duplicated \`process.env.NODE_ENV !== "test" && AIRMCP_TEST_MODE !== "1"\` guard in `audit._testReset` and `toolRegistry.reset`. Security guards being copy-pasted is risky if the env-var policy ever changes; one helper closes that gap.

### `usage-tracker.ts`
- Wrap `JSON.parse(data)` in its own try/catch and rethrow with `PATHS.USAGE_PROFILE` attached, so a corrupt file logs as \`Corrupt usage profile at /Users/.../profile.json: Unexpected token …\` instead of the bare `SyntaxError` the previous diff produced. Original error attached via `cause` (preserve-caught-error lint rule).
- Local `logErr(context, e)` helper inside the module so the four call sites share the \`[AirMCP UsageTracker] {ctx} failed: {msg}\` format.

### `audit.ts`, `tool-registry.ts`
- Use the new helpers; remove inline duplicates.

## Test plan
- [x] `npm run typecheck` — passes
- [x] `npm run build` — passes
- [x] `npm run lint` — passes (incl. `preserve-caught-error` rule)
- [x] `npm test` — **880/880 passing** (no test changes needed; the new wording matches what the tests expected)
- [x] Runtime contracts verified outside the test suite:
  - `formatError(new Error("x"))` → `"x"`
  - `formatError("plain")` → `"plain"`
  - `formatError({code:"ENOENT"})` → `"[object Object]"`
  - `assertTestMode("foo()")` throws in production, passes with `NODE_ENV=test`, passes with `AIRMCP_TEST_MODE=1`
  - `audit._testReset()` and `toolRegistry.reset()` throw with the helper's message text in production
  - Corrupt JSON path produces `Corrupt usage profile at ...: <SyntaxError msg>` with `cause` attached