### PR TITLE
fix(apps): escape playerState in Music Player innerHTML

### DIFF
--- a/src/apps/tools.ts
+++ b/src/apps/tools.ts
@@ -94,7 +94,7 @@ function render(d){
     '<div class="name">'+esc(t.name)+'</div>'+
     '<div class="artist">'+esc(t.artist)+'</div>'+
     '<div class="album">'+esc(t.album)+'</div>'+
-    '<div class="state">'+d.playerState+'</div>'+
+    '<div class="state">'+esc(d.playerState)+'</div>'+
     '<div class="bar-wrap"><div class="bar" style="width:'+pct+'%"></div></div>'+
     '<div class="time"><span>'+fmt(t.playerPosition||0)+'</span><span>'+fmt(t.duration||0)+'</span></div>'}
 function esc(s){const d=document.createElement("div");d.textContent=s||"";return d.innerHTML}


### PR DESCRIPTION
## Summary
- `d.playerState`가 Music Player 템플릿에서 `esc()` 없이 `innerHTML`에 직접 삽입되던 문제 수정
- 같은 파일의 `name`, `artist`, `album`은 모두 `esc()` 처리되어 있었으나 `playerState`만 누락

## Test plan
- [x] 전체 테스트 통과 (880/880)
- [x] ESLint, Prettier 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)