### PR TITLE
chore(release): v2.10.0 — skills dsl, memory, audit, timeline, http policy

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -7,7 +7,7 @@ body:
     attributes:
       label: AirMCP Version
       description: "Run `npx airmcp --help` to check"
-      placeholder: "2.9.0"
+      placeholder: "2.10.0"
     validations:
       required: true
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.10.0] - 2026-04-20
+
 ### Added
 - **Swift menubar onboarding — module coverage + v2.10 surface** — `OnboardingView` module picker grew from 15 to 25 items, reorganised into four readable clusters (Everyday · Media · System + automation · Intelligence + introspection · Context sensors · Integrations) instead of a flat list. The v2.10 introspection modules — **Context Memory** and **Audit** — get dedicated entries so first-run users see them alongside Notes/Calendar instead of having to discover them in config later. Localisable.strings gains `module.memory.*` and `module.audit.*` keys in both English and Korean. Swift build green; no Node-side changes.
 - **Registry submissions tracker + `server.json` refresh** — new `docs/REGISTRY_SUBMISSIONS.md` tracks status across Anthropic MCP Registry, Smithery, Glama, MCP Market, Cline Marketplace, and PulseMCP, with a resubmission checklist that requires `stats:sync` green before any registry UI is touched. `server.json` (Anthropic schema `static.modelcontextprotocol.io/schemas/2025-12-11`) gets a v2.10-era description ("269 tools across 29 modules with YAML skills, context memory, queryable audit log, and declarative HTTP network policy") and joins the `npm run stats:sync` fleet so its counts stay truthful automatically.

--- a/app/Sources/AirMCPApp/UpdateManager.swift
+++ b/app/Sources/AirMCPApp/UpdateManager.swift
@@ -10,7 +10,7 @@ final class UpdateManager {
 
     private var timer: Timer?
     private static let checkInterval: TimeInterval = 3600 // 1 hour
-    private let currentVersion = "2.9.0"
+    private let currentVersion = "2.10.0"
 
     var currentVersionString: String { currentVersion }
 

--- a/docs/PRIVACY_POLICY.md
+++ b/docs/PRIVACY_POLICY.md
@@ -1,6 +1,6 @@
 # Privacy Policy
 
-**AirMCP v2.9.0** — MCP Server for the Apple Ecosystem on macOS
+**AirMCP v2.10.0** — MCP Server for the Apple Ecosystem on macOS
 Last updated: 2026-03-28
 
 ## Overview

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "airmcp",
-  "version": "2.9.0",
+  "version": "2.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "airmcp",
-      "version": "2.9.0",
+      "version": "2.10.0",
       "license": "MIT",
       "os": [
         "darwin"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "airmcp",
-  "version": "2.9.0",
+  "version": "2.10.0",
   "description": "MCP server for the entire Apple ecosystem — Notes, Reminders, Calendar, Contacts, Mail, Messages, Music, Finder, Safari, System, Photos, Shortcuts, Apple Intelligence, TV, Screen Capture, Maps, and Podcasts. Connect any AI to your Mac.",
   "keywords": [
     "mcp",

--- a/scripts/bundle-app.sh
+++ b/scripts/bundle-app.sh
@@ -105,7 +105,7 @@ fi
 /usr/libexec/PlistBuddy -c "Delete :CFBundlePackageType" "$PLIST" 2>/dev/null || true
 /usr/libexec/PlistBuddy -c "Add :CFBundlePackageType string APPL" "$PLIST"
 /usr/libexec/PlistBuddy -c "Delete :CFBundleShortVersionString" "$PLIST" 2>/dev/null || true
-/usr/libexec/PlistBuddy -c "Add :CFBundleShortVersionString string 2.9.0" "$PLIST"
+/usr/libexec/PlistBuddy -c "Add :CFBundleShortVersionString string 2.10.0" "$PLIST"
 /usr/libexec/PlistBuddy -c "Delete :LSUIElement" "$PLIST" 2>/dev/null || true
 /usr/libexec/PlistBuddy -c "Add :LSUIElement bool true" "$PLIST"
 /usr/libexec/PlistBuddy -c "Delete :NSMicrophoneUsageDescription" "$PLIST" 2>/dev/null || true

--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.heznpc/airmcp",
   "description": "MCP server for the entire Apple ecosystem — 269 tools across 29 modules with YAML skills, context memory, queryable audit log, and declarative HTTP network policy. macOS only.",
-  "version": "2.9.0",
+  "version": "2.10.0",
   "websiteUrl": "https://github.com/heznpc/AirMCP",
   "repository": {
     "url": "https://github.com/heznpc/AirMCP",
@@ -12,7 +12,7 @@
     {
       "registryType": "npm",
       "identifier": "airmcp",
-      "version": "2.9.0",
+      "version": "2.10.0",
       "transport": {
         "type": "stdio"
       }
@@ -20,7 +20,7 @@
     {
       "registryType": "npm",
       "identifier": "airmcp",
-      "version": "2.9.0",
+      "version": "2.10.0",
       "transport": {
         "type": "http",
         "args": [

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -188,7 +188,7 @@ export const LIMITS = {
 
 export const IDENTITY = {
   /** User-Agent for HTTP requests to external APIs */
-  USER_AGENT: envStr("AIRMCP_USER_AGENT", "AirMCP/2.9 (https://github.com/heznpc/AirMCP)"),
+  USER_AGENT: envStr("AIRMCP_USER_AGENT", "AirMCP/2.10 (https://github.com/heznpc/AirMCP)"),
   /** Default HTTP server port */
   HTTP_PORT: envInt("AIRMCP_HTTP_PORT", 3847),
 } as const;


### PR DESCRIPTION
## Summary

Version bump from 2.9.0 → 2.10.0. Rolls up every entry in CHANGELOG's `[Unreleased]` block into the 2.10.0 cut.

**Release trigger**: merging this PR to `main` fires `auto-release.yml`, which in turn invokes `cd.yml` to create the `v2.10.0` git tag, publish to npm, and draft the GitHub Release.

## Highlights (full list under `## [2.10.0]` in CHANGELOG)

- **Skills DSL completes**: `inputs` + `parallel` + `loop` + `on_error` + `retry` + 9 event triggers (`screen_locked` / `screen_unlocked` added). 14 built-in skills including `daily-journal`, `evening-winddown`, `favorites-digest`, `clipboard-url-to-reading`, `sender-to-tasks`, `weekly-digest-note`, `focus-block-planner`.
- **Timeline MCP App** — third interactive UI, fuses Calendar + Reminders on a single day-axis with an Unscheduled rail.
- **Context memory module graduates** — outputSchema on all four tools + `memory://recent` resource + `daily-journal` reference skill.
- **Audit consumption tools** — `audit_log` + `audit_summary` + new `audit` module.
- **Agent safety** — two-tier rate limit (60/min + 10 destructive/hr) + `~/.config/airmcp/emergency-stop` kill switch.
- **RFC 0002** — declarative `allowNetwork` policy + startup invariant + reverse-proxy header detection + `doctor` CLI surface.
- **outputSchema Wave 2** — 14 additional read tools typed. Skill executor now prefers `structuredContent` on tool chaining.
- **`ai_plan_metrics`** — live on-device planner quality check over the expanded 31-case `GOLDEN_PLANS` set.
- **Registry + browser-MCP docs** — Claude in Chrome guide, Beyond Siri landing section, Registry submissions tracker.
- **Swift menubar onboarding** — module picker grows 15 → 25 entries, reorganised by cluster, Context Memory + Audit front-and-centre.

## Metrics

| | v2.9.0 | **v2.10.0** |
|---|---|---|
| Tests | 1217 | **1303** (+86) |
| Modules | 27 | **29** |
| Built-in skills | 7 | **14** |
| Event triggers | 7 | **9** |
| `outputSchema` coverage (read tools) | ~11% | **~35%** |

## Version sync

`node scripts/sync-version.mjs` propagated `2.10.0` to every manifest that carries the version string:

- `package.json` + `package-lock.json`
- `server.json` (Anthropic MCP Registry manifest)
- `src/shared/constants.ts` (User-Agent header)
- `app/Sources/AirMCPApp/UpdateManager.swift` (menubar update checker)
- `scripts/bundle-app.sh` (CFBundleShortVersionString)
- `docs/PRIVACY_POLICY.md` (version header)
- `.github/ISSUE_TEMPLATE/bug_report.yml` (placeholder)

## Test plan

- [x] `npm test` — 1303 passed
- [x] `npm run typecheck` — clean
- [x] `node scripts/sync-version.mjs --check` — clean
- [x] `node scripts/count-stats.mjs --check` — clean
- [x] `node scripts/check-i18n.mjs` — all locales have 191 keys
- [ ] Post-merge: confirm `auto-release.yml` fires → `cd.yml` tag + npm publish → GitHub Release draft appears