### PR TITLE
refactor: simplify PR #95 — zod SSOT, shared shapes, terser tests

### DIFF
--- a/src/health/tools.ts
+++ b/src/health/tools.ts
@@ -4,6 +4,32 @@ import type { AirMcpConfig } from "../shared/config.js";
 import { runSwift, checkSwiftBridge } from "../shared/swift.js";
 import { ok, okLinkedStructured, err, toolError } from "../shared/result.js";
 
+// Single source of truth for each Swift bridge payload. The zod shape drives
+// outputSchema validation; z.infer derives the TypeScript type that runSwift
+// returns, so adding a field to HealthKit only touches one definition.
+const healthSummaryShape = {
+  stepsToday: z.number().describe("Step count today"),
+  heartRateAvg7d: z.number().nullable().describe("7-day average resting heart rate (bpm)"),
+  sleepHoursLastNight: z.number().describe("Hours slept last night"),
+  activeEnergyToday: z.number().describe("Active calories burned today"),
+  exerciseMinutesToday: z.number().describe("Exercise minutes today"),
+};
+const healthStepsShape = {
+  stepsToday: z.number().describe("Step count today"),
+};
+const healthHeartRateShape = {
+  heartRateAvg7d: z.number().nullable().describe("7-day average resting heart rate (bpm); null if unavailable"),
+  message: z.string().optional().describe("Explanation when heartRateAvg7d is null (e.g. insufficient data)"),
+};
+const healthSleepShape = {
+  sleepHours: z.number().describe("Total sleep hours (actual sleep stages, not time in bed)"),
+};
+
+type HealthSummary = z.infer<ReturnType<typeof z.object<typeof healthSummaryShape>>>;
+type HealthSteps = z.infer<ReturnType<typeof z.object<typeof healthStepsShape>>>;
+type HealthHeartRate = z.infer<ReturnType<typeof z.object<typeof healthHeartRateShape>>>;
+type HealthSleep = z.infer<ReturnType<typeof z.object<typeof healthSleepShape>>>;
+
 export function registerHealthTools(server: McpServer, _config: AirMcpConfig): void {
   server.registerTool(
     "health_summary",
@@ -12,26 +38,14 @@ export function registerHealthTools(server: McpServer, _config: AirMcpConfig): v
       description:
         "Get a combined health dashboard: today's steps, 7-day average heart rate, last night's sleep, active energy burned, and exercise minutes. All data is aggregated — no raw samples or timestamps.",
       inputSchema: {},
-      outputSchema: {
-        stepsToday: z.number().describe("Step count today"),
-        heartRateAvg7d: z.number().nullable().describe("7-day average resting heart rate (bpm)"),
-        sleepHoursLastNight: z.number().describe("Hours slept last night"),
-        activeEnergyToday: z.number().describe("Active calories burned today"),
-        exerciseMinutesToday: z.number().describe("Exercise minutes today"),
-      },
+      outputSchema: healthSummaryShape,
       annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: false },
     },
     async () => {
       const bridgeErr = await checkSwiftBridge();
       if (bridgeErr) return err(`Swift bridge required: ${bridgeErr}`);
       try {
-        const result = await runSwift<{
-          stepsToday: number;
-          heartRateAvg7d: number | null;
-          sleepHoursLastNight: number;
-          activeEnergyToday: number;
-          exerciseMinutesToday: number;
-        }>("health-summary", "{}");
+        const result = await runSwift<HealthSummary>("health-summary", "{}");
         return okLinkedStructured("health_summary", result);
       } catch (e) {
         return toolError("get health summary", e);
@@ -45,16 +59,14 @@ export function registerHealthTools(server: McpServer, _config: AirMcpConfig): v
       title: "Today's Steps",
       description: "Get aggregated step count for today from HealthKit.",
       inputSchema: {},
-      outputSchema: {
-        stepsToday: z.number().describe("Step count today"),
-      },
+      outputSchema: healthStepsShape,
       annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: false },
     },
     async () => {
       const bridgeErr = await checkSwiftBridge();
       if (bridgeErr) return err(`Swift bridge required: ${bridgeErr}`);
       try {
-        const result = await runSwift<{ stepsToday: number }>("health-steps", "{}");
+        const result = await runSwift<HealthSteps>("health-steps", "{}");
         return okLinkedStructured("health_today_steps", result);
       } catch (e) {
         return toolError("get step count", e);
@@ -68,17 +80,14 @@ export function registerHealthTools(server: McpServer, _config: AirMcpConfig): v
       title: "Recent Heart Rate",
       description: "Get average resting heart rate over the last 7 days (bpm) from HealthKit.",
       inputSchema: {},
-      outputSchema: {
-        heartRateAvg7d: z.number().nullable().describe("7-day average resting heart rate (bpm); null if unavailable"),
-        message: z.string().optional().describe("Explanation when heartRateAvg7d is null (e.g. insufficient data)"),
-      },
+      outputSchema: healthHeartRateShape,
       annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: false },
     },
     async () => {
       const bridgeErr = await checkSwiftBridge();
       if (bridgeErr) return err(`Swift bridge required: ${bridgeErr}`);
       try {
-        const result = await runSwift<{ heartRateAvg7d: number | null; message?: string }>("health-heart-rate", "{}");
+        const result = await runSwift<HealthHeartRate>("health-heart-rate", "{}");
         return okLinkedStructured("health_heart_rate", result);
       } catch (e) {
         return toolError("get heart rate", e);
@@ -98,9 +107,7 @@ export function registerHealthTools(server: McpServer, _config: AirMcpConfig): v
           .optional()
           .describe("ISO 8601 date (e.g. '2026-03-22'). Defaults to today (last night's sleep)."),
       },
-      outputSchema: {
-        sleepHours: z.number().describe("Total sleep hours (actual sleep stages, not time in bed)"),
-      },
+      outputSchema: healthSleepShape,
       annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: false },
     },
     async ({ date }: { date?: string }) => {
@@ -108,7 +115,7 @@ export function registerHealthTools(server: McpServer, _config: AirMcpConfig): v
       if (bridgeErr) return err(`Swift bridge required: ${bridgeErr}`);
       try {
         const input = date ? JSON.stringify({ date }) : "{}";
-        const result = await runSwift<{ sleepHours: number }>("health-sleep", input);
+        const result = await runSwift<HealthSleep>("health-sleep", input);
         return okLinkedStructured("health_sleep", result);
       } catch (e) {
         return toolError("get sleep data", e);

--- a/src/messages/tools.ts
+++ b/src/messages/tools.ts
@@ -34,6 +34,12 @@ const chatSchema = z.object({
   updated: z.string().nullable(),
 });
 
+const chatListShape = {
+  total: z.number(),
+  returned: z.number(),
+  chats: z.array(chatSchema),
+};
+
 export function registerMessagesTools(server: McpServer, config: AirMcpConfig): void {
   const { allowSendMessages } = config;
   server.registerTool(
@@ -44,11 +50,7 @@ export function registerMessagesTools(server: McpServer, config: AirMcpConfig): 
       inputSchema: {
         limit: z.number().int().min(1).max(200).optional().default(50).describe("Max chats to return (default: 50)"),
       },
-      outputSchema: {
-        total: z.number(),
-        returned: z.number(),
-        chats: z.array(chatSchema),
-      },
+      outputSchema: chatListShape,
       annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: false },
     },
     async ({ limit }) => {
@@ -68,12 +70,7 @@ export function registerMessagesTools(server: McpServer, config: AirMcpConfig): 
       inputSchema: {
         chatId: z.string().max(500).describe("Chat ID"),
       },
-      outputSchema: {
-        id: z.string(),
-        name: z.string().nullable(),
-        participants: z.array(participantSchema),
-        updated: z.string().nullable(),
-      },
+      outputSchema: chatSchema.shape,
       annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: false },
     },
     async ({ chatId }) => {
@@ -94,11 +91,7 @@ export function registerMessagesTools(server: McpServer, config: AirMcpConfig): 
         query: z.string().max(500).describe("Search keyword (matches chat name, participant name, or handle)"),
         limit: z.number().int().min(1).max(100).optional().default(20).describe("Max results (default: 20)"),
       },
-      outputSchema: {
-        total: z.number(),
-        returned: z.number(),
-        chats: z.array(chatSchema),
-      },
+      outputSchema: chatListShape,
       annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: false },
     },
     async ({ query, limit }) => {

--- a/tests/output-schema-wave3.test.js
+++ b/tests/output-schema-wave3.test.js
@@ -46,29 +46,34 @@ function resetAll() {
 
 // ── messages ──────────────────────────────────────────────────────────
 
+const aliceChat = {
+  id: 'chat-1',
+  name: 'Alice',
+  participants: [{ name: 'Alice', handle: 'alice@example.com' }],
+  updated: '2026-04-20T10:00:00Z',
+};
+const anonymousChat = {
+  id: 'chat-2',
+  name: null,
+  participants: [{ name: null, handle: '+821012345678' }],
+  updated: null,
+};
+const teamChat = {
+  id: 'chat-3',
+  name: 'Team',
+  participants: [
+    { name: 'Bob', handle: 'bob@example.com' },
+    { name: null, handle: null },
+  ],
+  updated: '2026-04-20T10:00:00Z',
+};
+
 describe('Wave 3 — messages.list_chats', () => {
   beforeEach(resetAll);
   test('structuredContent matches outputSchema', async () => {
     const server = createMockServer();
     registerMessagesTools(server, createMockConfig());
-    mockRunJxa.mockResolvedValue({
-      total: 2,
-      returned: 2,
-      chats: [
-        {
-          id: 'chat-1',
-          name: 'Alice',
-          participants: [{ name: 'Alice', handle: 'alice@example.com' }],
-          updated: '2026-04-20T10:00:00Z',
-        },
-        {
-          id: 'chat-2',
-          name: null,
-          participants: [{ name: null, handle: '+821012345678' }],
-          updated: null,
-        },
-      ],
-    });
+    mockRunJxa.mockResolvedValue({ total: 2, returned: 2, chats: [aliceChat, anonymousChat] });
     const result = await server.callTool('list_chats', {});
     assertConforms(server, 'list_chats', result.structuredContent);
   });
@@ -79,12 +84,7 @@ describe('Wave 3 — messages.read_chat', () => {
   test('structuredContent matches outputSchema', async () => {
     const server = createMockServer();
     registerMessagesTools(server, createMockConfig());
-    mockRunJxa.mockResolvedValue({
-      id: 'chat-1',
-      name: 'Alice',
-      participants: [{ name: 'Alice', handle: 'alice@example.com' }],
-      updated: '2026-04-20T10:00:00Z',
-    });
+    mockRunJxa.mockResolvedValue(aliceChat);
     const result = await server.callTool('read_chat', { chatId: 'chat-1' });
     assertConforms(server, 'read_chat', result.structuredContent);
   });
@@ -95,21 +95,7 @@ describe('Wave 3 — messages.search_chats', () => {
   test('structuredContent matches outputSchema', async () => {
     const server = createMockServer();
     registerMessagesTools(server, createMockConfig());
-    mockRunJxa.mockResolvedValue({
-      total: 5,
-      returned: 1,
-      chats: [
-        {
-          id: 'chat-3',
-          name: 'Team',
-          participants: [
-            { name: 'Bob', handle: 'bob@example.com' },
-            { name: null, handle: null },
-          ],
-          updated: '2026-04-20T10:00:00Z',
-        },
-      ],
-    });
+    mockRunJxa.mockResolvedValue({ total: 5, returned: 1, chats: [teamChat] });
     const result = await server.callTool('search_chats', { query: 'team' });
     assertConforms(server, 'search_chats', result.structuredContent);
   });

--- a/tests/safari-tools.test.js
+++ b/tests/safari-tools.test.js
@@ -32,13 +32,9 @@ describe('Safari tools registration', () => {
   });
 
   test('registers safari tools (add_bookmark gated on macOS < 26)', () => {
-    // add_bookmark is only registered on macOS ≤ 25.
-    // - non-Darwin (getOsVersion() = 0): skipped → 11 tools
-    // - Darwin macOS ≤ 25: registered → 12 tools
-    // - Darwin macOS ≥ 26: skipped → 11 tools
-    // We assert the invariant that always holds: 11 non-gated tools are
-    // always registered, and `add_bookmark`'s presence matches the host's
-    // macOS version.
+    // WHY: Apple removed Safari bookmark scripting in macOS 26, so the gate
+    // in src/safari/tools.ts varies registration by host OS. The asserted
+    // invariant is the set that never depends on OS.
     const alwaysRegistered = [
       'list_tabs',
       'read_page_content',
@@ -55,8 +51,6 @@ describe('Safari tools registration', () => {
     for (const name of alwaysRegistered) {
       expect(server.tools.has(name)).toBe(true);
     }
-    expect([11, 12]).toContain(server.tools.size);
-    // `add_bookmark` registration mirrors the OS gate in src/safari/tools.ts.
     const hasAddBookmark = server.tools.has('add_bookmark');
     expect(server.tools.size).toBe(alwaysRegistered.length + (hasAddBookmark ? 1 : 0));
   });


### PR DESCRIPTION
## Summary

Follow-up cleanup for [#95](https://github.com/heznpc/AirMCP/pull/95) caught by `/simplify` review.

- **health/tools.ts**: zod schemas are now the single source of truth. `runSwift<T>` generics derive from `z.infer` instead of hand-rolled inline interfaces. Adding a HealthKit field now only touches the zod shape.
- **messages/tools.ts**: `list_chats` and `search_chats` now share a `chatListShape` constant; `read_chat` uses `chatSchema.shape` instead of re-listing its fields inline.
- **tests/output-schema-wave3.test.js**: 3 chat fixtures (`aliceChat`, `anonymousChat`, `teamChat`) hoisted to module scope and reused — drops ~50 lines of near-duplicate test payloads.
- **tests/safari-tools.test.js**: removes a WHAT-narrating comment (replaced with a one-line WHY) and a redundant `expect([11,12]).toContain(size)` that the per-count arithmetic already covers.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean
- [x] `npm test` — 91 suites, 1324 tests pass (unchanged)
- [ ] CI gates