### PR TITLE
fix: rename weekly-review skill to avoid prompt collision

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -7,7 +7,7 @@ body:
     attributes:
       label: AirMCP Version
       description: "Run `npx airmcp --help` to check"
-      placeholder: "2.8.0"
+      placeholder: "2.8.1"
     validations:
       required: true
 

--- a/app/Sources/AirMCPApp/UpdateManager.swift
+++ b/app/Sources/AirMCPApp/UpdateManager.swift
@@ -10,7 +10,7 @@ final class UpdateManager {
 
     private var timer: Timer?
     private static let checkInterval: TimeInterval = 3600 // 1 hour
-    private let currentVersion = "2.8.0"
+    private let currentVersion = "2.8.1"
 
     var currentVersionString: String { currentVersion }
 

--- a/docs/PRIVACY_POLICY.md
+++ b/docs/PRIVACY_POLICY.md
@@ -1,6 +1,6 @@
 # Privacy Policy
 
-**AirMCP v2.8.0** — MCP Server for the Apple Ecosystem on macOS
+**AirMCP v2.8.1** — MCP Server for the Apple Ecosystem on macOS
 Last updated: 2026-03-28
 
 ## Overview

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "airmcp",
-  "version": "2.8.0",
+  "version": "2.8.1",
   "description": "MCP server for the entire Apple ecosystem — Notes, Reminders, Calendar, Contacts, Mail, Messages, Music, Finder, Safari, System, Photos, Shortcuts, Apple Intelligence, TV, Screen Capture, Maps, and Podcasts. Connect any AI to your Mac.",
   "keywords": [
     "mcp",

--- a/scripts/bundle-app.sh
+++ b/scripts/bundle-app.sh
@@ -105,7 +105,7 @@ fi
 /usr/libexec/PlistBuddy -c "Delete :CFBundlePackageType" "$PLIST" 2>/dev/null || true
 /usr/libexec/PlistBuddy -c "Add :CFBundlePackageType string APPL" "$PLIST"
 /usr/libexec/PlistBuddy -c "Delete :CFBundleShortVersionString" "$PLIST" 2>/dev/null || true
-/usr/libexec/PlistBuddy -c "Add :CFBundleShortVersionString string 2.8.0" "$PLIST"
+/usr/libexec/PlistBuddy -c "Add :CFBundleShortVersionString string 2.8.1" "$PLIST"
 /usr/libexec/PlistBuddy -c "Delete :LSUIElement" "$PLIST" 2>/dev/null || true
 /usr/libexec/PlistBuddy -c "Add :LSUIElement bool true" "$PLIST"
 /usr/libexec/PlistBuddy -c "Delete :NSMicrophoneUsageDescription" "$PLIST" 2>/dev/null || true

--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.heznpc/airmcp",
   "description": "MCP server for the entire Apple ecosystem — 262 tools, 32 prompts across 27 modules. macOS only.",
-  "version": "2.8.0",
+  "version": "2.8.1",
   "websiteUrl": "https://github.com/heznpc/AirMCP",
   "repository": {
     "url": "https://github.com/heznpc/AirMCP",
@@ -12,7 +12,7 @@
     {
       "registryType": "npm",
       "identifier": "airmcp",
-      "version": "2.8.0",
+      "version": "2.8.1",
       "transport": {
         "type": "stdio"
       }
@@ -20,7 +20,7 @@
     {
       "registryType": "npm",
       "identifier": "airmcp",
-      "version": "2.8.0",
+      "version": "2.8.1",
       "transport": {
         "type": "http",
         "args": [

--- a/src/server/mcp-setup.ts
+++ b/src/server/mcp-setup.ts
@@ -477,7 +477,7 @@ export async function createServer(
     toolCount,
     promptCount,
     dynamicShortcuts: dynamicShortcutCount,
-    skillsBuiltin: 3,
+    skillsBuiltin: 7,
     skillsUser: 0,
     hitlLevel: config.hitl.level,
     macosVersion: osVersion,

--- a/src/skills/builtins/weekly-review.yaml
+++ b/src/skills/builtins/weekly-review.yaml
@@ -1,5 +1,5 @@
-name: weekly-review
-title: "Weekly Review"
+name: skills-weekly-review
+title: "Weekly Review (Skills DSL)"
 description: >-
   Pulls a structured week-in-review in a single pass: upcoming calendar,
   open reminders, recent notes, mail backlog, and a health snapshot — all


### PR DESCRIPTION
## Summary
- `weekly-review` prompt was registered by both `cross/prompts.ts` and `skills/builtins/weekly-review.yaml`, causing fatal crash on startup
- Renamed skill to `skills-weekly-review` to avoid collision
- Updated `skillsBuiltin` banner count from 3 to 7

## Test plan
- [ ] CI passes
- [ ] `npx airmcp` starts without "Prompt weekly-review is already registered" error