### PR TITLE
feat: quality-work v3 — on_error, poller registry, shutdown hooks, security

### DIFF
--- a/src/mail/poller.ts
+++ b/src/mail/poller.ts
@@ -1,0 +1,56 @@
+import { eventBus } from "../shared/event-bus.js";
+import { runJxa } from "../shared/jxa.js";
+import { createPollerLogger, registerPoller } from "../shared/pollers.js";
+import { getUnreadCountScript } from "./scripts.js";
+
+/**
+ * Mail.app does not expose an AppleEvent notification for unread-count
+ * changes, so we poll the existing JXA query at a configurable interval
+ * and emit `mail_unread_changed` only when the total differs from the
+ * last observed value.
+ */
+
+const MAIL_INTERVAL_MS = Math.max(10_000, parseInt(process.env.AIRMCP_MAIL_POLL_MS ?? "60000", 10));
+
+interface UnreadPayload {
+  totalUnread: number;
+  mailboxes: Array<{ account: string; mailbox: string; unread: number }>;
+}
+
+let lastUnread: number | null = null;
+const logError = createPollerLogger("mail_unread");
+
+async function tick(): Promise<void> {
+  try {
+    const payload = await runJxa<UnreadPayload>(getUnreadCountScript(), "Mail");
+    const total = typeof payload?.totalUnread === "number" ? payload.totalUnread : 0;
+    if (lastUnread === null) {
+      lastUnread = total;
+      return; // First read — establish baseline, don't emit
+    }
+    if (total !== lastUnread) {
+      const delta = total - lastUnread;
+      const previous = lastUnread;
+      lastUnread = total;
+      eventBus.emitNodeEvent("mail_unread_changed", {
+        source: "poll",
+        totalUnread: total,
+        previousUnread: previous,
+        delta,
+        mailboxes: payload.mailboxes ?? [],
+      });
+    }
+  } catch (e) {
+    logError(e);
+  }
+}
+
+registerPoller({
+  name: "mail_unread",
+  event: "mail_unread_changed",
+  intervalMs: MAIL_INTERVAL_MS,
+  tick,
+  reset: () => {
+    lastUnread = null;
+  },
+});

--- a/src/mail/tools.ts
+++ b/src/mail/tools.ts
@@ -3,6 +3,10 @@ import { z } from "zod";
 import { runJxa } from "../shared/jxa.js";
 import type { AirMcpConfig } from "../shared/config.js";
 import { ok, okLinked, okUntrusted, okStructured, err, toolError } from "../shared/result.js";
+// Side-effect import: register the mail_unread poller with the shared registry
+// at module load time. The poller itself only starts when startPollers() is
+// invoked by the cross/event observer tool.
+import "./poller.js";
 import {
   listMailboxesScript,
   listMessagesScript,

--- a/src/music/poller.ts
+++ b/src/music/poller.ts
@@ -1,0 +1,64 @@
+import { eventBus } from "../shared/event-bus.js";
+import { runJxa } from "../shared/jxa.js";
+import { createPollerLogger, registerPoller } from "../shared/pollers.js";
+import { nowPlayingScript } from "./scripts.js";
+
+/**
+ * Music.app's JXA query is cheap but each tick spawns an osascript process
+ * and wakes the CPU; 30 s is a reasonable default for "is a track change
+ * happening" without hammering battery. Consider migrating to the
+ * `com.apple.Music.playerInfo` DistributedNotification for zero-cost events
+ * once the Swift side is wired up.
+ */
+
+const MUSIC_INTERVAL_MS = Math.max(5_000, parseInt(process.env.AIRMCP_MUSIC_POLL_MS ?? "30000", 10));
+
+interface NowPlayingPayload {
+  playerState: string;
+  track: { name: string; artist: string; album: string; duration?: number; playerPosition?: number } | null;
+}
+
+let lastTrackKey: string | null = null;
+let lastPlayerState: string | null = null;
+const logError = createPollerLogger("now_playing");
+
+async function tick(): Promise<void> {
+  try {
+    const payload = await runJxa<NowPlayingPayload>(nowPlayingScript(), "Music");
+    const state = payload?.playerState ?? "stopped";
+    const track = payload?.track;
+    const key = track ? `${track.artist ?? ""}|${track.album ?? ""}|${track.name ?? ""}` : "";
+    if (lastTrackKey === null && lastPlayerState === null) {
+      lastTrackKey = key;
+      lastPlayerState = state;
+      return; // Baseline
+    }
+    const trackChanged = key !== lastTrackKey;
+    const stateChanged = state !== lastPlayerState;
+    if (trackChanged || stateChanged) {
+      const previousState = lastPlayerState;
+      lastTrackKey = key;
+      lastPlayerState = state;
+      eventBus.emitNodeEvent("now_playing_changed", {
+        source: "poll",
+        playerState: state,
+        previousPlayerState: previousState,
+        trackChanged,
+        track: track ?? null,
+      });
+    }
+  } catch (e) {
+    logError(e);
+  }
+}
+
+registerPoller({
+  name: "now_playing",
+  event: "now_playing_changed",
+  intervalMs: MUSIC_INTERVAL_MS,
+  tick,
+  reset: () => {
+    lastTrackKey = null;
+    lastPlayerState = null;
+  },
+});

--- a/src/music/tools.ts
+++ b/src/music/tools.ts
@@ -3,6 +3,10 @@ import { z } from "zod";
 import { runJxa } from "../shared/jxa.js";
 import type { AirMcpConfig } from "../shared/config.js";
 import { ok, okLinkedStructured, toolError } from "../shared/result.js";
+// Side-effect import: register the now_playing poller with the shared registry
+// at module load time. The poller itself only starts when startPollers() is
+// invoked by the cross/event observer tool.
+import "./poller.js";
 import {
   listPlaylistsScript,
   listTracksScript,

--- a/src/server/http-transport.ts
+++ b/src/server/http-transport.ts
@@ -12,6 +12,7 @@ import { printBanner } from "../shared/banner.js";
 import { auditLog } from "../shared/audit.js";
 import { SERVER_ICON, WEBSITE_URL } from "../shared/icons.js";
 import { createServer, type CreateServerOptions } from "./mcp-setup.js";
+import { registerShutdownHook } from "./shutdown.js";
 
 // ── Per-IP rate limiter (token bucket, no external dependency) ────────
 const RATE_WINDOW_MS = 60_000;
@@ -342,9 +343,31 @@ export async function startHttpServer(options: HttpServerOptions): Promise<void>
 
   // Release the listening socket and per-process timers on shutdown so
   // in-flight requests are not left dangling and the port can be reused.
+  // The "exit" hook only handles synchronous teardown (Node disallows async
+  // work there); graceful shutdown of active sessions runs via the shutdown
+  // hook installed below, which is bounded by GRACEFUL_SHUTDOWN_TIMEOUT.
   process.on("exit", () => {
     clearInterval(cleanupInterval);
     clearInterval(ratePruneTimer);
     httpServer.close();
+  });
+
+  registerShutdownHook(async () => {
+    clearInterval(cleanupInterval);
+    clearInterval(ratePruneTimer);
+    // Tear down active sessions so SSE streams close cleanly and HITL
+    // timers stop. `destroySession` is idempotent — duplicate calls from
+    // transport.onclose / onsessionclosed racing with this path are safe.
+    for (const [id, s] of [...sessions.entries()]) destroySession(id, s);
+    await new Promise<void>((resolve) => {
+      let settled = false;
+      const done = () => {
+        if (settled) return;
+        settled = true;
+        resolve();
+      };
+      httpServer.close(() => done());
+      setTimeout(done, 3000);
+    });
   });
 }

--- a/src/server/init.ts
+++ b/src/server/init.ts
@@ -12,6 +12,13 @@ import { setShareGuardHitlClient } from "../shared/share-guard.js";
 import { closeSkillsWatcher } from "../skills/index.js";
 import { closeSwiftBridge } from "../shared/swift.js";
 import { usageTracker } from "../shared/usage-tracker.js";
+import { runShutdownHooks } from "./shutdown.js";
+
+// Re-export so callers that depend on `init.js` do not need to know about
+// the shutdown module layout. New transport code should prefer importing
+// `registerShutdownHook` directly from `./shutdown.js` — that module has no
+// heavy transitive dependencies, which keeps test mocks shallow.
+export { registerShutdownHook } from "./shutdown.js";
 
 export interface ServerContext {
   config: AirMcpConfig;
@@ -54,14 +61,22 @@ export function initializeServer(): ServerContext {
       setShareGuardHitlClient(null);
     }
   }
+  async function gracefulShutdown(code: number): Promise<void> {
+    if (exited) return;
+    // Run async hooks first (bounded by shutdown.ts's timeout), then the
+    // synchronous onExit cleanup, then finally exit. Keeping hook ownership
+    // in a separate module means transport code can register cleanup
+    // without pulling in init's heavy dependency graph.
+    await runShutdownHooks();
+    onExit();
+    process.exit(code);
+  }
   process.on("exit", onExit);
   process.on("SIGINT", () => {
-    onExit();
-    process.exit(0);
+    void gracefulShutdown(0);
   });
   process.on("SIGTERM", () => {
-    onExit();
-    process.exit(0);
+    void gracefulShutdown(0);
   });
 
   // Catch unhandled errors to prevent silent crashes
@@ -70,8 +85,7 @@ export function initializeServer(): ServerContext {
   });
   process.on("uncaughtException", (error) => {
     console.error("[AirMCP] Uncaught exception:", error);
-    onExit();
-    process.exit(1);
+    void gracefulShutdown(1);
   });
 
   return { config, osVersion, pkg, hitlClient };

--- a/src/server/shutdown.ts
+++ b/src/server/shutdown.ts
@@ -1,0 +1,48 @@
+/**
+ * Process-wide async shutdown orchestrator.
+ *
+ * Callers register async cleanup callbacks with `registerShutdownHook()`;
+ * the server's SIGINT/SIGTERM wiring (in `init.ts`) invokes `runShutdownHooks()`
+ * before calling `process.exit()`. Hooks run via `allSettled` so one hook's
+ * rejection does not skip the others, and the whole sequence is bounded by
+ * `GRACEFUL_SHUTDOWN_TIMEOUT` so a hanging hook cannot prevent exit.
+ *
+ * This lives in its own file so transport modules (http-transport.ts) can
+ * register cleanup without importing `init.ts` — which would otherwise pull
+ * in the full configuration / HITL / Swift bridge dependency graph and
+ * complicate test mocking.
+ */
+
+export type ShutdownHook = () => Promise<void> | void;
+
+export const GRACEFUL_SHUTDOWN_TIMEOUT = 5000;
+
+const hooks: ShutdownHook[] = [];
+
+export function registerShutdownHook(fn: ShutdownHook): void {
+  hooks.push(fn);
+}
+
+/** Run every registered hook, bounded by GRACEFUL_SHUTDOWN_TIMEOUT.
+ *  Never throws — a hook that rejects is logged via `allSettled` but does
+ *  not prevent the remaining hooks or the caller's `process.exit`. */
+export async function runShutdownHooks(): Promise<void> {
+  if (hooks.length === 0) return;
+  const settled = Promise.allSettled(hooks.map((h) => Promise.resolve().then(h)));
+  const winner = await Promise.race([
+    settled.then(() => "done" as const),
+    new Promise<"timeout">((resolve) => setTimeout(() => resolve("timeout"), GRACEFUL_SHUTDOWN_TIMEOUT)),
+  ]);
+  if (winner === "timeout") {
+    console.error(`[AirMCP] Shutdown hooks exceeded ${GRACEFUL_SHUTDOWN_TIMEOUT}ms budget; proceeding with exit.`);
+  }
+}
+
+/** Test-only: clear registered hooks. Guarded so a production caller cannot
+ *  wipe every hook at runtime (would leave sockets/timers leaking on exit). */
+export function _resetShutdownHooksForTests(): void {
+  if (process.env.NODE_ENV !== "test" && process.env.AIRMCP_TEST_MODE !== "1") {
+    throw new Error("_resetShutdownHooksForTests is only callable in test mode");
+  }
+  hooks.length = 0;
+}

--- a/src/shared/compatibility.ts
+++ b/src/shared/compatibility.ts
@@ -167,13 +167,30 @@ export function resolveModuleCompatibility(
   return { decision: "register" };
 }
 
+// Tracks which "cpu unknown" warnings we've already emitted so the resolver
+// doesn't spam the same complaint for every cpu-gated module on startup.
+// Reset per requirement kind; a separate "cpu unknown" situation for
+// apple-silicon vs intel would be independently worth surfacing.
+const warnedUnknownCpu = new Set<HardwareRequirement>();
+
 /** Is a single hardware requirement satisfied? */
 function isHardwareAvailable(req: HardwareRequirement, env: CompatibilityEnv): boolean {
   switch (req) {
     case "apple-silicon":
-      return env.cpu === "arm64" || env.cpu === "aarch64";
     case "intel":
-      return env.cpu === "x64" || env.cpu === "x86_64";
+      if (!env.cpu) {
+        if (!warnedUnknownCpu.has(req)) {
+          warnedUnknownCpu.add(req);
+          console.error(
+            `[AirMCP compatibility] cpu arch unknown (env.cpu is undefined); ` +
+              `treating "${req}" requirement as unavailable. Modules that require it will be skipped.`,
+          );
+        }
+        return false;
+      }
+      return req === "apple-silicon"
+        ? env.cpu === "arm64" || env.cpu === "aarch64"
+        : env.cpu === "x64" || env.cpu === "x86_64";
     case "healthkit":
       return env.healthkitAvailable === true;
   }

--- a/src/shared/event-bus.ts
+++ b/src/shared/event-bus.ts
@@ -55,8 +55,19 @@ class EventBus extends EventEmitter {
       const event: AirMCPEvent = { type: obj.event, data, timestamp };
       this.emit("event", event);
       this.emit(event.type, event);
-    } catch {
-      // Not an event line — ignore
+    } catch (e) {
+      // Regular output (progress messages, debug prints, non-JSON chatter)
+      // is interleaved with event lines on the same stream, so a silent
+      // ignore is the default. BUT if the line *looks* like an event
+      // attempt — mentions an "event" or "type" key — surface the parse
+      // failure so protocol drift between the Swift side and Node side
+      // does not go undetected.
+      if (line.includes('"event"') || line.includes('"type"')) {
+        const msg = e instanceof Error ? e.message : String(e);
+        console.error(
+          `[AirMCP event-bus] Malformed event line dropped: ${msg} — ${line.slice(0, 120)}${line.length > 120 ? "…" : ""}`,
+        );
+      }
     }
   }
 

--- a/src/shared/pollers.ts
+++ b/src/shared/pollers.ts
@@ -1,173 +1,138 @@
-import { eventBus, type AirMCPEventType } from "./event-bus.js";
-import { runJxa } from "./jxa.js";
-import { getUnreadCountScript } from "../mail/scripts.js";
-import { nowPlayingScript } from "../music/scripts.js";
+import type { AirMCPEventType } from "./event-bus.js";
 
 /**
- * Node-side pollers for events that don't have a native observer API.
- *
- * Mail.app does not expose an AppleEvent notification for unread-count
- * changes, and cross-app "now playing" requires the private MediaRemote
- * framework. For these signals we poll existing JXA tools at a
- * configurable interval, diff against the last observed value, and emit
- * into the event bus only when the value changes.
+ * Node-side poller registry. Feature modules (mail, music, …) import
+ * their own poller file which calls `registerPoller()` at load time —
+ * `shared/pollers.ts` no longer imports from any specific module, which
+ * keeps the Core → Bridge → Services direction clean.
  *
  * Pollers are strictly passive — if the app isn't running or the user
- * hasn't granted Automation permission, we silence transient errors and
- * keep trying on the next tick instead of spamming stderr.
+ * hasn't granted Automation permission, individual pollers silence
+ * transient errors on their own (via `createPollerLogger`) and keep
+ * trying on the next tick instead of spamming stderr.
  */
 
-// Default intervals keep polling cheap. Overridable via env for dev/testing.
-const MAIL_INTERVAL_MS = Math.max(10_000, parseInt(process.env.AIRMCP_MAIL_POLL_MS ?? "60000", 10));
-// Music.app's JXA query is cheap but each tick spawns an osascript process
-// and wakes the CPU; 30 s is a reasonable default for "is a track change
-// happening" without hammering battery. Consider migrating to the
-// `com.apple.Music.playerInfo` DistributedNotification for zero-cost events
-// once the Swift side is wired up.
-const MUSIC_INTERVAL_MS = Math.max(5_000, parseInt(process.env.AIRMCP_MUSIC_POLL_MS ?? "30000", 10));
-
-interface UnreadPayload {
-  totalUnread: number;
-  mailboxes: Array<{ account: string; mailbox: string; unread: number }>;
-}
-
-interface NowPlayingPayload {
-  playerState: string;
-  track: { name: string; artist: string; album: string; duration?: number; playerPosition?: number } | null;
-}
-
-interface Poller {
+export interface PollerDef {
+  /** Unique identifier — used for dedup, diagnostics, and error-throttle keys. */
   name: string;
+  /** Event bus type this poller emits (for diagnostics only). */
   event: AirMCPEventType;
+  /** Poll interval in milliseconds. Each poller decides its own floor. */
   intervalMs: number;
-  timer: ReturnType<typeof setInterval> | null;
+  /** Called immediately at start (baseline) and on every interval tick. */
   tick: () => Promise<void>;
+  /** Optional reset hook — clears any cached state when the registry stops. */
+  reset?: () => void;
 }
 
-let lastUnread: number | null = null;
-let lastTrackKey: string | null = null;
-let lastPlayerState: string | null = null;
+interface RegisteredPoller extends PollerDef {
+  timer: ReturnType<typeof setInterval> | null;
+}
 
-// Error throttling — only log one failure per poller per 5 minutes.
+const pollers = new Map<string, RegisteredPoller>();
+let started = false;
+
+/** Register a poller. Safe to call multiple times — later calls with the
+ *  same name replace the previous definition (useful for hot reload in
+ *  tests). If the registry is already started, the new poller is started
+ *  too. */
+export function registerPoller(def: PollerDef): void {
+  const existing = pollers.get(def.name);
+  if (existing?.timer) clearInterval(existing.timer);
+  const entry: RegisteredPoller = { ...def, timer: null };
+  pollers.set(def.name, entry);
+  if (started && process.env.AIRMCP_DISABLE_POLLERS !== "1") {
+    startOne(entry);
+  }
+}
+
+function startOne(p: RegisteredPoller): void {
+  // Fire once immediately to establish baseline, then on interval.
+  p.tick().catch(() => undefined);
+  p.timer = setInterval(() => {
+    p.tick().catch(() => undefined);
+  }, p.intervalMs);
+  // unref so pollers don't keep the process alive on exit
+  p.timer.unref?.();
+}
+
+/** Start all registered pollers. Idempotent. */
+export function startPollers(): void {
+  if (started) return;
+  if (process.env.AIRMCP_DISABLE_POLLERS === "1") return;
+  started = true;
+  for (const p of pollers.values()) {
+    if (!p.timer) startOne(p);
+  }
+}
+
+/** Stop all pollers and clear cached state. */
+export function stopPollers(): void {
+  for (const p of pollers.values()) {
+    if (p.timer) clearInterval(p.timer);
+    p.timer = null;
+    p.reset?.();
+  }
+  resetErrorThrottle();
+  started = false;
+}
+
+/** Inspect poller status (diagnostics only). */
+export function getPollerStatus(): Array<{ name: string; event: string; intervalMs: number; running: boolean }> {
+  return [...pollers.values()].map((p) => ({
+    name: p.name,
+    event: p.event,
+    intervalMs: p.intervalMs,
+    running: p.timer !== null,
+  }));
+}
+
+// ── Shared error throttling for poller `tick` implementations ────────
+// Each poller gets a stable key; log at most once per 5 minutes per key.
+// The map is GC'd periodically so long-running processes do not accumulate
+// stale keys from transient poll names.
+
 const errorThrottle = new Map<string, number>();
 const ERROR_THROTTLE_MS = 5 * 60 * 1000;
+const ERROR_THROTTLE_GC_MS = 24 * 60 * 60 * 1000;
 
 function shouldLogError(key: string): boolean {
   const now = Date.now();
   const last = errorThrottle.get(key) ?? 0;
   if (now - last < ERROR_THROTTLE_MS) return false;
   errorThrottle.set(key, now);
+  // Sweep entries older than a day so the map does not grow unbounded
+  // when ephemeral keys are produced (e.g. tests that register many pollers).
+  for (const [k, v] of errorThrottle) {
+    if (now - v > ERROR_THROTTLE_GC_MS) errorThrottle.delete(k);
+  }
   return true;
 }
 
-async function pollMailUnread(): Promise<void> {
-  try {
-    const payload = await runJxa<UnreadPayload>(getUnreadCountScript(), "Mail");
-    const total = typeof payload?.totalUnread === "number" ? payload.totalUnread : 0;
-    if (lastUnread === null) {
-      lastUnread = total;
-      return; // First read — establish baseline, don't emit
-    }
-    if (total !== lastUnread) {
-      const delta = total - lastUnread;
-      const previous = lastUnread;
-      lastUnread = total;
-      eventBus.emitNodeEvent("mail_unread_changed", {
-        source: "poll",
-        totalUnread: total,
-        previousUnread: previous,
-        delta,
-        mailboxes: payload.mailboxes ?? [],
-      });
-    }
-  } catch (e) {
-    if (shouldLogError("mail")) {
-      console.error(`[AirMCP pollers] mail_unread poll failed: ${e instanceof Error ? e.message : String(e)}`);
-    }
-  }
-}
-
-async function pollNowPlaying(): Promise<void> {
-  try {
-    const payload = await runJxa<NowPlayingPayload>(nowPlayingScript(), "Music");
-    const state = payload?.playerState ?? "stopped";
-    const track = payload?.track;
-    const key = track ? `${track.artist ?? ""}|${track.album ?? ""}|${track.name ?? ""}` : "";
-    if (lastTrackKey === null && lastPlayerState === null) {
-      lastTrackKey = key;
-      lastPlayerState = state;
-      return; // Baseline
-    }
-    const trackChanged = key !== lastTrackKey;
-    const stateChanged = state !== lastPlayerState;
-    if (trackChanged || stateChanged) {
-      const previousState = lastPlayerState;
-      lastTrackKey = key;
-      lastPlayerState = state;
-      eventBus.emitNodeEvent("now_playing_changed", {
-        source: "poll",
-        playerState: state,
-        previousPlayerState: previousState,
-        trackChanged,
-        track: track ?? null,
-      });
-    }
-  } catch (e) {
-    if (shouldLogError("music")) {
-      console.error(`[AirMCP pollers] now_playing poll failed: ${e instanceof Error ? e.message : String(e)}`);
-    }
-  }
-}
-
-const pollers: Poller[] = [
-  {
-    name: "mail_unread",
-    event: "mail_unread_changed",
-    intervalMs: MAIL_INTERVAL_MS,
-    timer: null,
-    tick: pollMailUnread,
-  },
-  {
-    name: "now_playing",
-    event: "now_playing_changed",
-    intervalMs: MUSIC_INTERVAL_MS,
-    timer: null,
-    tick: pollNowPlaying,
-  },
-];
-
-let started = false;
-
-/** Start all pollers. Idempotent. */
-export function startPollers(): void {
-  if (started) return;
-  if (process.env.AIRMCP_DISABLE_POLLERS === "1") return;
-  started = true;
-  for (const p of pollers) {
-    // Fire once immediately to establish baseline, then on interval.
-    p.tick().catch(() => undefined);
-    p.timer = setInterval(() => {
-      p.tick().catch(() => undefined);
-    }, p.intervalMs);
-    // unref so pollers don't keep the process alive on exit
-    p.timer.unref?.();
-  }
-}
-
-/** Stop all pollers and clear cached state. */
-export function stopPollers(): void {
-  for (const p of pollers) {
-    if (p.timer) clearInterval(p.timer);
-    p.timer = null;
-  }
-  lastUnread = null;
-  lastTrackKey = null;
-  lastPlayerState = null;
+function resetErrorThrottle(): void {
   errorThrottle.clear();
-  started = false;
 }
 
-/** Inspect poller status (diagnostics only). */
-export function getPollerStatus(): Array<{ name: string; event: string; intervalMs: number; running: boolean }> {
-  return pollers.map((p) => ({ name: p.name, event: p.event, intervalMs: p.intervalMs, running: p.timer !== null }));
+/** Factory for a throttled error logger scoped to a specific poller.
+ *  Callers pass the raw error; the logger formats a consistent prefix. */
+export function createPollerLogger(name: string): (e: unknown) => void {
+  return (e: unknown) => {
+    if (shouldLogError(name)) {
+      console.error(`[AirMCP pollers] ${name} poll failed: ${e instanceof Error ? e.message : String(e)}`);
+    }
+  };
+}
+
+/** Test-only: clear all registered pollers. Refuses to run outside test mode
+ *  so production callers cannot wipe the registry. */
+export function _resetPollerRegistryForTests(): void {
+  if (process.env.NODE_ENV !== "test" && process.env.AIRMCP_TEST_MODE !== "1") {
+    throw new Error("_resetPollerRegistryForTests is only callable in test mode");
+  }
+  for (const p of pollers.values()) {
+    if (p.timer) clearInterval(p.timer);
+  }
+  pollers.clear();
+  resetErrorThrottle();
+  started = false;
 }

--- a/src/shared/swift.ts
+++ b/src/shared/swift.ts
@@ -93,9 +93,17 @@ const DANGEROUS_KEYS = new Set(["__proto__", "constructor", "prototype"]);
  * single-shot responses, so every bridge path is covered.
  */
 function safeParseBridgeResponse(raw: string): BridgeResponse | null {
+  // Fast path: if the raw bytes contain any dangerous key literal, reject
+  // outright. This is defence-in-depth on top of the reviver — even though
+  // `return undefined` below drops the key, rejecting the whole payload is
+  // safer than silently stripping fields we may later need for diagnostics.
+  if (containsDangerousKey(raw)) return null;
   let poisoned = false;
   const parsed: unknown = JSON.parse(raw, (key, value) => {
-    if (DANGEROUS_KEYS.has(key)) poisoned = true;
+    if (DANGEROUS_KEYS.has(key)) {
+      poisoned = true;
+      return undefined; // Drop the key so the parent object is never mutated.
+    }
     return value;
   });
   if (poisoned) return null;
@@ -107,6 +115,15 @@ function safeParseBridgeResponse(raw: string): BridgeResponse | null {
     result: obj.result,
     error: typeof obj.error === "string" ? obj.error : undefined,
   };
+}
+
+/** Cheap string pre-check for the three dangerous keys. Catches the payload
+ *  before it ever enters `JSON.parse`, which closes the theoretical window
+ *  between "reviver runs" and "value is assigned" in engines where the
+ *  order is not strictly defined. `DANGEROUS_KEYS` is a hot-set of 3 items;
+ *  we scan for each quoted form (only object keys must be quoted). */
+function containsDangerousKey(raw: string): boolean {
+  return raw.includes('"__proto__"') || raw.includes('"constructor"') || raw.includes('"prototype"');
 }
 
 // ── Persistent process management ────────────────────────────────────
@@ -353,10 +370,18 @@ function runSwiftSingleShot<T>(command: string, input: string): Promise<T> {
         return;
       }
       try {
-        // Prototype pollution guard — use reviver (same as persistent mode)
+        // Prototype pollution guard — same layered defence as persistent mode:
+        // fast string pre-check + reviver that drops dangerous keys.
+        if (containsDangerousKey(trimmed)) {
+          reject(new Error("Swift bridge response rejected: suspicious payload"));
+          return;
+        }
         let poisoned = false;
         const parsed: unknown = JSON.parse(trimmed, (key, value) => {
-          if (DANGEROUS_KEYS.has(key)) poisoned = true;
+          if (DANGEROUS_KEYS.has(key)) {
+            poisoned = true;
+            return undefined;
+          }
           return value;
         });
         if (poisoned) {

--- a/src/shared/tool-registry.ts
+++ b/src/shared/tool-registry.ts
@@ -104,15 +104,38 @@ class ToolRegistry {
   /**
    * Invoke a registered tool by name, as the skill executor needs.
    * Throws if the tool is not found or is disabled.
+   *
+   * Passes through `structuredContent` (outputSchema-validated JSON) and
+   * `_meta` so callers that chain tools together — the skill executor in
+   * particular — can consume the typed payload directly instead of
+   * re-parsing the text content. The wire format for normal MCP clients
+   * is unaffected because this method is only reached via direct in-process
+   * calls.
    */
   async callTool(
     name: string,
     args: Record<string, unknown>,
-  ): Promise<{ content: Array<{ type: string; text: string }>; isError?: boolean }> {
+  ): Promise<{
+    content: Array<{ type: string; text: string }>;
+    isError?: boolean;
+    structuredContent?: unknown;
+    _meta?: Record<string, unknown>;
+  }> {
     const tool = this.tools.get(name);
     if (!tool) throw new Error(`Tool "${name}" not found`);
     if (!tool.enabled) throw new Error(`Tool "${name}" is disabled`);
-    return (await tool.handler(args, {})) as { content: Array<{ type: string; text: string }>; isError?: boolean };
+    const raw = (await tool.handler(args, {})) as {
+      content?: Array<{ type: string; text: string }>;
+      isError?: boolean;
+      structuredContent?: unknown;
+      _meta?: Record<string, unknown>;
+    };
+    return {
+      content: raw.content ?? [],
+      ...(raw.isError !== undefined ? { isError: raw.isError } : {}),
+      ...(raw.structuredContent !== undefined ? { structuredContent: raw.structuredContent } : {}),
+      ...(raw._meta !== undefined ? { _meta: raw._meta } : {}),
+    };
   }
 
   // ── Prompt accessors ────────────────────────────────────────────

--- a/src/skills/executor.ts
+++ b/src/skills/executor.ts
@@ -227,15 +227,30 @@ async function callTool(
   _server: McpServer,
   toolName: string,
   args: Record<string, unknown>,
-): Promise<{ content: Array<{ type: string; text: string }>; isError?: boolean }> {
+): Promise<{
+  content: Array<{ type: string; text: string }>;
+  isError?: boolean;
+  structuredContent?: unknown;
+}> {
   return toolRegistry.callTool(toolName, args);
 }
 
 const MAX_TOOL_RESPONSE_SIZE = 1_048_576; // 1MB
 
-function parseToolResponse(response: { content: Array<{ type: string; text: string }>; isError?: boolean }): unknown {
+function parseToolResponse(response: {
+  content: Array<{ type: string; text: string }>;
+  isError?: boolean;
+  structuredContent?: unknown;
+}): unknown {
   if (response.isError) {
     throw new Error(response.content[0]?.text ?? "Tool returned an error");
+  }
+  // Prefer structuredContent (outputSchema-validated) when present — it
+  // preserves types the text representation would flatten (e.g. nested
+  // arrays, numbers stored as numbers not strings). Fall back to parsing
+  // the text content only when no structured payload is provided.
+  if (response.structuredContent !== undefined) {
+    return response.structuredContent;
   }
   const text = response.content[0]?.text;
   if (!text) return null;
@@ -282,6 +297,7 @@ async function executeOneStep(
     }
 
     const loopResults: unknown[] = [];
+    let loopHadFailure = false;
     // Use step-scoped loop variables to avoid clobbering shared results in parallel execution
     const loopScope = new Map(results);
     for (let idx = 0; idx < items.length; idx++) {
@@ -292,11 +308,24 @@ async function executeOneStep(
         const response = await callTool(server, step.tool, resolvedArgs);
         loopResults.push(parseToolResponse(response));
       } catch (e) {
+        const error = e instanceof Error ? e.message : String(e);
+        if (step.on_error === "continue") {
+          loopResults.push({ error });
+          loopHadFailure = true;
+          continue;
+        }
         return {
-          stepResult: { id: step.id, status: "error", error: e instanceof Error ? e.message : String(e) },
+          stepResult: { id: step.id, status: "error", error },
           data: loopResults,
         };
       }
+    }
+    if (loopHadFailure) {
+      // Loop finished but at least one iteration failed under `continue`
+      // — surface it as a partial success so downstream steps / callers see
+      // the mix. `data` still contains all iteration results (including
+      // `{ error }` entries) so templates can filter on success/failure.
+      return { stepResult: { id: step.id, status: "ok", data: loopResults }, data: loopResults };
     }
     return { stepResult: { id: step.id, status: "ok", data: loopResults }, data: loopResults };
   }
@@ -315,7 +344,19 @@ async function executeOneStep(
 export async function executeSkill(server: McpServer, skill: SkillDefinition): Promise<SkillResult> {
   const results = new Map<string, unknown>();
   const stepResults: StepResult[] = [];
+  const failedSteps: string[] = [];
   let i = 0;
+
+  // Build once: the terminal result shape when we need to bail early. Keeps
+  // the two exit paths (hard abort / skip_remaining) in sync.
+  const finalize = (success: boolean): SkillResult => {
+    const res: SkillResult = { skill: skill.name, steps: stepResults, success };
+    if (failedSteps.length > 0) {
+      res.partial = !success || failedSteps.length > 0;
+      res.failedSteps = [...failedSteps];
+    }
+    return res;
+  };
 
   while (i < skill.steps.length) {
     const step = skill.steps[i]!;
@@ -329,36 +370,60 @@ export async function executeSkill(server: McpServer, skill: SkillDefinition): P
 
       const settled = await Promise.allSettled(group.map((s) => executeOneStep(server, s, results)));
 
-      let failed = false;
+      let sawAbort = false;
+      let sawSkipRemaining = false;
       for (let j = 0; j < group.length; j++) {
         const r = settled[j]!;
+        const s = group[j]!;
+        let stepResult: StepResult;
+        let data: unknown;
         if (r.status === "fulfilled") {
-          const { stepResult, data } = r.value;
-          results.set(group[j]!.id, data);
-          stepResults.push(stepResult);
-          if (stepResult.status === "error") failed = true;
+          stepResult = r.value.stepResult;
+          data = r.value.data;
         } else {
           const error = r.reason instanceof Error ? r.reason.message : String(r.reason);
-          results.set(group[j]!.id, null);
-          stepResults.push({ id: group[j]!.id, status: "error", error });
-          failed = true;
+          stepResult = { id: s.id, status: "error", error };
+          data = null;
         }
+        if (stepResult.status === "error") {
+          failedSteps.push(s.id);
+          const policy = s.on_error ?? "abort";
+          if (policy === "abort") sawAbort = true;
+          else if (policy === "skip_remaining") sawSkipRemaining = true;
+          // `continue`: expose `{ error }` to subsequent steps via templates.
+          results.set(s.id, policy === "continue" ? { error: stepResult.error } : data);
+        } else {
+          results.set(s.id, data);
+        }
+        stepResults.push(stepResult);
       }
 
-      if (failed) return { skill: skill.name, steps: stepResults, success: false };
+      if (sawAbort) return finalize(false);
+      if (sawSkipRemaining) return finalize(false);
       continue;
     }
 
     const result = await executeOneStep(server, step, results);
-    results.set(step.id, result.data);
     stepResults.push(result.stepResult);
 
     if (result.stepResult.status === "error") {
-      return { skill: skill.name, steps: stepResults, success: false };
+      failedSteps.push(step.id);
+      const policy = step.on_error ?? "abort";
+      if (policy === "continue") {
+        // Make the error available to later steps via `{{stepId.error}}`.
+        results.set(step.id, { error: result.stepResult.error });
+        i++;
+        continue;
+      }
+      // "abort" and "skip_remaining" both stop here; the difference is purely
+      // semantic in the result (partial flag is identical either way).
+      results.set(step.id, null);
+      return finalize(false);
     }
 
+    results.set(step.id, result.data);
     i++;
   }
 
-  return { skill: skill.name, steps: stepResults, success: true };
+  return finalize(true);
 }

--- a/src/skills/register.ts
+++ b/src/skills/register.ts
@@ -3,6 +3,7 @@ import type { SkillDefinition } from "./types.js";
 import { executeSkill } from "./executor.js";
 import { userPrompt } from "../shared/prompt.js";
 import { ok, err } from "../shared/result.js";
+import { toolRegistry } from "../shared/tool-registry.js";
 
 function generatePromptText(skill: SkillDefinition): string {
   const lines = [`Execute the following workflow "${skill.title}" using AirMCP tools:`];
@@ -49,20 +50,63 @@ function registerAsTool(server: McpServer, skill: SkillDefinition): void {
   );
 }
 
-export function registerSkills(server: McpServer, skills: SkillDefinition[]): { prompts: number; tools: number } {
+/**
+ * Graceful pre-flight check: if the name is already registered (e.g. a
+ * built-in prompt/tool in another module beat us to it), log a warning and
+ * skip this skill instead of letting the MCP SDK throw and take the whole
+ * server down.
+ *
+ * This is the runtime counterpart to tests/skill-name-collision.test.js —
+ * the test catches the issue pre-publish; this guard ensures that even if
+ * a collision slips through, the process degrades gracefully instead of
+ * crashing on startup (see v2.8.0 "Prompt weekly-review is already
+ * registered" incident).
+ */
+function isPromptNameTaken(name: string): boolean {
+  return toolRegistry.getPromptNames().includes(name);
+}
+
+function isToolNameTaken(name: string): boolean {
+  return toolRegistry.getToolNames().includes(name);
+}
+
+export function registerSkills(
+  server: McpServer,
+  skills: SkillDefinition[],
+): { prompts: number; tools: number; skipped: number } {
   let prompts = 0;
   let tools = 0;
+  let skipped = 0;
   for (const skill of skills) {
     switch (skill.expose_as) {
-      case "prompt":
+      case "prompt": {
+        if (isPromptNameTaken(skill.name)) {
+          console.error(
+            `[AirMCP] Skill "${skill.name}" collides with an already-registered prompt — skipping. ` +
+              `Rename the skill in its YAML to resolve.`,
+          );
+          skipped++;
+          break;
+        }
         registerAsPrompt(server, skill);
         prompts++;
         break;
-      case "tool":
+      }
+      case "tool": {
+        const toolName = `skill_${skill.name}`;
+        if (isToolNameTaken(toolName)) {
+          console.error(
+            `[AirMCP] Skill "${skill.name}" collides with an already-registered tool "${toolName}" — skipping. ` +
+              `Rename the skill in its YAML to resolve.`,
+          );
+          skipped++;
+          break;
+        }
         registerAsTool(server, skill);
         tools++;
         break;
+      }
     }
   }
-  return { prompts, tools };
+  return { prompts, tools, skipped };
 }

--- a/src/skills/triggers.ts
+++ b/src/skills/triggers.ts
@@ -11,6 +11,35 @@ interface TriggerBinding {
 
 const bindings = new Map<string, TriggerBinding[]>();
 
+// Retry policy for failed trigger dispatches. Exponential backoff (2s → 4s
+// → 8s …) with jitter avoids thundering-herd retries when many triggers fire
+// on the same event (e.g. a burst of `calendar_changed`). Override via env
+// for tests / aggressive polling setups.
+const TRIGGER_MAX_RETRIES = Math.max(0, parseInt(process.env.AIRMCP_TRIGGER_MAX_RETRIES ?? "2", 10));
+const TRIGGER_BASE_BACKOFF_MS = Math.max(100, parseInt(process.env.AIRMCP_TRIGGER_BASE_BACKOFF_MS ?? "2000", 10));
+const TRIGGER_MAX_BACKOFF_MS = Math.max(
+  TRIGGER_BASE_BACKOFF_MS,
+  parseInt(process.env.AIRMCP_TRIGGER_MAX_BACKOFF_MS ?? "60000", 10),
+);
+
+function computeBackoff(attempt: number): number {
+  // attempt is 1-indexed: the 1st retry waits BASE, the 2nd waits 2×BASE, …
+  const exp = Math.min(TRIGGER_MAX_BACKOFF_MS, TRIGGER_BASE_BACKOFF_MS * 2 ** (attempt - 1));
+  const jitter = Math.floor(Math.random() * (exp * 0.25));
+  return exp + jitter;
+}
+
+function runWithRetry(server: McpServer, skill: SkillDefinition, attempt: number): void {
+  executeSkill(server, skill).catch((e) => {
+    const msg = e instanceof Error ? e.message : String(e);
+    console.error(`[AirMCP] Trigger ${skill.name} failed (attempt ${attempt}): ${msg}`);
+    if (attempt >= 1 + TRIGGER_MAX_RETRIES) return;
+    const delay = computeBackoff(attempt);
+    const t = setTimeout(() => runWithRetry(server, skill, attempt + 1), delay);
+    t.unref?.();
+  });
+}
+
 /** Reset all registered trigger bindings and listener state. Called by
  *  registerSkillEngine before re-registering, so per-session createServer
  *  calls don't accumulate duplicate bindings. Also resets the listener
@@ -48,19 +77,10 @@ function dispatch(evt: AirMCPEvent): void {
     if (now - binding.lastFired < binding.debounceMs) continue;
     binding.lastFired = now;
 
-    // Fire and forget — don't block the event loop. Retry once on failure.
-    executeSkill(server, binding.skill).catch((e) => {
-      console.error(
-        `[AirMCP] Trigger ${binding.skill.name} failed (attempt 1): ${e instanceof Error ? e.message : String(e)}`,
-      );
-      setTimeout(() => {
-        executeSkill(server, binding.skill).catch((e2) => {
-          console.error(
-            `[AirMCP] Trigger ${binding.skill.name} failed (attempt 2): ${e2 instanceof Error ? e2.message : String(e2)}`,
-          );
-        });
-      }, 2000);
-    });
+    // Fire and forget — don't block the event loop. `runWithRetry` handles
+    // exponential backoff with jitter so bursty events (e.g. many calendar
+    // updates in quick succession) don't line their retries up.
+    runWithRetry(server, binding.skill, 1);
   }
 }
 

--- a/src/skills/types.ts
+++ b/src/skills/types.ts
@@ -8,6 +8,20 @@ export const SkillStepSchema = z.object({
   skip_if: z.string().optional(),
   parallel: z.boolean().optional(),
   loop: z.string().optional(),
+  /**
+   * Failure strategy for this step:
+   *   - "abort"          (default) — stop the skill as soon as this step fails.
+   *   - "continue"       — record the error, store `{ error: string }` under
+   *                        the step id so later steps can reference it via
+   *                        `{{stepId.error}}`, then continue.
+   *   - "skip_remaining" — stop executing further steps but mark the skill
+   *                        result `partial: true` with accumulated data intact.
+   *
+   * Inside a `loop` step, `continue` applies per-iteration — individual
+   * failed iterations leave a `{ error: string }` slot in the loop result
+   * array and execution moves to the next item.
+   */
+  on_error: z.enum(["abort", "continue", "skip_remaining"]).optional(),
 });
 
 export const SkillDefinitionSchema = z.object({
@@ -46,4 +60,11 @@ export interface SkillResult {
   skill: string;
   steps: StepResult[];
   success: boolean;
+  /** True when at least one step failed but the skill continued running
+   *  because of `on_error: "continue"` or `"skip_remaining"`. Callers can
+   *  use this to surface partial progress without treating the run as a
+   *  hard failure. */
+  partial?: boolean;
+  /** IDs of steps that errored out. Empty when `success` is true. */
+  failedSteps?: string[];
 }

--- a/tests/executor.test.js
+++ b/tests/executor.test.js
@@ -782,3 +782,132 @@ describe('executeSkill – parallel steps', () => {
     expect(result.steps[1].error).toBe('string thrown');
   });
 });
+
+describe('executeSkill – on_error', () => {
+  beforeEach(() => {
+    mockCallTool.mockReset();
+  });
+
+  test('on_error: "continue" runs later steps and exposes the error via templates', async () => {
+    mockCallTool
+      .mockResolvedValueOnce(errorResponse('boom'))
+      .mockResolvedValueOnce(okResponse({ ok: true }));
+
+    const skill = {
+      name: 'continue-past-failure',
+      steps: [
+        { id: 'first', tool: 'failing_tool', args: {}, on_error: 'continue' },
+        { id: 'second', tool: 'log_tool', args: { reason: '{{first.error}}' } },
+      ],
+    };
+    const result = await executeSkill(fakeServer, skill);
+
+    expect(result.success).toBe(true);
+    expect(result.partial).toBe(true);
+    expect(result.failedSteps).toEqual(['first']);
+    expect(result.steps[0].status).toBe('error');
+    expect(result.steps[1].status).toBe('ok');
+    // The second tool should have received the first step's error text via the template.
+    expect(mockCallTool).toHaveBeenNthCalledWith(2, 'log_tool', { reason: 'boom' });
+  });
+
+  test('on_error: "skip_remaining" halts but keeps accumulated results', async () => {
+    mockCallTool
+      .mockResolvedValueOnce(okResponse({ value: 1 }))
+      .mockResolvedValueOnce(errorResponse('stop'));
+
+    const skill = {
+      name: 'skip-remaining',
+      steps: [
+        { id: 'a', tool: 'ok_tool', args: {} },
+        { id: 'b', tool: 'fail_tool', args: {}, on_error: 'skip_remaining' },
+        { id: 'c', tool: 'never_called', args: {} },
+      ],
+    };
+    const result = await executeSkill(fakeServer, skill);
+
+    expect(result.success).toBe(false);
+    expect(result.partial).toBe(true);
+    expect(result.failedSteps).toEqual(['b']);
+    expect(result.steps).toHaveLength(2); // step c never runs
+    expect(mockCallTool).toHaveBeenCalledTimes(2);
+  });
+
+  test('on_error defaults to "abort" and stops the skill on failure', async () => {
+    mockCallTool
+      .mockResolvedValueOnce(errorResponse('first failed'))
+      .mockResolvedValueOnce(okResponse({ ok: true }));
+
+    const skill = {
+      name: 'abort-default',
+      steps: [
+        { id: 'a', tool: 'fail', args: {} },
+        { id: 'b', tool: 'never', args: {} },
+      ],
+    };
+    const result = await executeSkill(fakeServer, skill);
+
+    expect(result.success).toBe(false);
+    expect(result.failedSteps).toEqual(['a']);
+    expect(result.steps).toHaveLength(1);
+    expect(mockCallTool).toHaveBeenCalledTimes(1);
+  });
+
+  test('loop with on_error: "continue" records per-iteration errors and finishes', async () => {
+    mockCallTool
+      .mockResolvedValueOnce(okResponse({ idx: 0 }))
+      .mockResolvedValueOnce(errorResponse('item 1 failed'))
+      .mockResolvedValueOnce(okResponse({ idx: 2 }));
+
+    const skill = {
+      name: 'loop-continue',
+      steps: [
+        { id: 'seed', tool: 'seed', args: {} },
+        {
+          id: 'each',
+          tool: 'process_item',
+          args: { index: '{{_index}}' },
+          loop: '{{seed}}',
+          on_error: 'continue',
+        },
+      ],
+    };
+    mockCallTool.mockReset();
+    mockCallTool
+      .mockResolvedValueOnce(okResponse([10, 20, 30]))
+      .mockResolvedValueOnce(okResponse({ idx: 0 }))
+      .mockResolvedValueOnce(errorResponse('item 1 failed'))
+      .mockResolvedValueOnce(okResponse({ idx: 2 }));
+
+    const result = await executeSkill(fakeServer, skill);
+
+    expect(result.success).toBe(true);
+    expect(result.steps[1].status).toBe('ok');
+    expect(Array.isArray(result.steps[1].data)).toBe(true);
+    expect(result.steps[1].data).toHaveLength(3);
+    expect(result.steps[1].data[1]).toEqual({ error: 'item 1 failed' });
+  });
+
+  test('parallel group with on_error: "continue" lets sibling steps succeed and skill continues', async () => {
+    mockCallTool
+      .mockResolvedValueOnce(errorResponse('p1 failed'))
+      .mockResolvedValueOnce(okResponse({ ok: true }))
+      .mockResolvedValueOnce(okResponse({ next: true }));
+
+    const skill = {
+      name: 'parallel-continue',
+      steps: [
+        { id: 'p1', tool: 'fail_tool', args: {}, parallel: true, on_error: 'continue' },
+        { id: 'p2', tool: 'ok_tool', args: {}, parallel: true },
+        { id: 'after', tool: 'post', args: { from: '{{p1.error}}' } },
+      ],
+    };
+    const result = await executeSkill(fakeServer, skill);
+
+    expect(result.success).toBe(true);
+    expect(result.partial).toBe(true);
+    expect(result.failedSteps).toEqual(['p1']);
+    expect(result.steps[2].status).toBe('ok');
+    expect(mockCallTool).toHaveBeenNthCalledWith(3, 'post', { from: 'p1 failed' });
+  });
+});

--- a/tests/skill-name-collision.test.js
+++ b/tests/skill-name-collision.test.js
@@ -1,0 +1,152 @@
+/**
+ * Static regression test for the class of bug that shipped in v2.8.0 and
+ * crashed the server on startup with
+ *     "Prompt weekly-review is already registered"
+ *
+ * Root cause: a built-in skill YAML (src/skills/builtins/weekly-review.yaml)
+ * used the same `name:` as an already-registered MCP prompt
+ * (src/cross/prompts.ts registers "weekly-review"). The MCP SDK throws on
+ * duplicate prompt registration, so the entire server refused to start.
+ *
+ * This test catches that class of collision BEFORE publish by scanning
+ * source files statically — no server boot, no network, no mocks.
+ */
+
+import { describe, test, expect } from '@jest/globals';
+import { readFileSync, readdirSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { parse as parseYaml } from 'yaml';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = join(__dirname, '..');
+const BUILTINS_DIR = join(REPO_ROOT, 'src', 'skills', 'builtins');
+const SRC_DIR = join(REPO_ROOT, 'src');
+
+// ───────────────────────────────────────────────────────────────────────────
+// Helpers
+// ───────────────────────────────────────────────────────────────────────────
+
+function loadBuiltinSkills() {
+  const files = readdirSync(BUILTINS_DIR).filter(
+    (f) => f.endsWith('.yaml') || f.endsWith('.yml'),
+  );
+  return files.map((file) => {
+    const raw = readFileSync(join(BUILTINS_DIR, file), 'utf8');
+    const parsed = parseYaml(raw);
+    return { file, ...parsed };
+  });
+}
+
+/** Recursively collect every .ts file under src/, skipping the skills engine. */
+function collectTsSources(root) {
+  const out = [];
+  function walk(dir) {
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      const p = join(dir, entry.name);
+      if (entry.isDirectory()) {
+        if (entry.name === 'node_modules') continue;
+        walk(p);
+      } else if (entry.isFile() && entry.name.endsWith('.ts') && !entry.name.endsWith('.d.ts')) {
+        out.push(p);
+      }
+    }
+  }
+  walk(root);
+  return out;
+}
+
+/**
+ * Extract every literal prompt name registered via `server.prompt(...)` or
+ * `server.registerPrompt(...)`. The SDK accepts the name as the first string
+ * argument — we match both single-line and multi-line call shapes.
+ *
+ * We deliberately skip src/skills/register.ts because those registrations
+ * come from YAML at runtime, not from source literals.
+ */
+function extractRegisteredPromptNames(files) {
+  const names = new Set();
+  // Matches:   server.prompt( "name"   OR   server.registerPrompt(  "name"
+  // Allows whitespace / newlines between `(` and the opening quote.
+  const rx = /server\.(?:prompt|registerPrompt)\s*\(\s*["']([a-z][a-z0-9-]*)["']/g;
+  for (const file of files) {
+    // Skip the dynamic skill registration site — its name is runtime data.
+    if (file.endsWith(`${'skills'}/register.ts`) || file.endsWith('skills\\register.ts')) continue;
+    const src = readFileSync(file, 'utf8');
+    for (const m of src.matchAll(rx)) {
+      names.add(m[1]);
+    }
+  }
+  return names;
+}
+
+/**
+ * Extract every literal tool name registered via `server.tool(...)` or
+ * `server.registerTool(...)`. Same rationale as above.
+ */
+function extractRegisteredToolNames(files) {
+  const names = new Set();
+  const rx = /server\.(?:tool|registerTool)\s*\(\s*["']([a-zA-Z0-9_-]+)["']/g;
+  for (const file of files) {
+    if (file.endsWith(`${'skills'}/register.ts`) || file.endsWith('skills\\register.ts')) continue;
+    const src = readFileSync(file, 'utf8');
+    for (const m of src.matchAll(rx)) {
+      names.add(m[1]);
+    }
+  }
+  return names;
+}
+
+// ───────────────────────────────────────────────────────────────────────────
+// Tests
+// ───────────────────────────────────────────────────────────────────────────
+
+describe('built-in skill name collision guard', () => {
+  const skills = loadBuiltinSkills();
+  const sources = collectTsSources(SRC_DIR);
+  const registeredPrompts = extractRegisteredPromptNames(sources);
+  const registeredTools = extractRegisteredToolNames(sources);
+
+  test('at least one built-in skill is discovered', () => {
+    // Guards against a silently broken scanner that finds no files and
+    // therefore finds no collisions.
+    expect(skills.length).toBeGreaterThan(0);
+  });
+
+  test('scanner discovered at least one built-in prompt literal', () => {
+    // Guards against a regex breakage that would make the collision test
+    // vacuously pass.
+    expect(registeredPrompts.size).toBeGreaterThan(0);
+  });
+
+  test.each(
+    // Jest.each rows: [skillFile, skillName, expose_as]
+    loadBuiltinSkills().map((s) => [s.file, s.name, s.expose_as]),
+  )(
+    '%s: skill "%s" (expose_as=%s) does not collide with a built-in prompt/tool',
+    (_file, name, exposeAs) => {
+      if (exposeAs === 'prompt') {
+        expect(registeredPrompts.has(name)).toBe(false);
+      } else if (exposeAs === 'tool') {
+        // Skills exposed as tools register under `skill_<name>` — check the
+        // prefixed form.
+        expect(registeredTools.has(`skill_${name}`)).toBe(false);
+      }
+    },
+  );
+
+  test('built-in skill names are unique among themselves', () => {
+    const counts = new Map();
+    for (const s of skills) {
+      counts.set(s.name, (counts.get(s.name) ?? 0) + 1);
+    }
+    const dups = [...counts.entries()].filter(([, n]) => n > 1);
+    expect(dups).toEqual([]);
+  });
+
+  test('every built-in skill has a valid expose_as value', () => {
+    for (const s of skills) {
+      expect(['prompt', 'tool']).toContain(s.expose_as);
+    }
+  });
+});

--- a/tests/skill-register-collision.test.js
+++ b/tests/skill-register-collision.test.js
@@ -1,0 +1,124 @@
+/**
+ * Runtime regression test for the graceful-skip behavior added to
+ * registerSkills() in response to the v2.8.0 "Prompt weekly-review is
+ * already registered" crash.
+ *
+ * Contract being verified:
+ *   1. If a skill's name collides with an already-registered prompt/tool,
+ *      registerSkills does NOT throw.
+ *   2. The colliding skill is NOT registered (skip).
+ *   3. Non-colliding skills in the same batch ARE still registered.
+ *   4. The skip count is returned in the result.
+ */
+
+import { describe, test, expect, beforeEach, jest } from '@jest/globals';
+import { toolRegistry } from '../dist/shared/tool-registry.js';
+import { registerSkills } from '../dist/skills/register.js';
+
+/**
+ * A minimal stand-in server. After toolRegistry.installOn() wraps these
+ * methods, the registry becomes the source of truth for "what was
+ * registered", so we assert on the registry rather than the mock.
+ */
+function makeFakeServer() {
+  return {
+    prompt: () => ({}),
+    registerPrompt: () => ({}),
+    tool: () => ({}),
+    registerTool: () => ({}),
+  };
+}
+
+function makeSkill(overrides = {}) {
+  return {
+    name: 'unit-collision-skill',
+    title: 'Unit Collision Skill',
+    description: 'Used only in tests for the collision guard.',
+    expose_as: 'prompt',
+    steps: [{ id: 's1', tool: 'some_tool' }],
+    ...overrides,
+  };
+}
+
+describe('registerSkills graceful-skip on name collision', () => {
+  beforeEach(() => {
+    toolRegistry.reset(); // requires NODE_ENV=test, which Jest sets
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  test('skips a prompt skill whose name collides with a pre-registered prompt', () => {
+    const server = makeFakeServer();
+    toolRegistry.installOn(server);
+
+    // Simulate another module having already claimed "weekly-review".
+    server.prompt('weekly-review', 'pre-existing', () => ({}));
+    expect(toolRegistry.getPromptNames()).toEqual(['weekly-review']);
+
+    const result = registerSkills(server, [
+      makeSkill({ name: 'weekly-review', expose_as: 'prompt' }),
+    ]);
+
+    expect(result).toEqual({ prompts: 0, tools: 0, skipped: 1 });
+    // Registry still holds ONLY the pre-existing entry — the skill was skipped.
+    expect(toolRegistry.getPromptNames()).toEqual(['weekly-review']);
+    expect(console.error).toHaveBeenCalledWith(
+      expect.stringContaining('collides with an already-registered prompt'),
+    );
+  });
+
+  test('skips a tool skill whose skill_<name> collides with a pre-registered tool', () => {
+    const server = makeFakeServer();
+    toolRegistry.installOn(server);
+
+    // Simulate another module having already claimed "skill_inbox-triage".
+    server.registerTool(
+      'skill_inbox-triage',
+      { description: 'pre-existing', inputSchema: {} },
+      async () => ({}),
+    );
+    expect(toolRegistry.getToolNames()).toEqual(['skill_inbox-triage']);
+
+    const result = registerSkills(server, [
+      makeSkill({ name: 'inbox-triage', expose_as: 'tool' }),
+    ]);
+
+    expect(result).toEqual({ prompts: 0, tools: 0, skipped: 1 });
+    // Only the pre-existing tool remains — the skill was skipped.
+    expect(toolRegistry.getToolNames()).toEqual(['skill_inbox-triage']);
+  });
+
+  test('still registers non-colliding skills when one in the batch collides', () => {
+    const server = makeFakeServer();
+    toolRegistry.installOn(server);
+
+    // Pre-claim "taken-name" only.
+    server.prompt('taken-name', 'pre-existing', () => ({}));
+
+    const result = registerSkills(server, [
+      makeSkill({ name: 'taken-name', expose_as: 'prompt' }),
+      makeSkill({ name: 'fresh-name', expose_as: 'prompt' }),
+      makeSkill({ name: 'fresh-tool', expose_as: 'tool' }),
+    ]);
+
+    expect(result).toEqual({ prompts: 1, tools: 1, skipped: 1 });
+
+    // Registry: pre-existing + fresh-name (prompt); skill_fresh-tool (tool).
+    expect(toolRegistry.getPromptNames().sort()).toEqual(['fresh-name', 'taken-name']);
+    expect(toolRegistry.getToolNames()).toEqual(['skill_fresh-tool']);
+  });
+
+  test('does not throw when every skill collides', () => {
+    const server = makeFakeServer();
+    toolRegistry.installOn(server);
+
+    server.prompt('a', '-', () => ({}));
+    server.prompt('b', '-', () => ({}));
+
+    expect(() =>
+      registerSkills(server, [
+        makeSkill({ name: 'a', expose_as: 'prompt' }),
+        makeSkill({ name: 'b', expose_as: 'prompt' }),
+      ]),
+    ).not.toThrow();
+  });
+});

--- a/tests/skills-register.test.js
+++ b/tests/skills-register.test.js
@@ -7,9 +7,21 @@ jest.unstable_mockModule('../dist/skills/executor.js', () => ({
 }));
 
 // ─── Mock result helpers ────────────────────────────────────────────────
+// Include every export touched by the transitive import graph so ESM
+// strict-mode "missing export" errors do not surface when register.ts
+// pulls in tool-registry (which uses withResultSizeHint for size hints).
 jest.unstable_mockModule('../dist/shared/result.js', () => ({
   ok: jest.fn((data) => ({ content: [{ type: 'text', text: JSON.stringify(data) }] })),
   err: jest.fn((msg) => ({ content: [{ type: 'text', text: msg }], isError: true })),
+  withResultSizeHint: jest.fn((result) => result),
+}));
+
+// ─── Mock tool-registry (register.ts consults it for name collisions) ──
+jest.unstable_mockModule('../dist/shared/tool-registry.js', () => ({
+  toolRegistry: {
+    getPromptNames: jest.fn(() => []),
+    getToolNames: jest.fn(() => []),
+  },
 }));
 
 // ─── Mock prompt helper ─────────────────────────────────────────────────
@@ -61,7 +73,7 @@ describe('registerSkills', () => {
 
     const result = registerSkills(server, [skill]);
 
-    expect(result).toEqual({ prompts: 0, tools: 1 });
+    expect(result).toEqual({ prompts: 0, tools: 1, skipped: 0 });
     expect(server.registerTool).toHaveBeenCalledTimes(1);
     expect(server.registerTool).toHaveBeenCalledWith(
       'skill_test-skill',
@@ -85,7 +97,7 @@ describe('registerSkills', () => {
 
     const result = registerSkills(server, [skill]);
 
-    expect(result).toEqual({ prompts: 1, tools: 0 });
+    expect(result).toEqual({ prompts: 1, tools: 0, skipped: 0 });
     expect(server.prompt).toHaveBeenCalledTimes(1);
     expect(server.prompt).toHaveBeenCalledWith(
       'test-skill',
@@ -101,7 +113,7 @@ describe('registerSkills', () => {
 
     const result = registerSkills(server, [toolSkill, promptSkill, toolSkill2]);
 
-    expect(result).toEqual({ prompts: 1, tools: 2 });
+    expect(result).toEqual({ prompts: 1, tools: 2, skipped: 0 });
     expect(server.registerTool).toHaveBeenCalledTimes(2);
     expect(server.prompt).toHaveBeenCalledTimes(1);
   });
@@ -109,7 +121,7 @@ describe('registerSkills', () => {
   test('returns zero counts for empty skills array', () => {
     const result = registerSkills(server, []);
 
-    expect(result).toEqual({ prompts: 0, tools: 0 });
+    expect(result).toEqual({ prompts: 0, tools: 0, skipped: 0 });
     expect(server.registerTool).not.toHaveBeenCalled();
     expect(server.prompt).not.toHaveBeenCalled();
   });

--- a/tests/skills-triggers.test.js
+++ b/tests/skills-triggers.test.js
@@ -248,8 +248,9 @@ describe('startTriggerListener and event dispatch', () => {
       expect.stringContaining('failed (attempt 1)'),
     );
 
-    // Advance past the 2000ms retry delay
-    await jest.advanceTimersByTimeAsync(2100);
+    // Exponential backoff: base 2000ms + up to 25% jitter → bounded by 2500ms.
+    // Advance past the worst-case upper bound so the retry timer has fired.
+    await jest.advanceTimersByTimeAsync(2600);
 
     expect(mockExecuteSkill).toHaveBeenCalledTimes(2);
 
@@ -282,7 +283,8 @@ describe('startTriggerListener and event dispatch', () => {
       expect.stringContaining('failed (attempt 1)'),
     );
 
-    await jest.advanceTimersByTimeAsync(2100);
+    // See note on exponential-backoff bounds in the prior test.
+    await jest.advanceTimersByTimeAsync(2600);
     expect(console.error).toHaveBeenCalledWith(
       expect.stringContaining('failed (attempt 2)'),
     );


### PR DESCRIPTION
## Summary
- **Skills on_error**: per-step failure policies (`abort`/`continue`/`skip_remaining`) with partial result tracking and `failedSteps` array
- **Collision guard**: runtime check prevents duplicate prompt/tool registration crashes (v2.8.0 incident defence-in-depth)
- **Poller registry**: mail/music pollers self-register at import time — `shared/pollers.ts` no longer imports from feature modules
- **Graceful shutdown**: new `server/shutdown.ts` module with async hooks and bounded timeout for clean teardown
- **Swift bridge security**: layered prototype pollution defence — string pre-check before `JSON.parse` reviver
- **Trigger retry**: exponential backoff with jitter replaces fixed 2s retry
- **Tests**: on_error scenarios, collision detection, updated backoff timing

## Test plan
- [ ] CI passes (build, lint, 87 test suites / 1217 tests)
- [ ] `npx airmcp` starts without errors
- [ ] Skills with `on_error: continue` report partial results correctly