### PR TITLE
chore(release): v2.7.3 — cli ux polish + swift app crash recovery

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -7,7 +7,7 @@ body:
     attributes:
       label: AirMCP Version
       description: "Run `npx airmcp --help` to check"
-      placeholder: "2.7.2"
+      placeholder: "2.7.3"
     validations:
       required: true
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,29 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.7.3] - 2026-04-16
+
+### Added
+- **`--version` / `-v` flag** — prints version and exits
+- **Unknown command rejection** — `npx airmcp typo` now exits with error instead of silently starting stdio server
+- **`NO_COLOR` support** — respects `NO_COLOR` env var across banner, help, doctor, init ([no-color.org](https://no-color.org/))
+- **TTY guard for `init`** — exits with helpful message in non-interactive environments (CI, Docker, pipes)
+- **First-time user hint** — banner shows `"First time? Run: npx airmcp init"` when no config exists
+- **Config validation warnings** — unknown module names, invalid HITL levels, wrong boolean types now logged
+
+### Fixed
+- **Doctor version comparison** — local version ahead of npm no longer falsely shown as "update available"
+- **Config parse errors** — actual JSON error now shown (was silently falling back to defaults)
+- **Init config write** — caught with try/catch, corrupt JSON warned before overwrite
+- **Config double file-read** — eliminated redundant `readFileSync`+`JSON.parse` on startup path
+
+### Changed (Swift app)
+- **Node.js not found** — shows error state with install instructions (was: silent failure)
+- **Server crash detection** — `terminationHandler` with auto-restart (max 3 within 5 minutes)
+- **Graceful shutdown** — polls for server exit up to 5 seconds (was: hardcoded 0.5s)
+- **HITL notification denied** — logs warning when permission denied (was: silently ignored)
+- **Widget "All day"** — now localized via `NSLocalizedString`
+
 ## [2.7.2] - 2026-04-16
 
 ### Security

--- a/README.md
+++ b/README.md
@@ -23,10 +23,11 @@ MCP server for the entire Apple ecosystem — Notes, Reminders, Calendar, Contac
 - **Recurring events/reminders** — EventKit recurrence rules (macOS 26+ Swift bridge)
 - **Photo import/delete** — PhotoKit photo management (macOS 26+ Swift bridge)
 - **Apple Intelligence** — On-device summarize, rewrite, proofread (macOS 26+)
-- **Native menubar app** — SwiftUI companion with onboarding wizard, auto-start, log viewer, update notifications, permission setup
+- **Native menubar app** — SwiftUI companion with onboarding wizard, auto-start, log viewer, update notifications, permission setup, server crash auto-restart
 - **42 Swift unit tests** — XCTest suites for AirMCPKit (types, formatting, recurrence) and AirMCPServer (JSON-RPC, MCP dispatch)
 - **One-click setup** — `setup_permissions` tool or menubar app to request all macOS permissions at once
 - **Dual transport** — stdio (default, safe local) + HTTP/SSE (`--http`) for remote agents and registries
+- **CLI ergonomics** — `--version` flag, `NO_COLOR` support, unknown command rejection, config validation warnings
 - **Safety annotations** — readOnly/destructive hints on all tools
 
 ## Get Started (2 minutes)
@@ -646,6 +647,7 @@ Or edit `~/.config/airmcp/config.json` directly:
 | `npx airmcp init` | Interactive setup wizard |
 | `npx airmcp doctor` | Diagnose installation issues |
 | `npx airmcp` | Start MCP server (stdio, default) |
+| `npx airmcp --version` | Print version and exit |
 | `npx airmcp --full` | Start with all 27 modules enabled |
 | `npx airmcp --http` | Start as HTTP server (port 3847) |
 

--- a/app/Sources/AirMCPApp/UpdateManager.swift
+++ b/app/Sources/AirMCPApp/UpdateManager.swift
@@ -10,7 +10,7 @@ final class UpdateManager {
 
     private var timer: Timer?
     private static let checkInterval: TimeInterval = 3600 // 1 hour
-    private let currentVersion = "2.7.2"
+    private let currentVersion = "2.7.3"
 
     var currentVersionString: String { currentVersion }
 

--- a/docs/PRIVACY_POLICY.md
+++ b/docs/PRIVACY_POLICY.md
@@ -1,6 +1,6 @@
 # Privacy Policy
 
-**AirMCP v2.7.2** — MCP Server for the Apple Ecosystem on macOS
+**AirMCP v2.7.3** — MCP Server for the Apple Ecosystem on macOS
 Last updated: 2026-03-28
 
 ## Overview

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "airmcp",
-  "version": "2.7.2",
+  "version": "2.7.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "airmcp",
-      "version": "2.7.2",
+      "version": "2.7.3",
       "license": "MIT",
       "os": [
         "darwin"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "airmcp",
-  "version": "2.7.2",
+  "version": "2.7.3",
   "description": "MCP server for the entire Apple ecosystem — Notes, Reminders, Calendar, Contacts, Mail, Messages, Music, Finder, Safari, System, Photos, Shortcuts, Apple Intelligence, TV, Screen Capture, Maps, and Podcasts. Connect any AI to your Mac.",
   "keywords": [
     "mcp",

--- a/scripts/bundle-app.sh
+++ b/scripts/bundle-app.sh
@@ -105,7 +105,7 @@ fi
 /usr/libexec/PlistBuddy -c "Delete :CFBundlePackageType" "$PLIST" 2>/dev/null || true
 /usr/libexec/PlistBuddy -c "Add :CFBundlePackageType string APPL" "$PLIST"
 /usr/libexec/PlistBuddy -c "Delete :CFBundleShortVersionString" "$PLIST" 2>/dev/null || true
-/usr/libexec/PlistBuddy -c "Add :CFBundleShortVersionString string 2.7.2" "$PLIST"
+/usr/libexec/PlistBuddy -c "Add :CFBundleShortVersionString string 2.7.3" "$PLIST"
 /usr/libexec/PlistBuddy -c "Delete :LSUIElement" "$PLIST" 2>/dev/null || true
 /usr/libexec/PlistBuddy -c "Add :LSUIElement bool true" "$PLIST"
 /usr/libexec/PlistBuddy -c "Delete :NSMicrophoneUsageDescription" "$PLIST" 2>/dev/null || true

--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.heznpc/airmcp",
   "description": "MCP server for the entire Apple ecosystem — 262 tools, 32 prompts across 27 modules. macOS only.",
-  "version": "2.7.2",
+  "version": "2.7.3",
   "websiteUrl": "https://github.com/heznpc/AirMCP",
   "repository": {
     "url": "https://github.com/heznpc/AirMCP",
@@ -12,7 +12,7 @@
     {
       "registryType": "npm",
       "identifier": "airmcp",
-      "version": "2.7.2",
+      "version": "2.7.3",
       "transport": {
         "type": "stdio"
       }
@@ -20,7 +20,7 @@
     {
       "registryType": "npm",
       "identifier": "airmcp",
-      "version": "2.7.2",
+      "version": "2.7.3",
       "transport": {
         "type": "http",
         "args": [


### PR DESCRIPTION
## Summary
- `--version` flag, unknown command rejection, `NO_COLOR` env var support
- TTY guard for `init` (non-interactive environments), first-time user hint
- Config validation: unknown modules, invalid HITL levels, wrong boolean types
- Swift app: Node.js missing detection, crash auto-restart (3/5min), graceful shutdown
- HITL notification permission check, widget "All day" localization

## Test plan
- [x] `npm test` — 1121 tests pass
- [x] `npx tsc --noEmit` — clean
- [x] `swift build --package-path app/ -c release` — clean
- [x] `swift build --package-path swift/ -c release` — clean
- [x] Version sync verified (package.json, server.json, app, docs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)