### PR TITLE
feat: outputSchema Wave 3 + Safari macOS 26 gate + Hono CVE fix + RFC 0005

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **outputSchema Wave 3** — 10 additional read tools now declare typed `outputSchema` with matching `structuredContent`: `list_chats`, `read_chat`, `search_chats`, `list_participants` (messages), `health_today_steps`, `health_heart_rate`, `health_sleep` (health), `list_shortcuts`, `search_shortcuts`, `get_shortcut_detail` (shortcuts). Brings outputSchema coverage of high-traffic read tools from ~30% to ~40%. Messages tools keep the `okUntrusted*` wrappers so external-content markers still guard against prompt injection, now layered with `structuredContent`. Health tools graduate from `okLinked` to `okLinkedStructured` so the primary text block, `_links`, and the typed payload all round-trip cleanly. `tests/output-schema-wave3.test.js` adds strict-parse drift guards for each new schema, and `output-schema-structured.test.js` picks up the 10 fixtures so the exhaustive coverage check stays green.
+- **RFC 0005 draft — OAuth 2.1 + Resource Indicators** — new RFC targeting v2.11.0 that lays out the migration from the legacy `AIRMCP_HTTP_TOKEN` Bearer path to the MCP 2025-06-18 OAuth 2.1 + RFC 8707 Resource Indicators flow. Covers `with-oauth` / `with-oauth+origin` network policies, `.well-known/oauth-protected-resource` discovery, scope design (`mcp:read`/`mcp:write`/`mcp:destructive`/`mcp:admin`), and a 5-step rollout that keeps the existing Bearer path working until v3.0.
+
+### Changed
+- **`safari.add_bookmark` gated on macOS 26+** — Safari removed bookmark scripting in macOS 26; the tool now skips registration on macOS 26+ instead of registering and returning an error at call time. Agents no longer see a "tool exists but always fails" entry in their plans on Tahoe hosts. Legacy hosts (macOS ≤ 25) keep the tool with the existing deprecation message. Test expectation updated from 12 → 11 registered Safari tools in the non-Darwin test env (`add_bookmark` gated off, other 11 always present).
+- **Prettier run across 9 drifted files** — `src/safari/scripts.ts`, `src/shared/esc.ts`, and the 7 skill built-in YAMLs (`daily-journal`, `favorites-digest`, `focus-block-planner`, `project-digest`, `sender-to-tasks`, `weekly-digest-note`, `weekly-review`). No behaviour change.
+
+### Security
+- **Hono / @hono/node-server overrides** — `package.json` `overrides` forces `hono@^4.12.13` + `@hono/node-server@^1.19.13` to address [CVE-2026-29045](https://advisories.gitlab.com/pkg/npm/hono/CVE-2026-29045/), [CVE-2026-39407](https://advisories.gitlab.com/pkg/npm/hono/CVE-2026-39407/), [CVE-2026-29087](https://advisories.gitlab.com/pkg/npm/@hono/node-server/CVE-2026-29087/), and [CVE-2026-39406](https://advisories.gitlab.com/pkg/npm/@hono/node-server/CVE-2026-39406/) (middleware bypass via repeated slashes + authorization bypass via encoded slashes in `serveStatic`). AirMCP does not use Hono directly — both are transitive via `@modelcontextprotocol/sdk` — but `npm audit --omit=dev` now reports 0 findings instead of 2 moderate.
+
 ## [2.10.0] - 2026-04-20
 
 ### Added

--- a/docs/rfc/0005-oauth-resource-indicators.md
+++ b/docs/rfc/0005-oauth-resource-indicators.md
@@ -1,0 +1,188 @@
+# RFC 0005 — OAuth 2.1 + Resource Indicators (MCP 2025-06-18 spec)
+
+- **Status**: Draft
+- **Author**: heznpc + Claude
+- **Created**: 2026-04-23
+- **Target**: v2.11.0
+- **Related**: RFC 0002 (HTTP allowNetwork policy), `src/server/http-transport.ts` (Bearer token path), [MCP 2025-06-18 authorization spec](https://modelcontextprotocol.io/specification/draft/basic/authorization), [RFC 8707 Resource Indicators](https://www.rfc-editor.org/rfc/rfc8707)
+
+---
+
+## 1. Motivation
+
+AirMCP의 HTTP 모드는 현재 **Bearer 토큰 단일 계층** 인증을 제공한다. `AIRMCP_HTTP_TOKEN`을 환경 변수로 설정하면 서버가 `Authorization: Bearer <token>`을 SHA-256 + `timingSafeEqual`로 검증한다 ([src/server/http-transport.ts:255-277](../../src/server/http-transport.ts:255)). 이는 v2.7.0부터 안정적으로 운영 중이고, RFC 0002에서 정책화(`with-token`, `with-token+origin`)까지 강화되어 있다.
+
+그러나 **2025-06-18 MCP 사양 개정**은 인증 축을 OAuth 2.1 + Resource Indicators (RFC 8707)로 옮겼다:
+
+1. **확장 가능성**: 단일 정적 토큰은 다중 사용자·다중 서버 환경에서 확장되지 않는다. 엔터프라이즈 배포에서는 사용자별 권한 분리·토큰 회수·수명 관리가 필수.
+2. **Confused Deputy 공격 방지**: 토큰이 여러 서버에 걸쳐 재사용될 경우, 한 서버가 다른 서버에 대한 요청을 대신 수행할 위험이 있다. Resource Indicators는 "이 토큰은 어느 MCP 서버용인지"를 명시해 이 공격을 차단한다.
+3. **Managed Agents·Cowork**: Claude의 Managed Agents 생태계가 Dynamic Client Registration(DCR)을 전제로 동작한다. AirMCP가 이 흐름에 합류하려면 OAuth 2.1 AS(Authorization Server) 또는 외부 AS 위임 모델이 필요.
+4. **브라우저 MCP 클라이언트** (Claude in Chrome 등): 쿠키 기반 인증이 아닌 토큰 기반 흐름이 요구되며, PKCE가 사실상 필수.
+
+### 현 상태의 실질적 한계
+- Bearer 토큰은 **기기 단위** 비밀로, 실수로 로그/Git·공유 터미널에 노출되면 회수 불가(수동 재발급 필요).
+- 토큰 **만료(TTL)** 가 없다. 한 번 발급되면 영구.
+- `.well-known/mcp.json`은 `authorization: { type: "bearer" }`만 선언 ([mcp-setup.ts 관련 로직](../../src/server/mcp-setup.ts)). OAuth flow 메타데이터 부재.
+
+---
+
+## 2. Goals
+
+1. MCP 2025-06-18 사양의 **OAuth 2.1 클라이언트·리소스 서버 역할**을 AirMCP가 수행 가능하게.
+2. **RFC 8707 Resource Indicators**를 받아들여 토큰 audience를 검증.
+3. 기존 Bearer 모드는 **하위 호환**으로 유지(레거시 `AIRMCP_HTTP_TOKEN` 구성은 v3.0까지 동작).
+4. `.well-known/oauth-protected-resource` 엔드포인트 추가로 **자동 탐색** 지원.
+5. 로컬·개인 사용자는 설정 복잡도가 늘지 않도록 디폴트는 기존과 동일(loopback + optional token).
+
+### Non-goals (이 RFC 범위 밖)
+
+- AirMCP 자체가 **AS 역할**을 할지 여부. 1단계는 외부 AS(Keycloak·Auth0·Hydra·Supabase 등) 위임만 목표.
+- 사용자 관리·그룹·RBAC. 이는 토큰의 scope·claim에 포함되어 들어오는 것으로 족하다.
+- iOS 위젯·Swift 앱의 쿠키 흐름.
+
+---
+
+## 3. Design
+
+### 3.1 네트워크 정책 enum 확장
+
+`src/server/allow-network-policy.ts`의 `NetworkPolicy` 유니온을 확장:
+
+```ts
+export type NetworkPolicy =
+  | "loopback-only"
+  | "with-token"                 // legacy Bearer (현행)
+  | "with-token+origin"
+  | "with-oauth"                 // NEW — OAuth 2.1 + RI
+  | "with-oauth+origin"          // NEW — OAuth + CORS allow-list
+  | "unauthenticated";
+```
+
+`with-oauth` 선택 시 시작 불변식(RFC 0002의 패턴 재사용):
+- `AIRMCP_OAUTH_ISSUER` 필수 (예: `https://auth.example.com/realms/airmcp`)
+- `AIRMCP_OAUTH_AUDIENCE` 필수 (= RFC 8707 target resource URI, 예: `https://airmcp.local/mcp`)
+- 빠진 값이 있으면 시작 거부 (`validateNetworkPolicy`).
+
+### 3.2 토큰 검증 파이프라인
+
+```
+Authorization: Bearer <JWT>
+    ↓
+verifyJWT(token, {
+  issuer: AIRMCP_OAUTH_ISSUER,   // iss 검증
+  audience: AIRMCP_OAUTH_AUDIENCE, // aud 검증 (RFC 8707)
+  algorithms: ["RS256", "ES256"],  // 대칭키 금지
+})
+    ↓
+claims = { sub, scope, exp, iat, resource?, ... }
+    ↓
+req.oauth = { subject, scopes, raw }
+    ↓
+미들웨어: destructive 도구 호출 시 scope 체크 (선택)
+```
+
+- JWKS는 `${issuer}/.well-known/jwks.json`에서 **프로세스 시작 시 1회 fetch + 캐시 + 10분 주기 백그라운드 갱신**. kid 회전 대응.
+- Resource Indicators 검증: `aud` claim이 `AIRMCP_OAUTH_AUDIENCE`를 **포함**하지 않으면 401. 토큰에 `resource` claim이 있다면 그 값도 audience와 매칭해야 통과(spec draft가 `aud`·`resource` 둘 다 언급하므로 둘 중 하나라도 매치되면 통과하도록 폴백).
+
+### 3.3 발견(discovery) 엔드포인트
+
+- `GET /.well-known/oauth-protected-resource` (RFC 9728):
+  ```json
+  {
+    "resource": "https://airmcp.local/mcp",
+    "authorization_servers": ["https://auth.example.com/realms/airmcp"],
+    "bearer_methods_supported": ["header"],
+    "resource_signing_alg_values_supported": ["RS256", "ES256"]
+  }
+  ```
+- `.well-known/mcp.json`의 `authorization` 필드 확장:
+  ```json
+  {
+    "authorization": {
+      "type": "oauth2",
+      "resource": "https://airmcp.local/mcp",
+      "authorization_servers": ["https://auth.example.com/realms/airmcp"],
+      "scopes_supported": ["mcp:read", "mcp:write", "mcp:destructive"]
+    }
+  }
+  ```
+
+### 3.4 scope 설계 (제안, v2.11 bake-in 대상 아님)
+
+| scope | 허용 도구 |
+|---|---|
+| `mcp:read` | `readOnlyHint: true`인 모든 도구 |
+| `mcp:write` | `readOnlyHint: false` + `destructiveHint: false` |
+| `mcp:destructive` | `destructiveHint: true` (기본 HITL 경로와 AND) |
+| `mcp:admin` | `audit_*`, `memory_forget`, `setup_permissions` 등 메타 |
+
+구현 1단계에서는 **scope 강제는 하지 않고 payload에 실어두기만**. 2단계에서 `tool-registry.ts`의 pre-handler gate에 scope 체크 삽입.
+
+### 3.5 하위 호환성
+
+- `AIRMCP_HTTP_TOKEN`이 설정된 상태에서 `AIRMCP_OAUTH_ISSUER`도 설정되면 **둘 다 받아들임** (토큰이 JWT 시그니처 파싱 성공하면 OAuth 경로, 실패하면 Bearer 경로). 이중 경로는 v3.0까지만 유지.
+- 모든 새 플래그·env var는 기본 off. 기존 deployments는 변경 없이 동작.
+
+---
+
+## 4. Risks / Open Questions
+
+### R1. JWKS fetch 실패 시 부팅
+- **위험**: 네트워크 단절·AS 장애 상태에서 서버 부팅 실패 → AirMCP는 로컬 도구 접근이 목적인데 외부 서비스 가용성에 종속.
+- **대응**: 부팅 시 JWKS를 **필수 fetch가 아니라 lazy**로 전환. 첫 요청 때 실패하면 503 반환하되, AS 복구 후 자동 재시도. `doctor`에 AS 헬스 체크 표출.
+
+### R2. 시계 동기화 (clock skew)
+- **위험**: `exp`/`nbf` 검증이 호스트 시계에 민감. Mac 시계가 조금만 흘러도 401 남발.
+- **대응**: `clockTolerance: 60` (60초) 허용. 이보다 넓히면 보안 희석 위험.
+
+### R3. 토큰 교환(Token Exchange) 표준 (RFC 8693) 통합 여부
+- Managed Agents는 AirMCP 토큰을 받아 downstream MCP 서버에 제시할 때 token exchange가 필요할 수 있다.
+- **1단계에서는 out of scope**. 2단계 RFC에서 재검토.
+
+### R4. 공격 표면 증가
+- JWT 파서·JWKS fetcher 도입은 이론적 공격 표면 증가. `jose` (DOS/시그니처 견고성 검증된 라이브러리) 사용 + `algorithms` allow-list로 `none` 알고리즘 취약점 회피.
+
+### R5. 로컬 개발자 UX
+- **위험**: 개발자가 OAuth AS를 로컬에 띄워야 하는 부담.
+- **대응**: `dev:oauth` 스크립트 하나로 Keycloak devcontainer 기동. 디폴트 realm·client·user 자동 생성. 문서에 **"로컬 개발은 `AIRMCP_HTTP_TOKEN` 유지 권장"** 명시.
+
+---
+
+## 5. Rollout
+
+| 단계 | 내용 | 버전 |
+|---|---|---|
+| 1 | `NetworkPolicy` enum 확장, `validateNetworkPolicy` 가드, `.well-known/oauth-protected-resource` 엔드포인트, `jose` 의존성, JWKS 캐시, 검증 미들웨어. **scope 강제 없음**. | v2.11.0 |
+| 2 | `tool-registry.ts` pre-handler에 scope 체크 삽입. `mcp:destructive` 없이 destructive 호출 시 403. | v2.12.0 |
+| 3 | 브라우저 MCP 클라이언트 대상 PKCE 플로우 가이드 문서 업데이트. | v2.12.0 |
+| 4 | `AIRMCP_HTTP_TOKEN` 경로 deprecation warning. | v2.13.0 |
+| 5 | `AIRMCP_HTTP_TOKEN` 제거. OAuth만 지원. | v3.0.0 |
+
+---
+
+## 6. KPIs / Acceptance Criteria
+
+- `doctor`의 HTTP policy 섹션이 OAuth 모드에서 `issuer`·`audience`·JWKS 최신 kid 요약을 출력.
+- `with-oauth` 모드에서 유효 JWT로 `list_tools` 호출 가능, 만료·잘못된 `aud`·잘못된 `iss` 토큰은 각각 401.
+- `with-token` (레거시) 경로 테스트 91개 전원 green 유지.
+- `npm audit --omit=dev` 0건 유지 (`jose` 포함).
+- E2E 테스트: Keycloak devcontainer 기동 → 클라이언트가 authorization code + PKCE로 토큰 획득 → AirMCP에 제시 → 툴 호출 성공 1종.
+
+---
+
+## 7. Alternatives Considered
+
+- **mTLS (client cert)**: 로컬 개발 UX가 최악. Managed Agents 생태계가 채택하지 않는 방향. 기각.
+- **HMAC 서명된 요청 (AWS SigV4 스타일)**: 토큰 만료·회수 측면은 해결하지만 MCP 생태계가 OAuth로 수렴. Single-sourcing 원칙. 기각.
+- **OAuth 2.0** (레거시): implicit flow·암묵적 토큰 만료 관례 등으로 보안 weak. 2025-06-18 spec이 **2.1 명시**. 기각.
+
+---
+
+## 8. References
+
+- [MCP 2025-06-18 Authorization Spec](https://modelcontextprotocol.io/specification/draft/basic/authorization)
+- [RFC 8707: Resource Indicators for OAuth 2.0](https://www.rfc-editor.org/rfc/rfc8707)
+- [RFC 9728: OAuth 2.0 Protected Resource Metadata](https://www.rfc-editor.org/rfc/rfc9728)
+- [OAuth 2.1 Draft](https://datatracker.ietf.org/doc/draft-ietf-oauth-v2-1/)
+- QUALITY_DIAGNOSIS_2026-04-17 HIGH-3 (공개 HTTP 배포 실수 경로)
+- RFC 0002 (HTTP `allowNetwork` 정책)

--- a/docs/rfc/README.md
+++ b/docs/rfc/README.md
@@ -87,6 +87,7 @@ Draft ──► Proposed ──► Accepted ──► Implemented
 | [0002](./0002-http-allow-network.md) | Declarative HTTP `allowNetwork` Mode | Draft | v2.8.0 → v2.9.0 |
 | [0003](./0003-ci-audit-stepwise.md) | CI npm audit 등급 단계적 상향 | Draft | v2.8.x |
 | [0004](./0004-macos-compat-matrix.md) | macOS 호환성 매트릭스 & 모듈 Manifest 확장 | Draft | v2.8.0 |
+| [0005](./0005-oauth-resource-indicators.md) | OAuth 2.1 + Resource Indicators (MCP 2025-06-18 spec) | Draft | v2.11.0 |
 
 ## 관련 문서
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1456,9 +1456,9 @@
       }
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.12",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.12.tgz",
-      "integrity": "sha512-txsUW4SQ1iilgE0l9/e9VQWmELXifEFvmdA1j6WFh/aFPj99hIntrSsq/if0UWyGVkmrRPKA1wCeP+UCr1B9Uw==",
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
       "license": "MIT",
       "engines": {
         "node": ">=18.14.1"
@@ -4913,9 +4913,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.10",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.10.tgz",
-      "integrity": "sha512-mx/p18PLy5og9ufies2GOSUqep98Td9q4i/EF6X7yJgAiIopxqdfIO3jbqsi3jRgTgw88jMDEzVKi+V2EF+27w==",
+      "version": "4.12.14",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.14.tgz",
+      "integrity": "sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"

--- a/package.json
+++ b/package.json
@@ -143,6 +143,10 @@
   "os": [
     "darwin"
   ],
+  "overrides": {
+    "hono": "^4.12.13",
+    "@hono/node-server": "^1.19.13"
+  },
   "lint-staged": {
     "src/**/*.ts": [
       "prettier --write",

--- a/src/health/tools.ts
+++ b/src/health/tools.ts
@@ -2,7 +2,7 @@ import { z } from "zod";
 import type { McpServer } from "../shared/mcp.js";
 import type { AirMcpConfig } from "../shared/config.js";
 import { runSwift, checkSwiftBridge } from "../shared/swift.js";
-import { ok, okLinked, okLinkedStructured, err, toolError } from "../shared/result.js";
+import { ok, okLinkedStructured, err, toolError } from "../shared/result.js";
 
 export function registerHealthTools(server: McpServer, _config: AirMcpConfig): void {
   server.registerTool(
@@ -45,6 +45,9 @@ export function registerHealthTools(server: McpServer, _config: AirMcpConfig): v
       title: "Today's Steps",
       description: "Get aggregated step count for today from HealthKit.",
       inputSchema: {},
+      outputSchema: {
+        stepsToday: z.number().describe("Step count today"),
+      },
       annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: false },
     },
     async () => {
@@ -52,7 +55,7 @@ export function registerHealthTools(server: McpServer, _config: AirMcpConfig): v
       if (bridgeErr) return err(`Swift bridge required: ${bridgeErr}`);
       try {
         const result = await runSwift<{ stepsToday: number }>("health-steps", "{}");
-        return okLinked("health_today_steps", result);
+        return okLinkedStructured("health_today_steps", result);
       } catch (e) {
         return toolError("get step count", e);
       }
@@ -65,6 +68,10 @@ export function registerHealthTools(server: McpServer, _config: AirMcpConfig): v
       title: "Recent Heart Rate",
       description: "Get average resting heart rate over the last 7 days (bpm) from HealthKit.",
       inputSchema: {},
+      outputSchema: {
+        heartRateAvg7d: z.number().nullable().describe("7-day average resting heart rate (bpm); null if unavailable"),
+        message: z.string().optional().describe("Explanation when heartRateAvg7d is null (e.g. insufficient data)"),
+      },
       annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: false },
     },
     async () => {
@@ -72,7 +79,7 @@ export function registerHealthTools(server: McpServer, _config: AirMcpConfig): v
       if (bridgeErr) return err(`Swift bridge required: ${bridgeErr}`);
       try {
         const result = await runSwift<{ heartRateAvg7d: number | null; message?: string }>("health-heart-rate", "{}");
-        return okLinked("health_heart_rate", result);
+        return okLinkedStructured("health_heart_rate", result);
       } catch (e) {
         return toolError("get heart rate", e);
       }
@@ -91,6 +98,9 @@ export function registerHealthTools(server: McpServer, _config: AirMcpConfig): v
           .optional()
           .describe("ISO 8601 date (e.g. '2026-03-22'). Defaults to today (last night's sleep)."),
       },
+      outputSchema: {
+        sleepHours: z.number().describe("Total sleep hours (actual sleep stages, not time in bed)"),
+      },
       annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: false },
     },
     async ({ date }: { date?: string }) => {
@@ -99,7 +109,7 @@ export function registerHealthTools(server: McpServer, _config: AirMcpConfig): v
       try {
         const input = date ? JSON.stringify({ date }) : "{}";
         const result = await runSwift<{ sleepHours: number }>("health-sleep", input);
-        return okLinked("health_sleep", result);
+        return okLinkedStructured("health_sleep", result);
       } catch (e) {
         return toolError("get sleep data", e);
       }

--- a/src/messages/tools.ts
+++ b/src/messages/tools.ts
@@ -2,7 +2,14 @@ import type { McpServer } from "../shared/mcp.js";
 import { z } from "zod";
 import { runJxa, runAppleScript } from "../shared/jxa.js";
 import type { AirMcpConfig } from "../shared/config.js";
-import { ok, okLinked, okUntrusted, err, toolError } from "../shared/result.js";
+import {
+  ok,
+  okLinkedStructured,
+  okUntrustedLinkedStructured,
+  okUntrustedStructured,
+  err,
+  toolError,
+} from "../shared/result.js";
 import { TIMEOUT } from "../shared/constants.js";
 import { zFilePath } from "../shared/validate.js";
 import {
@@ -14,6 +21,19 @@ import {
   listParticipantsScript,
 } from "./scripts.js";
 
+// Shared sub-schemas for messages outputs.
+const participantSchema = z.object({
+  name: z.string().nullable(),
+  handle: z.string().nullable(),
+});
+
+const chatSchema = z.object({
+  id: z.string(),
+  name: z.string().nullable(),
+  participants: z.array(participantSchema),
+  updated: z.string().nullable(),
+});
+
 export function registerMessagesTools(server: McpServer, config: AirMcpConfig): void {
   const { allowSendMessages } = config;
   server.registerTool(
@@ -24,11 +44,16 @@ export function registerMessagesTools(server: McpServer, config: AirMcpConfig): 
       inputSchema: {
         limit: z.number().int().min(1).max(200).optional().default(50).describe("Max chats to return (default: 50)"),
       },
+      outputSchema: {
+        total: z.number(),
+        returned: z.number(),
+        chats: z.array(chatSchema),
+      },
       annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: false },
     },
     async ({ limit }) => {
       try {
-        return okLinked("list_chats", await runJxa(listChatsScript(limit)));
+        return okLinkedStructured("list_chats", await runJxa(listChatsScript(limit)));
       } catch (e) {
         return toolError("list chats", e);
       }
@@ -43,11 +68,17 @@ export function registerMessagesTools(server: McpServer, config: AirMcpConfig): 
       inputSchema: {
         chatId: z.string().max(500).describe("Chat ID"),
       },
+      outputSchema: {
+        id: z.string(),
+        name: z.string().nullable(),
+        participants: z.array(participantSchema),
+        updated: z.string().nullable(),
+      },
       annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: false },
     },
     async ({ chatId }) => {
       try {
-        return okUntrusted(await runJxa(readChatScript(chatId)));
+        return okUntrustedLinkedStructured("read_chat", await runJxa(readChatScript(chatId)));
       } catch (e) {
         return toolError("read chat", e);
       }
@@ -63,11 +94,16 @@ export function registerMessagesTools(server: McpServer, config: AirMcpConfig): 
         query: z.string().max(500).describe("Search keyword (matches chat name, participant name, or handle)"),
         limit: z.number().int().min(1).max(100).optional().default(20).describe("Max results (default: 20)"),
       },
+      outputSchema: {
+        total: z.number(),
+        returned: z.number(),
+        chats: z.array(chatSchema),
+      },
       annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: false },
     },
     async ({ query, limit }) => {
       try {
-        return okUntrusted(await runJxa(searchMessagesScript(query, limit)));
+        return okUntrustedLinkedStructured("search_chats", await runJxa(searchMessagesScript(query, limit)));
       } catch (e) {
         return toolError("search chats", e);
       }
@@ -131,11 +167,16 @@ export function registerMessagesTools(server: McpServer, config: AirMcpConfig): 
       inputSchema: {
         chatId: z.string().max(500).describe("Chat ID"),
       },
+      outputSchema: {
+        chatId: z.string(),
+        chatName: z.string().nullable(),
+        participants: z.array(participantSchema),
+      },
       annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: false },
     },
     async ({ chatId }) => {
       try {
-        return okUntrusted(await runJxa(listParticipantsScript(chatId)));
+        return okUntrustedStructured(await runJxa(listParticipantsScript(chatId)));
       } catch (e) {
         return toolError("list participants", e);
       }

--- a/src/safari/scripts.ts
+++ b/src/safari/scripts.ts
@@ -99,7 +99,15 @@ export function activateTabScript(windowIndex: number, tabIndex: number): string
 }
 
 /** URL schemes where JavaScript execution is blocked for security. */
-const BLOCKED_URL_SCHEMES = ["file:", "about:", "safari-extension:", "safari-web-extension:", "blob:", "javascript:", "data:"];
+const BLOCKED_URL_SCHEMES = [
+  "file:",
+  "about:",
+  "safari-extension:",
+  "safari-web-extension:",
+  "blob:",
+  "javascript:",
+  "data:",
+];
 const BLOCKED_URL_SCHEMES_JSON = JSON.stringify(BLOCKED_URL_SCHEMES);
 
 export function runJavascriptScript(code: string, windowIndex: number, tabIndex: number): string {

--- a/src/safari/tools.ts
+++ b/src/safari/tools.ts
@@ -1,7 +1,7 @@
 import type { McpServer } from "../shared/mcp.js";
 import { z } from "zod";
 import { runJxa } from "../shared/jxa.js";
-import type { AirMcpConfig } from "../shared/config.js";
+import { getOsVersion, type AirMcpConfig } from "../shared/config.js";
 import {
   ok,
   okUntrusted,
@@ -266,26 +266,34 @@ export function registerSafariTools(server: McpServer, config: AirMcpConfig): vo
     },
   );
 
-  server.registerTool(
-    "add_bookmark",
-    {
-      title: "Add Bookmark (Deprecated)",
-      description:
-        "DEPRECATED: Safari removed bookmark scripting in macOS 26. This tool will return an error. " +
-        "Use add_to_reading_list instead, which still works.",
-      inputSchema: {
-        url: z.string().url().describe("URL to bookmark"),
-        title: z.string().max(500).describe("Bookmark title"),
+  // Safari removed bookmark scripting in macOS 26 (RFC 0004 tool-level gate):
+  // skip registration entirely so agents don't select a tool that cannot work.
+  // Legacy hosts (macOS ≤ 25) keep the tool, but it already returns err() because
+  // the underlying `make new bookmark` call is broken there too in many configs —
+  // the deprecation message steers callers toward add_to_reading_list.
+  const os = getOsVersion();
+  if (os > 0 && os < 26) {
+    server.registerTool(
+      "add_bookmark",
+      {
+        title: "Add Bookmark (Deprecated)",
+        description:
+          "DEPRECATED: Safari removed bookmark scripting in macOS 26. This tool returns an error on unsupported hosts. " +
+          "Use add_to_reading_list instead, which still works.",
+        inputSchema: {
+          url: z.string().url().describe("URL to bookmark"),
+          title: z.string().max(500).describe("Bookmark title"),
+        },
+        annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: false },
       },
-      annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: false },
-    },
-    async () => {
-      return err(
-        "add_bookmark is deprecated — Safari removed bookmark scripting in macOS 26. " +
-          "Use add_to_reading_list instead.",
-      );
-    },
-  );
+      async () => {
+        return err(
+          "add_bookmark is deprecated — Safari removed bookmark scripting in macOS 26. " +
+            "Use add_to_reading_list instead.",
+        );
+      },
+    );
+  }
 
   server.registerTool(
     "list_reading_list",

--- a/src/shared/esc.ts
+++ b/src/shared/esc.ts
@@ -3,34 +3,30 @@ const RE_CTRL = /[\x01-\x08\x0b\x0c\x0e-\x1f]/g;
 
 /** Escape a string for safe interpolation inside JXA single-quoted literals. */
 export function esc(str: string): string {
-  return (
-    str
-      .replace(/\0/g, "")
-      .replace(/\\/g, "\\\\")
-      .replace(/'/g, "\\'")
-      .replace(/\n/g, "\\n")
-      .replace(/\r/g, "\\r")
-      .replace(/\t/g, "\\t")
-      .replace(RE_CTRL, "")
-      .replace(/\u2028/g, "\\u2028")
-      .replace(/\u2029/g, "\\u2029")
-  );
+  return str
+    .replace(/\0/g, "")
+    .replace(/\\/g, "\\\\")
+    .replace(/'/g, "\\'")
+    .replace(/\n/g, "\\n")
+    .replace(/\r/g, "\\r")
+    .replace(/\t/g, "\\t")
+    .replace(RE_CTRL, "")
+    .replace(/\u2028/g, "\\u2028")
+    .replace(/\u2029/g, "\\u2029");
 }
 
 /** Escape a string for safe interpolation inside AppleScript double-quoted strings. */
 export function escAS(str: string): string {
-  return (
-    str
-      .replace(/\0/g, "")
-      .replace(RE_CTRL, "")
-      .replace(/\\/g, "\\\\")
-      .replace(/"/g, '\\"')
-      .replace(/\n/g, "\\n")
-      .replace(/\r/g, "\\r")
-      .replace(/\t/g, "\\t")
-      .replace(/\u2028/g, "\\u2028")
-      .replace(/\u2029/g, "\\u2029")
-  );
+  return str
+    .replace(/\0/g, "")
+    .replace(RE_CTRL, "")
+    .replace(/\\/g, "\\\\")
+    .replace(/"/g, '\\"')
+    .replace(/\n/g, "\\n")
+    .replace(/\r/g, "\\r")
+    .replace(/\t/g, "\\t")
+    .replace(/\u2028/g, "\\u2028")
+    .replace(/\u2029/g, "\\u2029");
 }
 
 /** Escape a string for safe interpolation inside shell double-quoted arguments via doShellScript. */

--- a/src/shortcuts/tools.ts
+++ b/src/shortcuts/tools.ts
@@ -4,7 +4,7 @@ import { execFile } from "node:child_process";
 import { promisify } from "node:util";
 import { runJxa } from "../shared/jxa.js";
 import type { AirMcpConfig } from "../shared/config.js";
-import { ok, okLinked, toolError } from "../shared/result.js";
+import { ok, okLinked, okLinkedStructured, okStructured, toolError } from "../shared/result.js";
 import { TIMEOUT } from "../shared/constants.js";
 import { zFilePath } from "../shared/validate.js";
 import {
@@ -44,11 +44,15 @@ export function registerShortcutsTools(server: McpServer, _config: AirMcpConfig)
       title: "List Shortcuts",
       description: "List all available Siri Shortcuts on this Mac.",
       inputSchema: {},
+      outputSchema: {
+        total: z.number(),
+        shortcuts: z.array(z.string()),
+      },
       annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: false },
     },
     async () => {
       try {
-        return okLinked("list_shortcuts", await runJxa(listShortcutsScript()));
+        return okLinkedStructured("list_shortcuts", await runJxa(listShortcutsScript()));
       } catch (e) {
         return toolError("list shortcuts", e);
       }
@@ -84,11 +88,15 @@ export function registerShortcutsTools(server: McpServer, _config: AirMcpConfig)
       inputSchema: {
         query: z.string().max(500).describe("Search keyword to match against shortcut names"),
       },
+      outputSchema: {
+        total: z.number(),
+        shortcuts: z.array(z.string()),
+      },
       annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: false },
     },
     async ({ query }) => {
       try {
-        return ok(await runJxa(searchShortcutsScript(query)));
+        return okStructured(await runJxa(searchShortcutsScript(query)));
       } catch (e) {
         return toolError("search shortcuts", e);
       }
@@ -103,11 +111,15 @@ export function registerShortcutsTools(server: McpServer, _config: AirMcpConfig)
       inputSchema: {
         name: z.string().max(500).describe("Shortcut name (exact match)"),
       },
+      outputSchema: {
+        shortcut: z.string(),
+        detail: z.string(),
+      },
       annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: false },
     },
     async ({ name }) => {
       try {
-        return ok(await runJxa(getShortcutDetailScript(name)));
+        return okStructured(await runJxa(getShortcutDetailScript(name)));
       } catch (e) {
         return toolError("get shortcut detail", e);
       }

--- a/src/skills/builtins/daily-journal.yaml
+++ b/src/skills/builtins/daily-journal.yaml
@@ -8,7 +8,6 @@ description: >-
   later recall "what did I do last Tuesday?" via `memory_query`.
   DESTRUCTIVE: writes a memory entry (non-destructive to Apple apps).
 expose_as: tool
-
 inputs:
   note:
     type: string

--- a/src/skills/builtins/favorites-digest.yaml
+++ b/src/skills/builtins/favorites-digest.yaml
@@ -7,7 +7,6 @@ description: >-
   The loop iterates inside `favorites` with `on_error: continue` so a
   single unreadable asset doesn't truncate the digest.
 expose_as: prompt
-
 steps:
   # 1) Read the user's Favorites album. Keeping `limit: 10` small so the
   #    downstream note stays readable.

--- a/src/skills/builtins/focus-block-planner.yaml
+++ b/src/skills/builtins/focus-block-planner.yaml
@@ -8,7 +8,6 @@ description: >-
   blocked and which didn't. DESTRUCTIVE: creates calendar events; each
   insertion is gated by HITL approval.
 expose_as: tool
-
 steps:
   # 1) Pull the open-reminder backlog. `limit: 8` keeps the loop small
   #    enough that HITL prompting stays tolerable.

--- a/src/skills/builtins/project-digest.yaml
+++ b/src/skills/builtins/project-digest.yaml
@@ -6,7 +6,6 @@ description: >-
   cross-app "everything about this project" view. Demonstrates the
   Skills DSL's loop construct and conditional execution.
 expose_as: tool
-
 steps:
   # 1) Seed search: semantic_search returns { query, results[], total, ... }.
   #    Threshold is permissive so the loop has something to work with even

--- a/src/skills/builtins/sender-to-tasks.yaml
+++ b/src/skills/builtins/sender-to-tasks.yaml
@@ -9,7 +9,6 @@ description: >-
   denial, Reminders permission, etc.). DESTRUCTIVE: creates reminders;
   each insertion is gated by HITL approval.
 expose_as: tool
-
 inputs:
   query:
     type: string

--- a/src/skills/builtins/weekly-digest-note.yaml
+++ b/src/skills/builtins/weekly-digest-note.yaml
@@ -8,7 +8,6 @@ description: >-
   written even if summarisation fails for one or two tracks (e.g.
   Foundation Models unavailable on an Intel Mac).
 expose_as: prompt
-
 steps:
   # 1) Fan out four independent reads. All parallel, individual failures
   #    are tolerated so a missing Swift bridge or app-not-running error

--- a/src/skills/builtins/weekly-review.yaml
+++ b/src/skills/builtins/weekly-review.yaml
@@ -6,7 +6,6 @@ description: >-
   gathered in parallel, with a conditional deep-dive when reminders are
   backlogged. Shows off the Skills DSL's parallel + conditional features.
 expose_as: prompt
-
 steps:
   # Fan-out: 5 independent read-only tools run concurrently. Failures are
   # isolated per step — the slow or unavailable ones don't block the rest.

--- a/tests/health-tools.test.js
+++ b/tests/health-tools.test.js
@@ -146,13 +146,17 @@ describe('health_today_steps', () => {
     mockCheckSwiftBridge.mockReset();
   });
 
-  test('returns step count with _links', async () => {
+  test('returns step count with structuredContent (and _links as separate block)', async () => {
     mockCheckSwiftBridge.mockResolvedValue(null);
     mockRunSwift.mockResolvedValue({ stepsToday: 12000 });
 
     const result = await server.callTool('health_today_steps');
+    // Primary text block is the typed payload; _links are a separate content block
+    // appended by okLinkedStructured so outputSchema stays strict.
     const parsed = JSON.parse(result.content[0].text);
     expect(parsed.stepsToday).toBe(12000);
-    expect(parsed._links).toBeDefined();
+    expect(result.structuredContent).toEqual({ stepsToday: 12000 });
+    // _links, if any, are in an additional text content block — not a required
+    // field of the primary payload.
   });
 });

--- a/tests/helpers/mock-runtime.js
+++ b/tests/helpers/mock-runtime.js
@@ -13,8 +13,10 @@ import { jest } from '@jest/globals';
 
 export function setupPlatformMocks() {
   const mockRunJxa = jest.fn();
+  const mockRunAppleScript = jest.fn();
   jest.unstable_mockModule('../../dist/shared/jxa.js', () => ({
     runJxa: mockRunJxa,
+    runAppleScript: mockRunAppleScript,
     osascriptSemaphore: { acquire: jest.fn().mockResolvedValue(undefined), release: jest.fn() },
   }));
 
@@ -36,6 +38,7 @@ export function setupPlatformMocks() {
 
   return {
     mockRunJxa,
+    mockRunAppleScript,
     mockRunSwift,
     mockCheckSwiftBridge,
     mockHasSwiftCommand,

--- a/tests/output-schema-structured.test.js
+++ b/tests/output-schema-structured.test.js
@@ -33,6 +33,8 @@ const { registerSafariTools } = await import('../dist/safari/tools.js');
 const { registerFinderTools } = await import('../dist/finder/tools.js');
 const { registerMusicTools } = await import('../dist/music/tools.js');
 const { registerHealthTools } = await import('../dist/health/tools.js');
+const { registerMessagesTools } = await import('../dist/messages/tools.js');
+const { registerShortcutsTools } = await import('../dist/shortcuts/tools.js');
 const { registerWeatherTools } = await import('../dist/weather/tools.js');
 const { fetchCurrentWeather } = await import('../dist/weather/api.js');
 
@@ -247,6 +249,50 @@ const TOOL_FIXTURES = {
     args: { playlist: 'Liked', limit: 100 },
     mock: { total: 0, returned: 0, tracks: [] },
   },
+  // ── Wave 3 additions ──
+  // messages
+  list_chats: {
+    args: { limit: 10 },
+    mock: { total: 0, returned: 0, chats: [] },
+  },
+  read_chat: {
+    args: { chatId: 'c1' },
+    mock: { id: 'c1', name: null, participants: [], updated: null },
+  },
+  search_chats: {
+    args: { query: 'test', limit: 10 },
+    mock: { total: 0, returned: 0, chats: [] },
+  },
+  list_participants: {
+    args: { chatId: 'c1' },
+    mock: { chatId: 'c1', chatName: null, participants: [] },
+  },
+  // health
+  health_today_steps: {
+    args: {},
+    mock: { stepsToday: 0 },
+  },
+  health_heart_rate: {
+    args: {},
+    mock: { heartRateAvg7d: null },
+  },
+  health_sleep: {
+    args: {},
+    mock: { sleepHours: 0 },
+  },
+  // shortcuts
+  list_shortcuts: {
+    args: {},
+    mock: { total: 0, shortcuts: [] },
+  },
+  search_shortcuts: {
+    args: { query: 'test' },
+    mock: { total: 0, shortcuts: [] },
+  },
+  get_shortcut_detail: {
+    args: { name: 'Daily' },
+    mock: { shortcut: 'Daily', detail: '' },
+  },
 };
 
 // ── Test suite ──────────────────────────────────────────────────────
@@ -267,6 +313,8 @@ describe('outputSchema → structuredContent contract', () => {
     registerFinderTools(server, config);
     registerMusicTools(server, config);
     registerHealthTools(server, config);
+    registerMessagesTools(server, config);
+    registerShortcutsTools(server, config);
     registerWeatherTools(server, config);
   });
 

--- a/tests/output-schema-wave3.test.js
+++ b/tests/output-schema-wave3.test.js
@@ -1,0 +1,212 @@
+/**
+ * outputSchema Wave 3 — drift guard for messages / health / shortcuts.
+ *
+ * Extends the Wave 1/2 contract to modules that were 0% before:
+ *   messages:  list_chats, read_chat, search_chats, list_participants
+ *   health:    health_today_steps, health_heart_rate, health_sleep
+ *   shortcuts: list_shortcuts, search_shortcuts, get_shortcut_detail
+ *
+ * When one of these fails, the fix is almost always in the handler's
+ * outputSchema declaration — the payload mirrors the real runtime JSON shape.
+ */
+import { describe, test, expect, beforeEach } from '@jest/globals';
+import { z } from 'zod';
+import { setupPlatformMocks } from './helpers/mock-runtime.js';
+import { createMockServer } from './helpers/mock-server.js';
+import { createMockConfig } from './helpers/mock-config.js';
+
+const { mockRunJxa, mockRunSwift, mockCheckSwiftBridge } = setupPlatformMocks();
+const { registerMessagesTools } = await import('../dist/messages/tools.js');
+const { registerHealthTools } = await import('../dist/health/tools.js');
+const { registerShortcutsTools } = await import('../dist/shortcuts/tools.js');
+
+function schemaFor(server, toolName) {
+  const tool = server._tools.get(toolName);
+  expect(tool).toBeDefined();
+  expect(tool.opts.outputSchema).toBeDefined();
+  return z.object(tool.opts.outputSchema).strict();
+}
+
+function assertConforms(server, toolName, structured) {
+  const schema = schemaFor(server, toolName);
+  const parsed = schema.safeParse(structured);
+  if (!parsed.success) {
+    throw new Error(`${toolName} drift: ${JSON.stringify(parsed.error.issues, null, 2)}`);
+  }
+}
+
+function resetAll() {
+  mockRunJxa.mockReset();
+  if (mockRunSwift) mockRunSwift.mockReset();
+  if (mockCheckSwiftBridge) {
+    mockCheckSwiftBridge.mockReset();
+    mockCheckSwiftBridge.mockResolvedValue(null); // Swift bridge available for health tests
+  }
+}
+
+// ── messages ──────────────────────────────────────────────────────────
+
+describe('Wave 3 — messages.list_chats', () => {
+  beforeEach(resetAll);
+  test('structuredContent matches outputSchema', async () => {
+    const server = createMockServer();
+    registerMessagesTools(server, createMockConfig());
+    mockRunJxa.mockResolvedValue({
+      total: 2,
+      returned: 2,
+      chats: [
+        {
+          id: 'chat-1',
+          name: 'Alice',
+          participants: [{ name: 'Alice', handle: 'alice@example.com' }],
+          updated: '2026-04-20T10:00:00Z',
+        },
+        {
+          id: 'chat-2',
+          name: null,
+          participants: [{ name: null, handle: '+821012345678' }],
+          updated: null,
+        },
+      ],
+    });
+    const result = await server.callTool('list_chats', {});
+    assertConforms(server, 'list_chats', result.structuredContent);
+  });
+});
+
+describe('Wave 3 — messages.read_chat', () => {
+  beforeEach(resetAll);
+  test('structuredContent matches outputSchema', async () => {
+    const server = createMockServer();
+    registerMessagesTools(server, createMockConfig());
+    mockRunJxa.mockResolvedValue({
+      id: 'chat-1',
+      name: 'Alice',
+      participants: [{ name: 'Alice', handle: 'alice@example.com' }],
+      updated: '2026-04-20T10:00:00Z',
+    });
+    const result = await server.callTool('read_chat', { chatId: 'chat-1' });
+    assertConforms(server, 'read_chat', result.structuredContent);
+  });
+});
+
+describe('Wave 3 — messages.search_chats', () => {
+  beforeEach(resetAll);
+  test('structuredContent matches outputSchema', async () => {
+    const server = createMockServer();
+    registerMessagesTools(server, createMockConfig());
+    mockRunJxa.mockResolvedValue({
+      total: 5,
+      returned: 1,
+      chats: [
+        {
+          id: 'chat-3',
+          name: 'Team',
+          participants: [
+            { name: 'Bob', handle: 'bob@example.com' },
+            { name: null, handle: null },
+          ],
+          updated: '2026-04-20T10:00:00Z',
+        },
+      ],
+    });
+    const result = await server.callTool('search_chats', { query: 'team' });
+    assertConforms(server, 'search_chats', result.structuredContent);
+  });
+});
+
+describe('Wave 3 — messages.list_participants', () => {
+  beforeEach(resetAll);
+  test('structuredContent matches outputSchema', async () => {
+    const server = createMockServer();
+    registerMessagesTools(server, createMockConfig());
+    mockRunJxa.mockResolvedValue({
+      chatId: 'chat-1',
+      chatName: 'Alice',
+      participants: [
+        { name: 'Alice', handle: 'alice@example.com' },
+        { name: null, handle: null },
+      ],
+    });
+    const result = await server.callTool('list_participants', { chatId: 'chat-1' });
+    assertConforms(server, 'list_participants', result.structuredContent);
+  });
+});
+
+// ── health ────────────────────────────────────────────────────────────
+
+describe('Wave 3 — health.health_today_steps', () => {
+  beforeEach(resetAll);
+  test('structuredContent matches outputSchema', async () => {
+    const server = createMockServer();
+    registerHealthTools(server, createMockConfig());
+    mockRunSwift.mockResolvedValue({ stepsToday: 8432 });
+    const result = await server.callTool('health_today_steps', {});
+    assertConforms(server, 'health_today_steps', result.structuredContent);
+  });
+});
+
+describe('Wave 3 — health.health_heart_rate', () => {
+  beforeEach(resetAll);
+  test('structuredContent matches outputSchema (null case)', async () => {
+    const server = createMockServer();
+    registerHealthTools(server, createMockConfig());
+    mockRunSwift.mockResolvedValue({ heartRateAvg7d: null, message: 'insufficient data' });
+    const result = await server.callTool('health_heart_rate', {});
+    assertConforms(server, 'health_heart_rate', result.structuredContent);
+  });
+
+  test('structuredContent matches outputSchema (value case)', async () => {
+    const server = createMockServer();
+    registerHealthTools(server, createMockConfig());
+    mockRunSwift.mockResolvedValue({ heartRateAvg7d: 62.3 });
+    const result = await server.callTool('health_heart_rate', {});
+    assertConforms(server, 'health_heart_rate', result.structuredContent);
+  });
+});
+
+describe('Wave 3 — health.health_sleep', () => {
+  beforeEach(resetAll);
+  test('structuredContent matches outputSchema', async () => {
+    const server = createMockServer();
+    registerHealthTools(server, createMockConfig());
+    mockRunSwift.mockResolvedValue({ sleepHours: 7.25 });
+    const result = await server.callTool('health_sleep', {});
+    assertConforms(server, 'health_sleep', result.structuredContent);
+  });
+});
+
+// ── shortcuts ─────────────────────────────────────────────────────────
+
+describe('Wave 3 — shortcuts.list_shortcuts', () => {
+  beforeEach(resetAll);
+  test('structuredContent matches outputSchema', async () => {
+    const server = createMockServer();
+    registerShortcutsTools(server, createMockConfig());
+    mockRunJxa.mockResolvedValue({ total: 3, shortcuts: ['A', 'B', 'C'] });
+    const result = await server.callTool('list_shortcuts', {});
+    assertConforms(server, 'list_shortcuts', result.structuredContent);
+  });
+});
+
+describe('Wave 3 — shortcuts.search_shortcuts', () => {
+  beforeEach(resetAll);
+  test('structuredContent matches outputSchema', async () => {
+    const server = createMockServer();
+    registerShortcutsTools(server, createMockConfig());
+    mockRunJxa.mockResolvedValue({ total: 1, shortcuts: ['Daily Brief'] });
+    const result = await server.callTool('search_shortcuts', { query: 'daily' });
+    assertConforms(server, 'search_shortcuts', result.structuredContent);
+  });
+});
+
+describe('Wave 3 — shortcuts.get_shortcut_detail', () => {
+  beforeEach(resetAll);
+  test('structuredContent matches outputSchema', async () => {
+    const server = createMockServer();
+    registerShortcutsTools(server, createMockConfig());
+    mockRunJxa.mockResolvedValue({ shortcut: 'Daily Brief', detail: 'actions: Get URL, Text' });
+    const result = await server.callTool('get_shortcut_detail', { name: 'Daily Brief' });
+    assertConforms(server, 'get_shortcut_detail', result.structuredContent);
+  });
+});

--- a/tests/safari-tools.test.js
+++ b/tests/safari-tools.test.js
@@ -32,11 +32,14 @@ describe('Safari tools registration', () => {
   });
 
   test('registers safari tools (add_bookmark gated on macOS < 26)', () => {
-    // add_bookmark is only registered on macOS ≤ 25 — the test runner is
-    // non-Darwin (getOsVersion() = 0), so it is skipped. On older hosts the
-    // size would be 12. The 11 non-gated tools below must always register.
-    expect(server.tools.size).toBe(11);
-    const expected = [
+    // add_bookmark is only registered on macOS ≤ 25.
+    // - non-Darwin (getOsVersion() = 0): skipped → 11 tools
+    // - Darwin macOS ≤ 25: registered → 12 tools
+    // - Darwin macOS ≥ 26: skipped → 11 tools
+    // We assert the invariant that always holds: 11 non-gated tools are
+    // always registered, and `add_bookmark`'s presence matches the host's
+    // macOS version.
+    const alwaysRegistered = [
       'list_tabs',
       'read_page_content',
       'get_current_tab',
@@ -49,10 +52,13 @@ describe('Safari tools registration', () => {
       'list_reading_list',
       'add_to_reading_list',
     ];
-    for (const name of expected) {
+    for (const name of alwaysRegistered) {
       expect(server.tools.has(name)).toBe(true);
     }
-    expect(server.tools.has('add_bookmark')).toBe(false);
+    expect([11, 12]).toContain(server.tools.size);
+    // `add_bookmark` registration mirrors the OS gate in src/safari/tools.ts.
+    const hasAddBookmark = server.tools.has('add_bookmark');
+    expect(server.tools.size).toBe(alwaysRegistered.length + (hasAddBookmark ? 1 : 0));
   });
 
   test('all tools have titles and descriptions', () => {

--- a/tests/safari-tools.test.js
+++ b/tests/safari-tools.test.js
@@ -31,8 +31,11 @@ describe('Safari tools registration', () => {
     registerSafariTools(server, {});
   });
 
-  test('registers all 12 safari tools', () => {
-    expect(server.tools.size).toBe(12);
+  test('registers safari tools (add_bookmark gated on macOS < 26)', () => {
+    // add_bookmark is only registered on macOS ≤ 25 — the test runner is
+    // non-Darwin (getOsVersion() = 0), so it is skipped. On older hosts the
+    // size would be 12. The 11 non-gated tools below must always register.
+    expect(server.tools.size).toBe(11);
     const expected = [
       'list_tabs',
       'read_page_content',
@@ -43,13 +46,13 @@ describe('Safari tools registration', () => {
       'run_javascript',
       'search_tabs',
       'list_bookmarks',
-      'add_bookmark',
       'list_reading_list',
       'add_to_reading_list',
     ];
     for (const name of expected) {
       expect(server.tools.has(name)).toBe(true);
     }
+    expect(server.tools.has('add_bookmark')).toBe(false);
   });
 
   test('all tools have titles and descriptions', () => {


### PR DESCRIPTION
## Summary

- **outputSchema Wave 3**: 10 read tools across messages/health/shortcuts now declare typed `outputSchema` + matching `structuredContent`. Coverage of high-traffic read tools ~30% → ~40%. Includes `tests/output-schema-wave3.test.js` (+11 strict-parse drift guards).
- **Safari `add_bookmark` macOS 26+ gate**: tool skips registration on Tahoe instead of registering a "tool exists but always fails" entry. Legacy hosts (macOS ≤ 25) keep the deprecated tool with the existing error message.
- **Hono / @hono/node-server CVE fix**: `package.json` `overrides` force `hono@^4.12.13` + `@hono/node-server@^1.19.13` to close CVE-2026-29045/39407/29087/39406 (serveStatic middleware bypass). `npm audit --omit=dev` now reports 0 findings (was 2 moderate).
- **RFC 0005 draft**: OAuth 2.1 + Resource Indicators targeting v2.11.0 — MCP 2025-06-18 spec response. 5-step rollout keeps the existing Bearer path alive through v3.0.
- **Prettier run** across 9 drifted files.

## Rationale

Addresses the risk + high-value + research axes flagged in `QUALITY_DIAGNOSIS_2026-04-17.md`:

- **HIGH-1 (outputSchema coverage)** — Wave 3 lands 10 more tools. Coverage: 50 → 60 tools.
- **HIGH-4 (macOS 26 blast radius)** — Safari `add_bookmark` no longer pollutes agent plans on Tahoe.
- **MEDIUM-3 (Hono transitive CVE)** — resolved via `overrides`, no direct-dep change.
- **Research** — RFC 0005 positions AirMCP for MCP 2025-06-18 auth conformance.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean
- [x] `npm run format:check` — clean
- [x] `npm test` — 91 suites, 1324 tests pass (+11 new)
- [x] `npm audit --omit=dev` — 0 findings
- [x] `node scripts/count-stats.mjs --check` — green
- [ ] CI end-to-end (ci.yml, 13 gates)