### PR TITLE
docs: sync landing page module count (25 → 27)

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -104,7 +104,7 @@
           <div class="glass-fx"></div>
           <div class="glass-tint"></div>
           <div class="glass-content text-center py-5">
-            <div class="text-2xl font-bold tracking-tight">25</div>
+            <div class="text-2xl font-bold tracking-tight">27</div>
             <div class="text-xs opacity-35 mt-1" data-i18n="stat_modules">Modules</div>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- 랜딩 페이지 stats 섹션의 모듈 수가 25로 하드코딩되어 있었음 (실제: 27)
- meta 태그와 README는 이미 27로 정확했으나 visible counter만 누락

## Test plan
- [x] `docs/index.html` 내 다른 수치(262 tools, 32 prompts, 8 resources) 변경 없음 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)