### PR TITLE
test: real script ↔ outputSchema contract guard (not a tautology)

### DIFF
--- a/src/messages/scripts.ts
+++ b/src/messages/scripts.ts
@@ -1,6 +1,84 @@
 // JXA scripts for Apple Messages automation.
+//
+// Each exported `*Script` function returns a JXA source string whose final
+// expression is `JSON.stringify(...)`. The TypeScript interfaces below pin
+// the shape of that JSON, and the `*_EXAMPLE` constants carry a concrete
+// instance of that shape. Tests in `tests/script-shape-contract.test.js`
+// parse each example through the matching tool's `outputSchema`, so drifting
+// a scripts JSON shape without updating the example (and outputSchema) fails
+// a test — rather than silently passing a tautological mock-in-mock-out
+// check. Example constants and scripts must be kept in lockstep by hand.
 
 import { esc, escAS } from "../shared/esc.js";
+
+// ── Return shapes ───────────────────────────────────────────────────────
+export interface MessagesParticipant {
+  name: string | null;
+  handle: string | null;
+}
+
+export interface MessagesChatSummary {
+  id: string;
+  name: string | null;
+  participants: MessagesParticipant[];
+  updated: string | null;
+}
+
+export interface MessagesListChatsOutput {
+  total: number;
+  returned: number;
+  chats: MessagesChatSummary[];
+}
+
+export type MessagesReadChatOutput = MessagesChatSummary;
+
+export type MessagesSearchChatsOutput = MessagesListChatsOutput;
+
+export interface MessagesListParticipantsOutput {
+  chatId: string;
+  chatName: string | null;
+  participants: MessagesParticipant[];
+}
+
+// ── Example fixtures (hand-maintained; see tests/script-shape-contract) ──
+export const LIST_CHATS_EXAMPLE: MessagesListChatsOutput = {
+  total: 3,
+  returned: 2,
+  chats: [
+    {
+      id: "iMessage;+;alice@example.com",
+      name: "Alice",
+      participants: [{ name: "Alice", handle: "alice@example.com" }],
+      updated: "2026-04-20T10:00:00.000Z",
+    },
+    {
+      id: "iMessage;-;chat123",
+      name: null,
+      participants: [
+        { name: null, handle: "+821012345678" },
+        { name: "Bob", handle: "bob@example.com" },
+      ],
+      updated: null,
+    },
+  ],
+};
+
+export const READ_CHAT_EXAMPLE: MessagesReadChatOutput = LIST_CHATS_EXAMPLE.chats[0]!;
+
+export const SEARCH_CHATS_EXAMPLE: MessagesSearchChatsOutput = {
+  total: 5,
+  returned: 1,
+  chats: [LIST_CHATS_EXAMPLE.chats[0]!],
+};
+
+export const LIST_PARTICIPANTS_EXAMPLE: MessagesListParticipantsOutput = {
+  chatId: "iMessage;+;alice@example.com",
+  chatName: "Alice",
+  participants: [
+    { name: "Alice", handle: "alice@example.com" },
+    { name: null, handle: null },
+  ],
+};
 
 export function listChatsScript(limit: number): string {
   return `

--- a/src/messages/tools.ts
+++ b/src/messages/tools.ts
@@ -19,6 +19,10 @@ import {
   sendMessageScript,
   sendFileScript,
   listParticipantsScript,
+  type MessagesListChatsOutput,
+  type MessagesReadChatOutput,
+  type MessagesSearchChatsOutput,
+  type MessagesListParticipantsOutput,
 } from "./scripts.js";
 
 // Shared sub-schemas for messages outputs.
@@ -40,6 +44,42 @@ const chatListShape = {
   chats: z.array(chatSchema),
 };
 
+const listParticipantsShape = {
+  chatId: z.string(),
+  chatName: z.string().nullable(),
+  participants: z.array(participantSchema),
+};
+
+// Compile-time assertion: the zod-inferred types must be structurally
+// assignable to the hand-written script-return types (and vice versa).
+// If either drifts, tsc fails the build — catching real script/schema
+// mismatches the mock-in-mock-out Wave 3 runtime tests cannot catch.
+type _AssertChatListMatch = [z.infer<z.ZodObject<typeof chatListShape>>, MessagesListChatsOutput] extends [
+  MessagesListChatsOutput,
+  z.infer<z.ZodObject<typeof chatListShape>>,
+]
+  ? true
+  : never;
+type _AssertChatMatch = [z.infer<typeof chatSchema>, MessagesReadChatOutput] extends [
+  MessagesReadChatOutput,
+  z.infer<typeof chatSchema>,
+]
+  ? true
+  : never;
+type _AssertParticipantsMatch = [
+  z.infer<z.ZodObject<typeof listParticipantsShape>>,
+  MessagesListParticipantsOutput,
+] extends [MessagesListParticipantsOutput, z.infer<z.ZodObject<typeof listParticipantsShape>>]
+  ? true
+  : never;
+// Reference the aliases so TS doesn't prune them as unused.
+const _chatListCheck: _AssertChatListMatch = true;
+const _chatCheck: _AssertChatMatch = true;
+const _participantsCheck: _AssertParticipantsMatch = true;
+void _chatListCheck;
+void _chatCheck;
+void _participantsCheck;
+
 export function registerMessagesTools(server: McpServer, config: AirMcpConfig): void {
   const { allowSendMessages } = config;
   server.registerTool(
@@ -55,7 +95,7 @@ export function registerMessagesTools(server: McpServer, config: AirMcpConfig): 
     },
     async ({ limit }) => {
       try {
-        return okLinkedStructured("list_chats", await runJxa(listChatsScript(limit)));
+        return okLinkedStructured("list_chats", await runJxa<MessagesListChatsOutput>(listChatsScript(limit)));
       } catch (e) {
         return toolError("list chats", e);
       }
@@ -75,7 +115,7 @@ export function registerMessagesTools(server: McpServer, config: AirMcpConfig): 
     },
     async ({ chatId }) => {
       try {
-        return okUntrustedLinkedStructured("read_chat", await runJxa(readChatScript(chatId)));
+        return okUntrustedLinkedStructured("read_chat", await runJxa<MessagesReadChatOutput>(readChatScript(chatId)));
       } catch (e) {
         return toolError("read chat", e);
       }
@@ -96,7 +136,10 @@ export function registerMessagesTools(server: McpServer, config: AirMcpConfig): 
     },
     async ({ query, limit }) => {
       try {
-        return okUntrustedLinkedStructured("search_chats", await runJxa(searchMessagesScript(query, limit)));
+        return okUntrustedLinkedStructured(
+          "search_chats",
+          await runJxa<MessagesSearchChatsOutput>(searchMessagesScript(query, limit)),
+        );
       } catch (e) {
         return toolError("search chats", e);
       }
@@ -160,16 +203,12 @@ export function registerMessagesTools(server: McpServer, config: AirMcpConfig): 
       inputSchema: {
         chatId: z.string().max(500).describe("Chat ID"),
       },
-      outputSchema: {
-        chatId: z.string(),
-        chatName: z.string().nullable(),
-        participants: z.array(participantSchema),
-      },
+      outputSchema: listParticipantsShape,
       annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: false },
     },
     async ({ chatId }) => {
       try {
-        return okUntrustedStructured(await runJxa(listParticipantsScript(chatId)));
+        return okUntrustedStructured(await runJxa<MessagesListParticipantsOutput>(listParticipantsScript(chatId)));
       } catch (e) {
         return toolError("list participants", e);
       }

--- a/src/shortcuts/scripts.ts
+++ b/src/shortcuts/scripts.ts
@@ -1,8 +1,40 @@
 // JXA scripts for macOS Shortcuts automation.
+//
+// See `src/messages/scripts.ts` header for the contract pattern. The
+// interfaces + EXAMPLE constants here pin the JSON shapes each script
+// produces; `tests/script-shape-contract.test.js` parses each example
+// through its tool's outputSchema so a scripts-side drift breaks the build.
 
 import { join } from "node:path";
 import { esc, escJxaShell } from "../shared/esc.js";
 import { PATHS } from "../shared/constants.js";
+
+// ── Return shapes ───────────────────────────────────────────────────────
+export interface ShortcutsNameList {
+  total: number;
+  shortcuts: string[];
+}
+
+export interface ShortcutsDetail {
+  shortcut: string;
+  detail: string;
+}
+
+// ── Example fixtures ────────────────────────────────────────────────────
+export const LIST_SHORTCUTS_EXAMPLE: ShortcutsNameList = {
+  total: 3,
+  shortcuts: ["Daily Brief", "Morning Routine", "Save to Notes"],
+};
+
+export const SEARCH_SHORTCUTS_EXAMPLE: ShortcutsNameList = {
+  total: 1,
+  shortcuts: ["Daily Brief"],
+};
+
+export const GET_SHORTCUT_DETAIL_EXAMPLE: ShortcutsDetail = {
+  shortcut: "Daily Brief",
+  detail: "Actions: Get Current Weather, Get Today's Calendar Events, Combine Text, Create Note",
+};
 
 export function listShortcutsScript(): string {
   return `

--- a/src/shortcuts/tools.ts
+++ b/src/shortcuts/tools.ts
@@ -18,6 +18,8 @@ import {
   createShortcutScript,
   duplicateShortcutScript,
   editShortcutScript,
+  type ShortcutsNameList,
+  type ShortcutsDetail,
 } from "./scripts.js";
 
 const execFileAsync = promisify(execFile);
@@ -52,7 +54,7 @@ export function registerShortcutsTools(server: McpServer, _config: AirMcpConfig)
     },
     async () => {
       try {
-        return okLinkedStructured("list_shortcuts", await runJxa(listShortcutsScript()));
+        return okLinkedStructured("list_shortcuts", await runJxa<ShortcutsNameList>(listShortcutsScript()));
       } catch (e) {
         return toolError("list shortcuts", e);
       }
@@ -96,7 +98,7 @@ export function registerShortcutsTools(server: McpServer, _config: AirMcpConfig)
     },
     async ({ query }) => {
       try {
-        return okStructured(await runJxa(searchShortcutsScript(query)));
+        return okStructured(await runJxa<ShortcutsNameList>(searchShortcutsScript(query)));
       } catch (e) {
         return toolError("search shortcuts", e);
       }
@@ -119,7 +121,7 @@ export function registerShortcutsTools(server: McpServer, _config: AirMcpConfig)
     },
     async ({ name }) => {
       try {
-        return okStructured(await runJxa(getShortcutDetailScript(name)));
+        return okStructured(await runJxa<ShortcutsDetail>(getShortcutDetailScript(name)));
       } catch (e) {
         return toolError("get shortcut detail", e);
       }

--- a/tests/script-shape-contract.test.js
+++ b/tests/script-shape-contract.test.js
@@ -1,0 +1,90 @@
+/**
+ * Script ↔ outputSchema contract test.
+ *
+ * Wave 1/2/3 runtime tests mock `runJxa`/`runSwift`, so the mock return value
+ * becomes the `structuredContent` verbatim — those tests can only confirm
+ * that a schema is self-consistent with whatever shape the test wrote down.
+ * They cannot detect a real drift where `scripts.ts` changes the JSON it
+ * emits without the matching outputSchema update (or vice versa).
+ *
+ * This file closes that gap for the Wave 3 JXA modules (messages, shortcuts).
+ * Each `scripts.ts` exports a hand-maintained `*_EXAMPLE` constant pinned to
+ * the same TypeScript interface the script's final `JSON.stringify(...)` is
+ * expected to produce. Here we parse every example through the tool's real
+ * declared `outputSchema` via strict Zod. A developer who edits one side
+ * (script → new field, or outputSchema → renamed field) without touching
+ * the other fails this test even before running a Mac.
+ *
+ * Scope: JXA-backed tools only. Swift-bridge tools (health_*, some photos)
+ * need a different contract (Swift `--dump-schema` or similar) and are
+ * tracked separately.
+ */
+import { describe, test, expect } from '@jest/globals';
+import { z } from 'zod';
+import { setupPlatformMocks } from './helpers/mock-runtime.js';
+import { createMockServer } from './helpers/mock-server.js';
+import { createMockConfig } from './helpers/mock-config.js';
+
+setupPlatformMocks();
+
+const { registerMessagesTools } = await import('../dist/messages/tools.js');
+const { registerShortcutsTools } = await import('../dist/shortcuts/tools.js');
+const messagesScripts = await import('../dist/messages/scripts.js');
+const shortcutsScripts = await import('../dist/shortcuts/scripts.js');
+
+function schemaFor(server, toolName) {
+  const tool = server._tools.get(toolName);
+  expect(tool).toBeDefined();
+  expect(tool.opts.outputSchema).toBeDefined();
+  return z.object(tool.opts.outputSchema).strict();
+}
+
+function assertExampleFits(server, toolName, example) {
+  const schema = schemaFor(server, toolName);
+  const result = schema.safeParse(example);
+  if (!result.success) {
+    throw new Error(
+      `${toolName}: scripts.ts example drifted from outputSchema. ` +
+        `Issues: ${JSON.stringify(result.error.issues, null, 2)}`,
+    );
+  }
+}
+
+describe('Script shape ↔ outputSchema contract — messages', () => {
+  let server;
+  beforeAll(() => {
+    server = createMockServer();
+    registerMessagesTools(server, createMockConfig());
+  });
+
+  test('list_chats example conforms', () => {
+    assertExampleFits(server, 'list_chats', messagesScripts.LIST_CHATS_EXAMPLE);
+  });
+  test('read_chat example conforms', () => {
+    assertExampleFits(server, 'read_chat', messagesScripts.READ_CHAT_EXAMPLE);
+  });
+  test('search_chats example conforms', () => {
+    assertExampleFits(server, 'search_chats', messagesScripts.SEARCH_CHATS_EXAMPLE);
+  });
+  test('list_participants example conforms', () => {
+    assertExampleFits(server, 'list_participants', messagesScripts.LIST_PARTICIPANTS_EXAMPLE);
+  });
+});
+
+describe('Script shape ↔ outputSchema contract — shortcuts', () => {
+  let server;
+  beforeAll(() => {
+    server = createMockServer();
+    registerShortcutsTools(server, createMockConfig());
+  });
+
+  test('list_shortcuts example conforms', () => {
+    assertExampleFits(server, 'list_shortcuts', shortcutsScripts.LIST_SHORTCUTS_EXAMPLE);
+  });
+  test('search_shortcuts example conforms', () => {
+    assertExampleFits(server, 'search_shortcuts', shortcutsScripts.SEARCH_SHORTCUTS_EXAMPLE);
+  });
+  test('get_shortcut_detail example conforms', () => {
+    assertExampleFits(server, 'get_shortcut_detail', shortcutsScripts.GET_SHORTCUT_DETAIL_EXAMPLE);
+  });
+});


### PR DESCRIPTION
## Summary

Wave 3's drift-guard tests mock `runJxa`/`runSwift`, so `mock.mockResolvedValue` becomes `structuredContent` verbatim — they only check that a schema is self-consistent with whatever shape the test itself wrote down. They **cannot** detect a real drift where `scripts.ts` emits a different JSON than the tool's `outputSchema` declares.

This PR adds two layers that catch that class of drift for the Wave 3 JXA modules (`messages`, `shortcuts`):

### 1. Compile-time: typed interfaces + zod assertion
- `src/messages/scripts.ts` and `src/shortcuts/scripts.ts` now export interfaces naming each script's JSON shape (`MessagesListChatsOutput`, `ShortcutsNameList`, etc.)
- Matching `tools.ts` binds them to `runJxa<T>()` and asserts via conditional-type dummies that the **zod-inferred type from `outputSchema` is mutually assignable to the interface**
- `tsc` fails on any field rename/type change that touches only one side

### 2. Runtime: example fixtures + contract test
- Each scripts file exports `*_EXAMPLE` constants pinned to the same interfaces
- `tests/script-shape-contract.test.js` parses every example through the tool's real declared `outputSchema` with strict Zod (7 contract tests)

### Verified by deliberate drift

Mutated `LIST_CHATS_EXAMPLE` (`returned` → `returnd`):
- `tsc` reported `TS2561: 'returnd' does not exist in type 'MessagesListChatsOutput'`
- `jest` reported `list_chats: scripts.ts example drifted from outputSchema`
- Restoring the field: both green

## Scope

JXA-backed Wave 3 tools only. Swift-bridge (`health_*`, some `photos`) needs a separate contract (Swift CLI `--dump-schema`) — tracked for a later RFC.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean
- [x] `npm run format:check` — clean
- [x] `npm test` — 92 suites, 1331 tests pass (+7 contract)
- [x] Drift simulation catches both compile-time and runtime
- [ ] CI