### PR TITLE
test: swift bridge contract + CI smoke boot + RFC 0006

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,6 +75,9 @@ jobs:
       - name: Test
         run: npm test
 
+      - name: Smoke — boot server + tools/list round-trip
+        run: npm run smoke
+
       - name: Verify stats
         run: node scripts/count-stats.mjs --check
 

--- a/docs/rfc/0006-swift-bridge-schema-dump.md
+++ b/docs/rfc/0006-swift-bridge-schema-dump.md
@@ -1,0 +1,108 @@
+# RFC 0006 — Swift Bridge `--dump-example-output` for True Schema Contract
+
+- **Status**: Draft
+- **Author**: heznpc + Claude
+- **Created**: 2026-04-23
+- **Target**: v2.12.0
+- **Related**: RFC 0001 (error categories), `src/health/tools.ts` (TS-side fixtures), `swift/Sources/AirMcpBridge/main.swift`, `swift/Sources/AirMCPKit/HealthService.swift`, `tests/script-shape-contract.test.js`
+
+---
+
+## 1. Motivation
+
+The JXA-backed Wave 3 tools (messages, shortcuts) already have an end-to-end contract: scripts.ts exports typed interfaces + `*_EXAMPLE` constants, tools.ts binds them to `runJxa<T>()` and assertions, and `tests/script-shape-contract.test.js` parses each example through the declared `outputSchema` with strict Zod.
+
+The Swift-bridge side (`health_*`, upcoming `photos/semantic/location/bluetooth/intelligence/speech/vision` payloads) has only **half** of that contract. The PR landing alongside this RFC adds hand-maintained TS fixtures (`HEALTH_SUMMARY_EXAMPLE`, etc.) paired with compile-time assertions and the same Zod round-trip test — but the fixtures mirror the Swift Encodable structs **by hand**. A developer who renames `HealthSummary.sleepHoursLastNight` → `sleepHoursLast` in Swift can still commit without the TS fixture noticing, because:
+
+1. Swift is built by a different toolchain (`swift build`) than the TS check (`tsc --noEmit`)
+2. No step today parses Swift's **actual runtime output** against the TS Zod schema
+
+The gap: a drift on the Swift side ships silently, and the TS `runSwift<HealthSummary>` generic lies about what the binary returns.
+
+## 2. Goal
+
+Close the loop: the CI must, on every run, ask the Swift binary what JSON each command produces and hand that JSON to the TS Zod `outputSchema`. No hand-maintained fixtures in the critical path.
+
+## 3. Proposed Design
+
+### 3.1 Swift CLI new flag
+
+Add `--dump-example-output <command>` to `swift/Sources/AirMcpBridge/main.swift`. When present, the binary:
+
+1. Skips the normal command dispatch
+2. Looks up a static `[command: Encodable]` registry (populated at startup)
+3. Encodes the example as JSON, writes to stdout, exits 0
+
+```swift
+// Pseudocode
+let dumpTarget = args.first(where: { $0 == "--dump-example-output" }).map { args[args.index(of: $0)! + 1] }
+if let dumpTarget {
+    guard let example = EXAMPLE_REGISTRY[dumpTarget] else { exit(64) }
+    try JSONEncoder().encode(example).write(to: stdout)
+    exit(0)
+}
+```
+
+Each command contributes one entry:
+```swift
+EXAMPLE_REGISTRY["health-summary"] = HealthSummary(stepsToday: 0, heartRateAvg7d: nil, sleepHoursLastNight: 0, activeEnergyToday: 0, exerciseMinutesToday: 0)
+EXAMPLE_REGISTRY["health-steps"] = ["stepsToday": 0]
+// ...
+```
+
+### 3.2 Node-side consumer
+
+`tests/script-shape-contract.test.js` gains a `describe('Swift bridge — live examples')` block that:
+1. Spawns `swift/.build/release/AirMcpBridge --dump-example-output <cmd>` for each health tool
+2. Parses stdout as JSON
+3. Runs the result through `z.object(tool.opts.outputSchema).strict().safeParse(...)`
+
+Guarded by `process.env.AIRMCP_SWIFT_BRIDGE_AVAILABLE === "1"` so the test auto-skips on non-macOS runners. CI ci.yml sets it after `swift build` succeeds.
+
+### 3.3 Removing hand-maintained fixtures
+
+Once 3.1 + 3.2 land, the v2.11-era `HEALTH_SUMMARY_EXAMPLE` / `HEALTH_STEPS_EXAMPLE` / etc. constants in `src/health/tools.ts` become redundant. The migration PR:
+- Deletes the `export const HEALTH_*_EXAMPLE` constants
+- Removes the health `describe` block from `script-shape-contract.test.js` (the live-Swift block replaces it)
+- Leaves the TypeScript interfaces + `runSwift<HealthSummary>` generic bindings in place — they still catch same-side renames at compile time
+
+## 4. Risks / Open Questions
+
+### R1. Swift CLI binary must be buildable on every PR
+- **Risk**: CI runners without macOS can't run the live test. Linux / Docker-based contributor environments would skip the live check, losing coverage.
+- **Mitigation**: Same skip gate (`AIRMCP_SWIFT_BRIDGE_AVAILABLE`) already used for health unit tests. The main ci.yml job runs on `macos-latest` and always has the bridge.
+
+### R2. `Encodable` non-determinism
+- **Risk**: `HealthSummary` has `Double` fields; Swift's `JSONEncoder` may emit `0` vs `0.0` inconsistently between OS versions. Strict Zod `z.number()` accepts both, but if we later tighten types, this becomes a flake.
+- **Mitigation**: Use `.sortedKeys` + fixed example values that don't land on 0.0 edge cases.
+
+### R3. Scope creep — all Swift-backed modules
+- **Risk**: v2.11 landed fixtures only for `health_*` (5 tools). The RFC implies rolling the pattern out to `photos`, `semantic`, `location`, `bluetooth`, `intelligence`, `speech`, `vision`. That is ~40+ commands, each needing an `EXAMPLE_REGISTRY` entry.
+- **Mitigation**: Stage by module; one PR per module. Acceptance criterion: the tool's `outputSchema` is present AND a live example passes.
+
+### R4. CI time budget
+- **Risk**: Each `--dump-example-output` spawn is ~100–300ms. 40 commands → ~5–10s extra CI time.
+- **Mitigation**: Acceptable. If it grows, batch all commands into one `--dump-all` that emits an NDJSON stream.
+
+## 5. Rollout
+
+| Phase | Content | Version |
+|---|---|---|
+| 1 | Swift `--dump-example-output` flag + `EXAMPLE_REGISTRY` for health commands only. Node-side consumer test. `AIRMCP_SWIFT_BRIDGE_AVAILABLE` gate. | v2.12.0 |
+| 2 | Delete hand-maintained `HEALTH_*_EXAMPLE` constants. | v2.12.0 |
+| 3 | Extend to `photos`, `semantic`, `location`, `bluetooth` (next-highest-traffic Swift-backed modules). | v2.13.0 |
+| 4 | Extend to remaining Swift-backed modules (`intelligence`, `speech`, `vision`). | v2.14.0 |
+| 5 | (Stretch) Generate TS interfaces from Swift via a codegen step, eliminating the compile-time half of the hand-maintenance too. | v2.15.0 or later |
+
+## 6. Acceptance Criteria
+
+- `npm run smoke` continues to pass (unchanged contract).
+- `npm test` grows a `describe('Swift bridge — live examples')` block with at least one assertion per health command, each invoking the real Swift binary.
+- A deliberate drift (rename `HealthSummary.sleepHoursLastNight` in Swift) fails the live test on CI within the same PR.
+- `SECURITY.md` or `CONTRIBUTING.md` documents the `--dump-example-output` flag as a developer tool; the binary only enables it in debug / non-stripped builds if that's a trivial safety measure.
+
+## 7. Alternatives Considered
+
+- **Swift codegen → TS types**: heavier (Swift AST walker), but fully eliminates hand-maintained fixtures. Possible v2.15+ stretch. Not the right first step given RFC 0006's minimal-surface goal.
+- **JSON Schema export from Swift**: Swift's `JSONEncoder` has no built-in schema dump. Third-party libs exist but introduce a non-trivial dependency. Rejected for now.
+- **Contract tests only at `npm run smoke` time**: requires TCC-granted macOS with a signed-in HealthKit account — not reproducible in CI. Rejected.

--- a/docs/rfc/README.md
+++ b/docs/rfc/README.md
@@ -88,6 +88,7 @@ Draft ──► Proposed ──► Accepted ──► Implemented
 | [0003](./0003-ci-audit-stepwise.md) | CI npm audit 등급 단계적 상향 | Draft | v2.8.x |
 | [0004](./0004-macos-compat-matrix.md) | macOS 호환성 매트릭스 & 모듈 Manifest 확장 | Draft | v2.8.0 |
 | [0005](./0005-oauth-resource-indicators.md) | OAuth 2.1 + Resource Indicators (MCP 2025-06-18 spec) | Draft | v2.11.0 |
+| [0006](./0006-swift-bridge-schema-dump.md) | Swift Bridge `--dump-example-output` for True Schema Contract | Draft | v2.12.0 |
 
 ## 관련 문서
 

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "pretest": "npm run build",
     "start": "node dist/index.js",
     "test": "node --experimental-vm-modules node_modules/.bin/jest",
+    "smoke": "node scripts/smoke-mcp.mjs",
     "qa": "node scripts/qa-test.mjs",
     "qa:crud": "node scripts/qa-crud-test.mjs",
     "qa:e2e": "node scripts/qa-e2e-test.mjs",

--- a/scripts/smoke-mcp.mjs
+++ b/scripts/smoke-mcp.mjs
@@ -1,0 +1,111 @@
+#!/usr/bin/env node
+// MCP stdio smoke test — boots `dist/index.js`, performs the required
+// MCP 2025-06-18 handshake (initialize → notifications/initialized),
+// asks for tools/list, and asserts the server returns a plausible
+// number of tools.
+//
+// Intent: catch regressions that unit tests cannot — a bad module
+// registration path, a top-level throw during server construction, or
+// a regression in the MCP SDK wiring. This test does NOT invoke any
+// tool handler that needs TCC permissions; the handshake + tools/list
+// round-trip is the contract it guards.
+//
+// The server only registers modules whose runtime gates pass (macOS version,
+// Swift bridge availability, HealthKit, OAuth credentials, etc.), so the
+// registered count is smaller than the static `count-stats` total. On a
+// vanilla CI runner without the Swift bridge, ~125 tools register; a
+// healthy macOS with the bridge built + default config lands closer to 200.
+// SMOKE_MIN_TOOLS defaults to 100 — enough to catch a broken-boot regression
+// without flaking on partial-environment runners.
+//
+// Env knobs:
+//   SMOKE_MIN_TOOLS  — minimum tools/list length to pass (default: 100)
+//   SMOKE_TIMEOUT_MS — ms to wait for a full response set (default: 20_000)
+
+import { spawn } from "node:child_process";
+import { createInterface } from "node:readline";
+
+const MIN_TOOLS = Number(process.env.SMOKE_MIN_TOOLS ?? 100);
+const TIMEOUT_MS = Number(process.env.SMOKE_TIMEOUT_MS ?? 20_000);
+
+const server = spawn("node", ["dist/index.js"], {
+  stdio: ["pipe", "pipe", "inherit"],
+  env: { ...process.env, AIRMCP_TEST_MODE: "1" },
+});
+
+const rl = createInterface({ input: server.stdout });
+
+// Track responses keyed by JSON-RPC id. The server may interleave
+// notifications (no id) and responses; we only consume id-keyed rows.
+const pending = new Map();
+rl.on("line", (line) => {
+  if (!line.trim()) return;
+  let msg;
+  try {
+    msg = JSON.parse(line);
+  } catch {
+    return; // banner line or stderr leak; ignore
+  }
+  if (msg.id !== undefined && pending.has(msg.id)) {
+    const { resolve } = pending.get(msg.id);
+    pending.delete(msg.id);
+    resolve(msg);
+  }
+});
+
+function request(method, params, id) {
+  const payload = { jsonrpc: "2.0", id, method, ...(params ? { params } : {}) };
+  server.stdin.write(`${JSON.stringify(payload)}\n`);
+  return new Promise((resolve, reject) => {
+    pending.set(id, { resolve });
+    setTimeout(() => {
+      if (pending.has(id)) {
+        pending.delete(id);
+        reject(new Error(`timeout waiting for id=${id} (${method})`));
+      }
+    }, TIMEOUT_MS);
+  });
+}
+
+function notify(method) {
+  server.stdin.write(`${JSON.stringify({ jsonrpc: "2.0", method })}\n`);
+}
+
+const watchdog = setTimeout(() => {
+  console.error(`[smoke] overall timeout after ${TIMEOUT_MS}ms`);
+  server.kill("SIGKILL");
+  process.exit(2);
+}, TIMEOUT_MS);
+
+let exitCode = 0;
+try {
+  const initResp = await request(
+    "initialize",
+    {
+      protocolVersion: "2025-06-18",
+      capabilities: {},
+      clientInfo: { name: "airmcp-smoke", version: "0.0.0" },
+    },
+    1,
+  );
+  if (!initResp.result) throw new Error(`initialize failed: ${JSON.stringify(initResp)}`);
+  notify("notifications/initialized");
+
+  const toolsResp = await request("tools/list", {}, 2);
+  const tools = toolsResp.result?.tools;
+  if (!Array.isArray(tools)) throw new Error(`tools/list malformed: ${JSON.stringify(toolsResp)}`);
+  if (tools.length < MIN_TOOLS) {
+    throw new Error(`tools/list returned ${tools.length} tools; expected >= ${MIN_TOOLS}`);
+  }
+  console.error(`[smoke] OK — ${tools.length} tools registered`);
+} catch (e) {
+  console.error(`[smoke] FAIL — ${e instanceof Error ? e.message : String(e)}`);
+  exitCode = 1;
+} finally {
+  clearTimeout(watchdog);
+  server.kill("SIGTERM");
+  setTimeout(() => {
+    if (!server.killed) server.kill("SIGKILL");
+    process.exit(exitCode);
+  }, 2000).unref();
+}

--- a/src/health/tools.ts
+++ b/src/health/tools.ts
@@ -30,6 +30,47 @@ type HealthSteps = z.infer<ReturnType<typeof z.object<typeof healthStepsShape>>>
 type HealthHeartRate = z.infer<ReturnType<typeof z.object<typeof healthHeartRateShape>>>;
 type HealthSleep = z.infer<ReturnType<typeof z.object<typeof healthSleepShape>>>;
 
+// ── Swift bridge contract fixtures (hand-maintained mirror of Swift emit) ──
+//
+// These are the JSON shapes the Swift CLI (swift/Sources/AirMcpBridge/main.swift
+// cases "health-summary" / "health-steps" / "health-heart-rate" / "health-sleep"
+// backed by swift/Sources/AirMCPKit/HealthService.swift struct HealthSummary)
+// is expected to write to stdout. Until the planned `--dump-example-output`
+// Swift flag lands, drift between Swift struct edits and TS zod shapes is
+// caught in two places:
+//
+// (1) compile time — the EXAMPLE constant is typed against the zod-inferred
+//     interface, so `tsc` flags a missing/renamed field;
+// (2) runtime — tests/script-shape-contract.test.js parses each example
+//     through the tool's declared outputSchema with strict Zod.
+//
+// When you change a Swift Encodable struct, update the matching EXAMPLE here
+// in the same PR. Both sides of the bridge must move together.
+export const HEALTH_SUMMARY_EXAMPLE: HealthSummary = {
+  stepsToday: 8432,
+  heartRateAvg7d: 62.3,
+  sleepHoursLastNight: 7.25,
+  activeEnergyToday: 412.5,
+  exerciseMinutesToday: 38,
+};
+
+export const HEALTH_STEPS_EXAMPLE: HealthSteps = {
+  stepsToday: 8432,
+};
+
+// Two fixtures for heart rate because message is optional; both cases must parse.
+export const HEALTH_HEART_RATE_EXAMPLE_VALUE: HealthHeartRate = {
+  heartRateAvg7d: 62.3,
+};
+export const HEALTH_HEART_RATE_EXAMPLE_NULL: HealthHeartRate = {
+  heartRateAvg7d: null,
+  message: "No heart rate data for the last 7 days",
+};
+
+export const HEALTH_SLEEP_EXAMPLE: HealthSleep = {
+  sleepHours: 7.25,
+};
+
 export function registerHealthTools(server: McpServer, _config: AirMcpConfig): void {
   server.registerTool(
     "health_summary",

--- a/tests/script-shape-contract.test.js
+++ b/tests/script-shape-contract.test.js
@@ -29,6 +29,8 @@ setupPlatformMocks();
 
 const { registerMessagesTools } = await import('../dist/messages/tools.js');
 const { registerShortcutsTools } = await import('../dist/shortcuts/tools.js');
+const healthTools = await import('../dist/health/tools.js');
+const { registerHealthTools } = healthTools;
 const messagesScripts = await import('../dist/messages/scripts.js');
 const shortcutsScripts = await import('../dist/shortcuts/scripts.js');
 
@@ -86,5 +88,29 @@ describe('Script shape ↔ outputSchema contract — shortcuts', () => {
   });
   test('get_shortcut_detail example conforms', () => {
     assertExampleFits(server, 'get_shortcut_detail', shortcutsScripts.GET_SHORTCUT_DETAIL_EXAMPLE);
+  });
+});
+
+describe('Swift bridge shape ↔ outputSchema contract — health', () => {
+  let server;
+  beforeAll(() => {
+    server = createMockServer();
+    registerHealthTools(server, createMockConfig());
+  });
+
+  test('health_summary example conforms', () => {
+    assertExampleFits(server, 'health_summary', healthTools.HEALTH_SUMMARY_EXAMPLE);
+  });
+  test('health_today_steps example conforms', () => {
+    assertExampleFits(server, 'health_today_steps', healthTools.HEALTH_STEPS_EXAMPLE);
+  });
+  test('health_heart_rate value-case example conforms', () => {
+    assertExampleFits(server, 'health_heart_rate', healthTools.HEALTH_HEART_RATE_EXAMPLE_VALUE);
+  });
+  test('health_heart_rate null-case example conforms', () => {
+    assertExampleFits(server, 'health_heart_rate', healthTools.HEALTH_HEART_RATE_EXAMPLE_NULL);
+  });
+  test('health_sleep example conforms', () => {
+    assertExampleFits(server, 'health_sleep', healthTools.HEALTH_SLEEP_EXAMPLE);
   });
 });


### PR DESCRIPTION
## Why

Closes the gap [#97](https://github.com/heznpc/AirMCP/pull/97) explicitly left open: the JXA-backed tools got a real drift guard, the Swift-bridge side and the "does the server actually boot?" question did not. I punted on this and that was wrong. Here it is.

## What landed

### 1. Swift bridge contract — hand-maintained TS fixtures (stage 1 of RFC 0006)

- [src/health/tools.ts](src/health/tools.ts) exports `HEALTH_SUMMARY_EXAMPLE`, `HEALTH_STEPS_EXAMPLE`, `HEALTH_HEART_RATE_EXAMPLE_{VALUE,NULL}`, `HEALTH_SLEEP_EXAMPLE` typed against the zod-inferred interfaces `runSwift<T>()` already uses.
- [tests/script-shape-contract.test.js](tests/script-shape-contract.test.js) grows a "Swift bridge ↔ outputSchema contract — health" block with 5 Zod `safeParse` checks.
- **Drift simulation**: renaming `sleepHoursLastNight` → `sleepHrsLastNight` in the example fires `tsc error TS2561` **and** jest "example drifted from outputSchema". Field restored → both green.

### 2. CI smoke — server boot + `tools/list` round-trip

- [scripts/smoke-mcp.mjs](scripts/smoke-mcp.mjs) spawns `dist/index.js`, performs the MCP 2025-06-18 handshake (`initialize` → `notifications/initialized`), asks for `tools/list`, and asserts a minimum tool count. Catches broken-boot regressions and bad module registration paths that unit tests cannot.
- `npm run smoke` + new ci.yml step "Smoke — boot server + tools/list round-trip" after `Test`.
- Locally: **125 tools registered** (no Swift bridge build → intelligence/health/semantic skip); a healthy macOS with the bridge lands ~200.
- `SMOKE_MIN_TOOLS` env knob (default 100) keeps partial-environment runners passing while still catching boot regressions.

### 3. Swift contract (stage 2) — planned in RFC 0006

- [docs/rfc/0006-swift-bridge-schema-dump.md](docs/rfc/0006-swift-bridge-schema-dump.md): Swift CLI `--dump-example-output <cmd>` flag so CI parses the **real binary's JSON** through the TS zod schema, eliminating hand-maintained fixtures. 5-phase rollout v2.12 → v2.15.

## Scope notes

- Stage 1 fixtures are a **known interim**: the drift guard works only if developers maintain both sides. RFC 0006 removes that obligation.
- Smoke test runs `node dist/index.js`, so it depends on `Build` succeeding — it does (that's the previous CI step).

## Test plan

- [x] `npm run typecheck`, `lint`, `format:check` — clean
- [x] `npm test` — 92 suites, **1336 tests** pass (+5)
- [x] `npm run smoke` — 125 tools, exit 0
- [x] Drift simulation verified — both TS and Zod catch health-side rename
- [ ] CI (ci + Analyze + CodeQL + new Smoke step)