### PR TITLE
feat(rfc-0007): a0 — MCP tool manifest dump + CI drift guard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,6 +78,9 @@ jobs:
       - name: Smoke — boot server + tools/list round-trip
         run: npm run smoke
 
+      - name: Verify tool manifest (RFC 0007 A.0)
+        run: npm run gen:manifest:check
+
       - name: Verify stats
         run: node scripts/count-stats.mjs --check
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,7 +79,12 @@ jobs:
         run: npm run smoke
 
       - name: Verify tool manifest (RFC 0007 A.0)
-        run: npm run gen:manifest:check
+        run: |
+          npm run gen:manifest
+          echo "--- diff (should be empty) ---"
+          git --no-pager diff --stat docs/tool-manifest.json || true
+          git --no-pager diff docs/tool-manifest.json | head -200 || true
+          git diff --exit-code docs/tool-manifest.json
 
       - name: Verify stats
         run: node scripts/count-stats.mjs --check

--- a/.prettierignore
+++ b/.prettierignore
@@ -3,3 +3,6 @@ coverage/
 node_modules/
 *.mcpb
 package-lock.json
+# RFC 0007 A.0 — generated MCP tool manifest (JSON.stringify output,
+# prettier would reflow short arrays and trip the drift check).
+docs/tool-manifest.json

--- a/docs/tool-manifest.json
+++ b/docs/tool-manifest.json
@@ -1,0 +1,5236 @@
+{
+  "generatedAt": "STABLE_PLACEHOLDER",
+  "protocolVersion": "2025-06-18",
+  "toolCount": 120,
+  "eligibleCount": 117,
+  "tools": [
+    {
+      "name": "audit_log",
+      "title": "Audit Log",
+      "description": "Query the on-device audit log of tool calls.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "since": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Lower-bound ISO 8601 timestamp. Entries older than this are dropped. Defaults to 7 days ago."
+          },
+          "tool": {
+            "type": "string",
+            "maxLength": 120,
+            "description": "Filter to a single tool name (exact match)."
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "ok",
+              "error"
+            ],
+            "description": "Filter by status. Omit to include both."
+          },
+          "limit": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 1000,
+            "default": 100,
+            "description": "Max entries to return (default: 100, max: 1000)."
+          }
+        },
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "outputSchema": {
+        "type": "object",
+        "properties": {
+          "total": {
+            "type": "number"
+          },
+          "returned": {
+            "type": "number"
+          },
+          "scannedFiles": {
+            "type": "number"
+          },
+          "entries": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "timestamp": {
+                  "type": "string"
+                },
+                "tool": {
+                  "type": "string"
+                },
+                "status": {
+                  "type": "string",
+                  "enum": [
+                    "ok",
+                    "error"
+                  ]
+                },
+                "durationMs": {
+                  "type": "number"
+                },
+                "args": {
+                  "type": "object",
+                  "additionalProperties": {}
+                }
+              },
+              "required": [
+                "timestamp",
+                "tool",
+                "status"
+              ],
+              "additionalProperties": false
+            }
+          }
+        },
+        "required": [
+          "total",
+          "returned",
+          "scannedFiles",
+          "entries"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "audit_summary",
+      "title": "Audit Summary",
+      "description": "Aggregate the audit log over a time window — total call count, error rate, an...",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "since": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Lower-bound ISO 8601 timestamp. Defaults to 7 days ago."
+          },
+          "topN": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 50,
+            "default": 10,
+            "description": "Top-N busiest tools (default: 10)."
+          }
+        },
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "outputSchema": {
+        "type": "object",
+        "properties": {
+          "since": {
+            "type": "string"
+          },
+          "total": {
+            "type": "number"
+          },
+          "errors": {
+            "type": "number"
+          },
+          "errorRate": {
+            "type": "number"
+          },
+          "scannedFiles": {
+            "type": "number"
+          },
+          "topTools": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "tool": {
+                  "type": "string"
+                },
+                "count": {
+                  "type": "number"
+                },
+                "errors": {
+                  "type": "number"
+                }
+              },
+              "required": [
+                "tool",
+                "count",
+                "errors"
+              ],
+              "additionalProperties": false
+            }
+          }
+        },
+        "required": [
+          "since",
+          "total",
+          "errors",
+          "errorRate",
+          "scannedFiles",
+          "topTools"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "bulk_move_notes",
+      "title": "Bulk Move Notes",
+      "description": "Move multiple notes to a target folder at once.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "ids": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "maxLength": 500
+            },
+            "minItems": 1,
+            "maxItems": 100,
+            "description": "Array of note IDs to move (max 100)"
+          },
+          "folder": {
+            "type": "string",
+            "maxLength": 500,
+            "description": "Target folder name"
+          }
+        },
+        "required": [
+          "ids",
+          "folder"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": true,
+        "idempotentHint": false,
+        "openWorldHint": false
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "calendar_week_view",
+      "title": "Calendar Week View",
+      "description": "Display an interactive calendar week view showing events for a 7-day period.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "startDate": {
+            "type": "string",
+            "maxLength": 64,
+            "description": "Start date (YYYY-MM-DD). Defaults to current week's Monday."
+          }
+        },
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "capture_screenshot",
+      "title": "Capture Screenshot",
+      "description": "Take a screenshot and save to the specified path.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "path": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 4096,
+            "description": "Absolute file path to save the screenshot (e.g. '/tmp/screenshot.png')"
+          },
+          "region": {
+            "type": "string",
+            "enum": [
+              "fullscreen",
+              "window",
+              "selection"
+            ],
+            "default": "fullscreen",
+            "description": "Capture region: fullscreen (default), window, or selection"
+          }
+        },
+        "required": [
+          "path"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": true,
+        "idempotentHint": false,
+        "openWorldHint": false
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "cloud_sync_status",
+      "title": "iCloud Sync Status",
+      "description": "Check iCloud sync status — see what usage data and config is synced across yo...",
+      "inputSchema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {}
+      },
+      "outputSchema": null,
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "compare_notes",
+      "title": "Compare Notes",
+      "description": "Retrieve full plaintext content of 2-5 notes at once for comparison.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "ids": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "minItems": 2,
+            "maxItems": 5,
+            "description": "Array of 2-5 note IDs to compare"
+          }
+        },
+        "required": [
+          "ids"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "complete_reminder",
+      "title": "Complete Reminder",
+      "description": "Mark a reminder as completed or un-complete it.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "maxLength": 500,
+            "description": "Reminder ID"
+          },
+          "completed": {
+            "type": "boolean",
+            "default": true,
+            "description": "Set to true to complete, false to un-complete (default: true)"
+          }
+        },
+        "required": [
+          "id"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "create_directory",
+      "title": "Create Directory",
+      "description": "Create a new directory (and intermediate directories if needed).",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "path": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 4096,
+            "description": "Absolute path of the folder to create"
+          }
+        },
+        "required": [
+          "path"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "create_event",
+      "title": "Create Event",
+      "description": "Create a new calendar event.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "summary": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 500,
+            "description": "Event title"
+          },
+          "startDate": {
+            "type": "string",
+            "maxLength": 64,
+            "description": "Start date/time (ISO 8601, e.g. '2026-03-15T09:00:00Z')"
+          },
+          "endDate": {
+            "type": "string",
+            "maxLength": 64,
+            "description": "End date/time (ISO 8601, e.g. '2026-03-15T10:00:00Z')"
+          },
+          "location": {
+            "type": "string",
+            "maxLength": 5000,
+            "description": "Event location"
+          },
+          "description": {
+            "type": "string",
+            "maxLength": 5000,
+            "description": "Event notes/description"
+          },
+          "calendar": {
+            "type": "string",
+            "maxLength": 500,
+            "description": "Target calendar name. Defaults to first writable calendar."
+          },
+          "allDay": {
+            "type": "boolean",
+            "description": "Set as all-day event"
+          }
+        },
+        "required": [
+          "summary",
+          "startDate",
+          "endDate"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": false
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "create_folder",
+      "title": "Create Folder",
+      "description": "Create a new folder.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "maxLength": 500,
+            "description": "Folder name"
+          },
+          "account": {
+            "type": "string",
+            "maxLength": 500,
+            "description": "Account name (e.g. 'iCloud'). Defaults to primary account."
+          }
+        },
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "create_note",
+      "title": "Create Note",
+      "description": "Create a new note with HTML body.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "body": {
+            "type": "string",
+            "maxLength": 50000,
+            "description": "Note content in HTML (e.g. '<h1>Title</h1><p>Body text</p>')"
+          },
+          "folder": {
+            "type": "string",
+            "maxLength": 500,
+            "description": "Target folder name"
+          }
+        },
+        "required": [
+          "body"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": false
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "create_recurring_event",
+      "title": "Create Recurring Event",
+      "description": "Create a recurring calendar event via EventKit.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "summary": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 500,
+            "description": "Event title"
+          },
+          "startDate": {
+            "type": "string",
+            "maxLength": 64,
+            "description": "Start date/time (ISO 8601, e.g. '2026-03-15T09:00:00Z')"
+          },
+          "endDate": {
+            "type": "string",
+            "maxLength": 64,
+            "description": "End date/time (ISO 8601, e.g. '2026-03-15T10:00:00Z')"
+          },
+          "location": {
+            "type": "string",
+            "maxLength": 5000,
+            "description": "Event location"
+          },
+          "description": {
+            "type": "string",
+            "maxLength": 5000,
+            "description": "Event notes/description"
+          },
+          "calendar": {
+            "type": "string",
+            "maxLength": 500,
+            "description": "Target calendar name. Defaults to the default calendar."
+          },
+          "recurrence": {
+            "type": "object",
+            "properties": {
+              "frequency": {
+                "type": "string",
+                "enum": [
+                  "daily",
+                  "weekly",
+                  "monthly",
+                  "yearly"
+                ],
+                "description": "Recurrence frequency"
+              },
+              "interval": {
+                "type": "integer",
+                "minimum": 1,
+                "description": "Repeat every N frequency units (e.g. 2 = every 2 weeks)"
+              },
+              "endDate": {
+                "type": "string",
+                "maxLength": 64,
+                "description": "Recurrence end date (ISO 8601, e.g. '2026-12-31T23:59:59Z')"
+              },
+              "count": {
+                "type": "integer",
+                "minimum": 1,
+                "description": "Number of occurrences (alternative to endDate)"
+              },
+              "daysOfWeek": {
+                "type": "array",
+                "items": {
+                  "type": "integer",
+                  "minimum": 1,
+                  "maximum": 7
+                },
+                "description": "Days of week for weekly recurrence (1=Sun, 2=Mon, ..., 7=Sat)"
+              }
+            },
+            "required": [
+              "frequency",
+              "interval"
+            ],
+            "additionalProperties": false,
+            "description": "Recurrence rule"
+          }
+        },
+        "required": [
+          "summary",
+          "startDate",
+          "endDate",
+          "recurrence"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": false
+      },
+      "appIntentEligible": false
+    },
+    {
+      "name": "create_recurring_reminder",
+      "title": "Create Recurring Reminder",
+      "description": "Create a recurring reminder via EventKit.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "title": {
+            "type": "string",
+            "maxLength": 500,
+            "description": "Reminder title"
+          },
+          "list": {
+            "type": "string",
+            "maxLength": 500,
+            "description": "Target reminder list name. Defaults to the default list."
+          },
+          "notes": {
+            "type": "string",
+            "maxLength": 5000,
+            "description": "Reminder notes/body text"
+          },
+          "dueDate": {
+            "type": "string",
+            "maxLength": 64,
+            "description": "Due date (ISO 8601, e.g. '2026-03-15T10:00:00Z')"
+          },
+          "priority": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 9,
+            "description": "Priority: 0=none, 1-4=high, 5=medium, 6-9=low"
+          },
+          "recurrence": {
+            "type": "object",
+            "properties": {
+              "frequency": {
+                "type": "string",
+                "enum": [
+                  "daily",
+                  "weekly",
+                  "monthly",
+                  "yearly"
+                ],
+                "description": "Recurrence frequency"
+              },
+              "interval": {
+                "type": "integer",
+                "minimum": 1,
+                "description": "Repeat every N frequency units (e.g. 2 = every 2 weeks)"
+              },
+              "endDate": {
+                "type": "string",
+                "maxLength": 64,
+                "description": "Recurrence end date (ISO 8601, e.g. '2026-12-31T23:59:59Z')"
+              },
+              "count": {
+                "type": "integer",
+                "minimum": 1,
+                "description": "Number of occurrences (alternative to endDate)"
+              },
+              "daysOfWeek": {
+                "type": "array",
+                "items": {
+                  "type": "integer",
+                  "minimum": 1,
+                  "maximum": 7
+                },
+                "description": "Days of week for weekly recurrence (1=Sun, 2=Mon, ..., 7=Sat)"
+              }
+            },
+            "required": [
+              "frequency",
+              "interval"
+            ],
+            "additionalProperties": false,
+            "description": "Recurrence rule"
+          }
+        },
+        "required": [
+          "title",
+          "recurrence"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": false
+      },
+      "appIntentEligible": false
+    },
+    {
+      "name": "create_reminder",
+      "title": "Create Reminder",
+      "description": "Create a new reminder.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "title": {
+            "type": "string",
+            "maxLength": 500,
+            "description": "Reminder title"
+          },
+          "body": {
+            "type": "string",
+            "maxLength": 5000,
+            "description": "Notes/body text"
+          },
+          "dueDate": {
+            "type": "string",
+            "maxLength": 64,
+            "description": "Due date in ISO 8601 format (e.g. '2026-03-15T10:00:00Z')"
+          },
+          "priority": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 9,
+            "description": "Priority: 0=none, 1-4=high, 5=medium, 6-9=low"
+          },
+          "list": {
+            "type": "string",
+            "maxLength": 500,
+            "description": "Target list name. Defaults to the default list."
+          }
+        },
+        "required": [
+          "title"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": false
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "create_reminder_list",
+      "title": "Create Reminder List",
+      "description": "Create a new reminder list.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "maxLength": 500,
+            "description": "Name for the new list"
+          }
+        },
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": false
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "create_shortcut",
+      "title": "Create Shortcut",
+      "description": "Create a new Siri Shortcut by name.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "maxLength": 500,
+            "description": "Name for the new shortcut"
+          }
+        },
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": true
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "delete_event",
+      "title": "Delete Event",
+      "description": "Delete a calendar event by ID.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "maxLength": 500,
+            "description": "Event UID"
+          }
+        },
+        "required": [
+          "id"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": true,
+        "idempotentHint": true,
+        "openWorldHint": false
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "delete_note",
+      "title": "Delete Note",
+      "description": "Delete a note by ID.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "maxLength": 500,
+            "description": "Note ID (x-coredata:// format)"
+          }
+        },
+        "required": [
+          "id"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": true,
+        "idempotentHint": true,
+        "openWorldHint": false
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "delete_reminder",
+      "title": "Delete Reminder",
+      "description": "Delete a reminder by ID.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "maxLength": 500,
+            "description": "Reminder ID"
+          }
+        },
+        "required": [
+          "id"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": true,
+        "idempotentHint": true,
+        "openWorldHint": false
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "delete_reminder_list",
+      "title": "Delete Reminder List",
+      "description": "Delete a reminder list by name.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "maxLength": 500,
+            "description": "Name of the list to delete"
+          }
+        },
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": true,
+        "idempotentHint": true,
+        "openWorldHint": false
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "delete_shortcut",
+      "title": "Delete Shortcut",
+      "description": "Delete a Siri Shortcut by name.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "maxLength": 500,
+            "description": "Shortcut name to delete (exact match)"
+          }
+        },
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": true,
+        "idempotentHint": false,
+        "openWorldHint": false
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "discover_tools",
+      "title": "Discover Tools",
+      "description": "Search available tools by keyword.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "query": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 500,
+            "description": "Search query — e.g. 'calendar', 'send email', 'music playback'"
+          },
+          "limit": {
+            "type": "number",
+            "minimum": 1,
+            "maximum": 50,
+            "description": "Max results (default 20)"
+          }
+        },
+        "required": [
+          "query"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "outputSchema": {
+        "type": "object",
+        "properties": {
+          "query": {
+            "type": "string"
+          },
+          "matches": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                },
+                "description": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "name"
+              ],
+              "additionalProperties": false
+            }
+          },
+          "total": {
+            "type": "number"
+          },
+          "method": {
+            "type": "string"
+          },
+          "hint": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "query",
+          "matches"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "duplicate_shortcut",
+      "title": "Duplicate Shortcut",
+      "description": "Duplicate an existing Siri Shortcut.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "maxLength": 500,
+            "description": "Name of the shortcut to duplicate (exact match)"
+          },
+          "newName": {
+            "type": "string",
+            "maxLength": 500,
+            "description": "Name for the duplicated shortcut"
+          }
+        },
+        "required": [
+          "name",
+          "newName"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": false
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "edit_shortcut",
+      "title": "Edit Shortcut",
+      "description": "Open a Siri Shortcut in the Shortcuts app for manual editing.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "maxLength": 500,
+            "description": "Shortcut name to edit (exact match)"
+          }
+        },
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": true
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "event_status",
+      "title": "Event Monitor Status",
+      "description": "Check if real-time event monitoring is active.",
+      "inputSchema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {}
+      },
+      "outputSchema": null,
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "event_subscribe",
+      "title": "Subscribe to Events",
+      "description": "Start real-time monitoring of Apple data changes: calendar, reminders, clipbo...",
+      "inputSchema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {}
+      },
+      "outputSchema": null,
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": false
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "export_shortcut",
+      "title": "Export Shortcut",
+      "description": "Export a Siri Shortcut to a .shortcut file.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "maxLength": 500,
+            "description": "Shortcut name to export (exact match)"
+          },
+          "outputPath": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 4096,
+            "description": "File path to export the .shortcut file to (e.g. ~/Desktop/MyShortcut.shortcut)"
+          }
+        },
+        "required": [
+          "name",
+          "outputPath"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "find_related",
+      "title": "Find Related Items",
+      "description": "Given a note, event, reminder, or email ID, find semantically related items a...",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "maxLength": 500,
+            "description": "Item ID (as stored in the vector index)"
+          },
+          "limit": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 50,
+            "description": "Max results (default 10)"
+          },
+          "threshold": {
+            "type": "number",
+            "minimum": 0,
+            "maximum": 1,
+            "description": "Minimum similarity (default 0.6)"
+          }
+        },
+        "required": [
+          "id"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "get_battery_status",
+      "title": "Get Battery Status",
+      "description": "Get battery percentage, charging state, power source, and estimated time rema...",
+      "inputSchema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {}
+      },
+      "outputSchema": null,
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "get_brightness",
+      "title": "Get Brightness",
+      "description": "Get the current display brightness level.",
+      "inputSchema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {}
+      },
+      "outputSchema": null,
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "get_clipboard",
+      "title": "Get Clipboard",
+      "description": "Read the current text content of the system clipboard.",
+      "inputSchema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {}
+      },
+      "outputSchema": {
+        "type": "object",
+        "properties": {
+          "content": {
+            "type": "string"
+          },
+          "length": {
+            "type": "number"
+          },
+          "truncated": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "content",
+          "length",
+          "truncated"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "get_current_weather",
+      "title": "Get Current Weather",
+      "description": "Get current weather conditions for a location using coordinates.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "latitude": {
+            "type": "number",
+            "minimum": -90,
+            "maximum": 90,
+            "description": "Latitude coordinate"
+          },
+          "longitude": {
+            "type": "number",
+            "minimum": -180,
+            "maximum": 180,
+            "description": "Longitude coordinate"
+          }
+        },
+        "required": [
+          "latitude",
+          "longitude"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "outputSchema": {
+        "type": "object",
+        "properties": {
+          "temperature": {
+            "type": "number",
+            "description": "Current temperature in Celsius"
+          },
+          "feelsLike": {
+            "type": "number",
+            "description": "Apparent temperature in Celsius"
+          },
+          "humidity": {
+            "type": "number",
+            "description": "Relative humidity percentage"
+          },
+          "weatherCode": {
+            "type": "number",
+            "description": "WMO weather code"
+          },
+          "weatherDescription": {
+            "type": "string",
+            "maxLength": 5000,
+            "description": "Human-readable weather description"
+          },
+          "windSpeed": {
+            "type": "number",
+            "description": "Wind speed in km/h"
+          },
+          "windDirection": {
+            "type": "number",
+            "description": "Wind direction in degrees"
+          },
+          "precipitation": {
+            "type": "number",
+            "description": "Precipitation in mm"
+          },
+          "cloudCover": {
+            "type": "number",
+            "description": "Cloud cover percentage"
+          },
+          "units": {
+            "type": "object",
+            "properties": {
+              "temperature": {
+                "type": "string"
+              },
+              "windSpeed": {
+                "type": "string"
+              },
+              "precipitation": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "temperature",
+              "windSpeed",
+              "precipitation"
+            ],
+            "additionalProperties": false,
+            "description": "Units for numeric values"
+          }
+        },
+        "required": [
+          "temperature",
+          "feelsLike",
+          "humidity",
+          "weatherCode",
+          "weatherDescription",
+          "windSpeed",
+          "windDirection",
+          "precipitation",
+          "cloudCover",
+          "units"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "get_daily_forecast",
+      "title": "Get Daily Forecast",
+      "description": "Get daily weather forecast for a location.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "latitude": {
+            "type": "number",
+            "minimum": -90,
+            "maximum": 90,
+            "description": "Latitude coordinate"
+          },
+          "longitude": {
+            "type": "number",
+            "minimum": -180,
+            "maximum": 180,
+            "description": "Longitude coordinate"
+          },
+          "days": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 16,
+            "default": 7,
+            "description": "Number of forecast days (default: 7)"
+          }
+        },
+        "required": [
+          "latitude",
+          "longitude"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "get_file_info",
+      "title": "Get File Info",
+      "description": "Get detailed file information including size, dates, kind, and tags.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "path": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 4096,
+            "description": "Absolute file path"
+          }
+        },
+        "required": [
+          "path"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "outputSchema": {
+        "type": "object",
+        "properties": {
+          "path": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "kind": {
+            "type": "string"
+          },
+          "size": {
+            "type": "number"
+          },
+          "creationDate": {
+            "type": "string"
+          },
+          "modificationDate": {
+            "type": "string"
+          },
+          "tags": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        },
+        "required": [
+          "path",
+          "name",
+          "kind",
+          "size",
+          "creationDate",
+          "modificationDate",
+          "tags"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "get_frontmost_app",
+      "title": "Get Frontmost App",
+      "description": "Get the name, bundle identifier, and PID of the currently active (frontmost) ...",
+      "inputSchema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {}
+      },
+      "outputSchema": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "bundleIdentifier": {
+            "type": "string"
+          },
+          "pid": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "name",
+          "bundleIdentifier",
+          "pid"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "get_hourly_forecast",
+      "title": "Get Hourly Forecast",
+      "description": "Get hourly weather forecast for a location.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "latitude": {
+            "type": "number",
+            "minimum": -90,
+            "maximum": 90,
+            "description": "Latitude coordinate"
+          },
+          "longitude": {
+            "type": "number",
+            "minimum": -180,
+            "maximum": 180,
+            "description": "Longitude coordinate"
+          },
+          "hours": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 168,
+            "default": 24,
+            "description": "Number of forecast hours (default: 24)"
+          }
+        },
+        "required": [
+          "latitude",
+          "longitude"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "get_screen_info",
+      "title": "Get Screen Info",
+      "description": "Get display information including resolution, pixel dimensions, and Retina st...",
+      "inputSchema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {}
+      },
+      "outputSchema": null,
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "get_shortcut_detail",
+      "title": "Get Shortcut Detail",
+      "description": "Get details about a Siri Shortcut including its actions.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "maxLength": 500,
+            "description": "Shortcut name (exact match)"
+          }
+        },
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "outputSchema": {
+        "type": "object",
+        "properties": {
+          "shortcut": {
+            "type": "string"
+          },
+          "detail": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "shortcut",
+          "detail"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "get_upcoming_events",
+      "title": "Get Upcoming Events",
+      "description": "Get the next N upcoming events from now (searches up to 30 days ahead).",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "limit": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 500,
+            "default": 10,
+            "description": "Max events to return (default: 10)"
+          }
+        },
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "outputSchema": {
+        "type": "object",
+        "properties": {
+          "total": {
+            "type": "number"
+          },
+          "returned": {
+            "type": "number"
+          },
+          "events": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string"
+                },
+                "summary": {
+                  "type": "string"
+                },
+                "startDate": {
+                  "type": "string"
+                },
+                "endDate": {
+                  "type": "string"
+                },
+                "allDay": {
+                  "type": "boolean"
+                },
+                "calendar": {
+                  "type": "string"
+                },
+                "location": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "id",
+                "summary",
+                "startDate",
+                "endDate",
+                "allDay",
+                "calendar",
+                "location"
+              ],
+              "additionalProperties": false
+            }
+          }
+        },
+        "required": [
+          "total",
+          "returned",
+          "events"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "get_volume",
+      "title": "Get Volume",
+      "description": "Get the current system output volume level and mute state.",
+      "inputSchema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {}
+      },
+      "outputSchema": {
+        "type": "object",
+        "properties": {
+          "outputVolume": {
+            "type": "number"
+          },
+          "inputVolume": {
+            "type": "number"
+          },
+          "outputMuted": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "outputVolume",
+          "inputVolume",
+          "outputMuted"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "get_wifi_status",
+      "title": "Get WiFi Status",
+      "description": "Get the current WiFi status including connected network name, signal strength...",
+      "inputSchema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {}
+      },
+      "outputSchema": null,
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "get_workflow",
+      "title": "Get Workflow",
+      "description": "Retrieve a registered MCP prompt by name and return its workflow instructions...",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 500,
+            "description": "Prompt name (e.g. 'daily-briefing', 'dev-session')"
+          },
+          "args": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            },
+            "description": "Prompt arguments as key-value pairs"
+          }
+        },
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false
+      },
+      "appIntentEligible": false
+    },
+    {
+      "name": "import_shortcut",
+      "title": "Import Shortcut",
+      "description": "Import a .shortcut file into Siri Shortcuts.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "filePath": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 4096,
+            "description": "Path to the .shortcut file to import"
+          }
+        },
+        "required": [
+          "filePath"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": false
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "is_app_running",
+      "title": "Is App Running",
+      "description": "Check whether an application is currently running.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 500,
+            "description": "Application name to check (e.g. 'Safari')"
+          }
+        },
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "launch_app",
+      "title": "Launch App",
+      "description": "Launch an application by name.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 500,
+            "description": "Application name (e.g. 'Safari', 'Xcode') or bundle ID"
+          }
+        },
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "list_all_windows",
+      "title": "List All Windows",
+      "description": "List windows across all running applications with title, size, position, app ...",
+      "inputSchema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {}
+      },
+      "outputSchema": null,
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "list_bluetooth_devices",
+      "title": "List Bluetooth Devices",
+      "description": "List paired Bluetooth devices with their connection status.",
+      "inputSchema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {}
+      },
+      "outputSchema": null,
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "list_calendars",
+      "title": "List Calendars",
+      "description": "List all calendars with name, color, and writable status.",
+      "inputSchema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {}
+      },
+      "outputSchema": {
+        "type": "object",
+        "properties": {
+          "calendars": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string"
+                },
+                "name": {
+                  "type": "string"
+                },
+                "color": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "writable": {
+                  "type": "boolean"
+                }
+              },
+              "required": [
+                "id",
+                "name",
+                "color",
+                "writable"
+              ],
+              "additionalProperties": false
+            }
+          }
+        },
+        "required": [
+          "calendars"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "list_directory",
+      "title": "List Directory",
+      "description": "List files and folders in a directory with metadata (kind, size, modification...",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "path": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 4096,
+            "description": "Absolute directory path"
+          },
+          "limit": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 500,
+            "default": 100,
+            "description": "Max items to return (default: 100)"
+          }
+        },
+        "required": [
+          "path"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "outputSchema": {
+        "type": "object",
+        "properties": {
+          "total": {
+            "type": "number"
+          },
+          "returned": {
+            "type": "number"
+          },
+          "items": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string"
+                },
+                "kind": {
+                  "type": "string"
+                },
+                "size": {
+                  "type": "number"
+                },
+                "modificationDate": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "name",
+                "kind"
+              ],
+              "additionalProperties": false
+            }
+          }
+        },
+        "required": [
+          "total",
+          "returned",
+          "items"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "list_events",
+      "title": "List Events",
+      "description": "List events within a date range.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "startDate": {
+            "type": "string",
+            "maxLength": 64,
+            "description": "Start of range (ISO 8601, e.g. '2026-03-01T00:00:00Z')"
+          },
+          "endDate": {
+            "type": "string",
+            "maxLength": 64,
+            "description": "End of range (ISO 8601, e.g. '2026-03-31T23:59:59Z')"
+          },
+          "calendar": {
+            "type": "string",
+            "maxLength": 500,
+            "description": "Filter by calendar name"
+          },
+          "limit": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 1000,
+            "default": 100,
+            "description": "Max events to return (default: 100)"
+          },
+          "offset": {
+            "type": "integer",
+            "minimum": 0,
+            "default": 0,
+            "description": "Number of events to skip (default: 0)"
+          }
+        },
+        "required": [
+          "startDate",
+          "endDate"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "outputSchema": {
+        "type": "object",
+        "properties": {
+          "total": {
+            "type": "number"
+          },
+          "offset": {
+            "type": "number"
+          },
+          "returned": {
+            "type": "number"
+          },
+          "events": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string"
+                },
+                "summary": {
+                  "type": "string"
+                },
+                "startDate": {
+                  "type": "string"
+                },
+                "endDate": {
+                  "type": "string"
+                },
+                "allDay": {
+                  "type": "boolean"
+                },
+                "calendar": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "id",
+                "summary",
+                "startDate",
+                "endDate",
+                "allDay",
+                "calendar"
+              ],
+              "additionalProperties": false
+            }
+          }
+        },
+        "required": [
+          "total",
+          "offset",
+          "returned",
+          "events"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "list_folders",
+      "title": "List Folders",
+      "description": "List all folders across all accounts with note counts.",
+      "inputSchema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {}
+      },
+      "outputSchema": {
+        "type": "object",
+        "properties": {
+          "folders": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string"
+                },
+                "name": {
+                  "type": "string"
+                },
+                "account": {
+                  "type": "string"
+                },
+                "noteCount": {
+                  "type": "number"
+                },
+                "shared": {
+                  "type": "boolean"
+                }
+              },
+              "required": [
+                "id",
+                "name",
+                "account",
+                "noteCount",
+                "shared"
+              ],
+              "additionalProperties": false
+            }
+          }
+        },
+        "required": [
+          "folders"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "list_notes",
+      "title": "List Notes",
+      "description": "List all notes with title, folder, and dates.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "folder": {
+            "type": "string",
+            "maxLength": 500,
+            "description": "Filter by folder name"
+          },
+          "limit": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 1000,
+            "default": 200,
+            "description": "Max number of notes to return (default: 200)"
+          },
+          "offset": {
+            "type": "integer",
+            "minimum": 0,
+            "default": 0,
+            "description": "Number of notes to skip for pagination (default: 0)"
+          }
+        },
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "outputSchema": {
+        "type": "object",
+        "properties": {
+          "total": {
+            "type": "number"
+          },
+          "offset": {
+            "type": "number"
+          },
+          "returned": {
+            "type": "number"
+          },
+          "notes": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string"
+                },
+                "name": {
+                  "type": "string"
+                },
+                "folder": {
+                  "type": "string"
+                },
+                "shared": {
+                  "type": "boolean"
+                },
+                "creationDate": {
+                  "type": "string"
+                },
+                "modificationDate": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "id",
+                "name",
+                "folder",
+                "shared",
+                "creationDate",
+                "modificationDate"
+              ],
+              "additionalProperties": false
+            }
+          }
+        },
+        "required": [
+          "total",
+          "offset",
+          "returned",
+          "notes"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "list_reminder_lists",
+      "title": "List Reminder Lists",
+      "description": "List all reminder lists with reminder counts.",
+      "inputSchema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {}
+      },
+      "outputSchema": {
+        "type": "object",
+        "properties": {
+          "lists": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string"
+                },
+                "name": {
+                  "type": "string"
+                },
+                "reminderCount": {
+                  "type": "number"
+                }
+              },
+              "required": [
+                "id",
+                "name",
+                "reminderCount"
+              ],
+              "additionalProperties": false
+            }
+          }
+        },
+        "required": [
+          "lists"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "list_reminders",
+      "title": "List Reminders",
+      "description": "List reminders.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "list": {
+            "type": "string",
+            "maxLength": 500,
+            "description": "Filter by list name"
+          },
+          "completed": {
+            "type": "boolean",
+            "description": "Filter by completed status (true/false). Omit to list all."
+          },
+          "limit": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 1000,
+            "default": 200,
+            "description": "Max number of reminders to return (default: 200)"
+          },
+          "offset": {
+            "type": "integer",
+            "minimum": 0,
+            "default": 0,
+            "description": "Number of reminders to skip for pagination (default: 0)"
+          }
+        },
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "outputSchema": {
+        "type": "object",
+        "properties": {
+          "total": {
+            "type": "number"
+          },
+          "offset": {
+            "type": "number"
+          },
+          "returned": {
+            "type": "number"
+          },
+          "reminders": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string"
+                },
+                "name": {
+                  "type": "string"
+                },
+                "completed": {
+                  "type": "boolean"
+                },
+                "dueDate": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "priority": {
+                  "type": "number"
+                },
+                "flagged": {
+                  "type": "boolean"
+                },
+                "list": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "id",
+                "name",
+                "completed",
+                "dueDate",
+                "priority",
+                "flagged",
+                "list"
+              ],
+              "additionalProperties": false
+            }
+          }
+        },
+        "required": [
+          "total",
+          "offset",
+          "returned",
+          "reminders"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "list_running_apps",
+      "title": "List Running Apps",
+      "description": "List all running applications with name, bundle identifier, PID, and visibility.",
+      "inputSchema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {}
+      },
+      "outputSchema": null,
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "list_shortcuts",
+      "title": "List Shortcuts",
+      "description": "List all available Siri Shortcuts on this Mac.",
+      "inputSchema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {}
+      },
+      "outputSchema": {
+        "type": "object",
+        "properties": {
+          "total": {
+            "type": "number"
+          },
+          "shortcuts": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        },
+        "required": [
+          "total",
+          "shortcuts"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "list_triggers",
+      "title": "List Event Triggers",
+      "description": "Show all skills with event triggers (calendar_changed, reminders_changed, pas...",
+      "inputSchema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {}
+      },
+      "outputSchema": null,
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "local_llm_generate",
+      "title": "Local LLM Generate",
+      "description": "Generate text using a local Ollama model.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "prompt": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 10000,
+            "description": "The prompt to send to the local LLM"
+          },
+          "model": {
+            "type": "string",
+            "maxLength": 500,
+            "description": "Ollama model name (default: llama3.2)"
+          },
+          "system": {
+            "type": "string",
+            "maxLength": 10000,
+            "description": "System instruction for the model"
+          }
+        },
+        "required": [
+          "prompt"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": true
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "local_llm_status",
+      "title": "Local LLM Status",
+      "description": "Check if a local Ollama LLM is available and list installed models.",
+      "inputSchema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {}
+      },
+      "outputSchema": null,
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "memory_forget",
+      "title": "Forget Memory Entries",
+      "description": "Delete context-memory entries.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Exact entry id to remove"
+          },
+          "key": {
+            "type": "string",
+            "description": "Delete all entries with this key"
+          },
+          "tag": {
+            "type": "string",
+            "description": "Delete all entries tagged with this label"
+          },
+          "kind": {
+            "type": "string",
+            "enum": [
+              "fact",
+              "entity",
+              "episode"
+            ],
+            "description": "Only delete entries of this kind"
+          }
+        },
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "outputSchema": {
+        "type": "object",
+        "properties": {
+          "removed": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "count": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "removed",
+          "count"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": true,
+        "idempotentHint": true,
+        "openWorldHint": false
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "memory_put",
+      "title": "Remember a Fact, Entity, or Episode",
+      "description": "Insert or update a context-memory entry.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "kind": {
+            "type": "string",
+            "enum": [
+              "fact",
+              "entity",
+              "episode"
+            ],
+            "description": "Entry category: fact | entity | episode"
+          },
+          "key": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Stable label (e.g. 'favorite_editor', 'person:Ada')"
+          },
+          "value": {
+            "type": "string",
+            "description": "Payload. JSON-stringify structured data upstream."
+          },
+          "id": {
+            "type": "string",
+            "description": "Override the default `${kind}:${key}` id"
+          },
+          "tags": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Optional tags for later filtering"
+          },
+          "source": {
+            "type": "string",
+            "description": "Originator — tool name, skill id, 'user' …"
+          },
+          "ttl_ms": {
+            "type": "integer",
+            "exclusiveMinimum": 0,
+            "description": "Self-expire after N milliseconds"
+          }
+        },
+        "required": [
+          "kind",
+          "key",
+          "value"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "outputSchema": {
+        "type": "object",
+        "properties": {
+          "stored": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "string"
+              },
+              "kind": {
+                "type": "string",
+                "enum": [
+                  "fact",
+                  "entity",
+                  "episode"
+                ]
+              },
+              "key": {
+                "type": "string"
+              },
+              "value": {
+                "type": "string"
+              },
+              "tags": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "source": {
+                "type": "string"
+              },
+              "createdAt": {
+                "type": "string"
+              },
+              "updatedAt": {
+                "type": "string"
+              },
+              "expiresAt": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "id",
+              "kind",
+              "key",
+              "value",
+              "tags",
+              "createdAt",
+              "updatedAt"
+            ],
+            "additionalProperties": false
+          }
+        },
+        "required": [
+          "stored"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "memory_query",
+      "title": "Query Context Memory",
+      "description": "List non-expired memory entries.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "kind": {
+            "type": "string",
+            "enum": [
+              "fact",
+              "entity",
+              "episode"
+            ],
+            "description": "Restrict to one kind"
+          },
+          "contains": {
+            "type": "string",
+            "description": "Case-insensitive substring in key or value"
+          },
+          "tags": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Match entries carrying ALL given tags"
+          },
+          "limit": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 500,
+            "description": "Max rows (default 50, cap 500)"
+          },
+          "order": {
+            "type": "string",
+            "enum": [
+              "desc",
+              "asc"
+            ],
+            "description": "Sort by updatedAt (default desc)"
+          }
+        },
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "outputSchema": {
+        "type": "object",
+        "properties": {
+          "total": {
+            "type": "number"
+          },
+          "entries": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string"
+                },
+                "kind": {
+                  "type": "string",
+                  "enum": [
+                    "fact",
+                    "entity",
+                    "episode"
+                  ]
+                },
+                "key": {
+                  "type": "string"
+                },
+                "value": {
+                  "type": "string"
+                },
+                "tags": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "source": {
+                  "type": "string"
+                },
+                "createdAt": {
+                  "type": "string"
+                },
+                "updatedAt": {
+                  "type": "string"
+                },
+                "expiresAt": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "id",
+                "kind",
+                "key",
+                "value",
+                "tags",
+                "createdAt",
+                "updatedAt"
+              ],
+              "additionalProperties": false
+            }
+          }
+        },
+        "required": [
+          "total",
+          "entries"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "memory_stats",
+      "title": "Context Memory Stats",
+      "description": "Summarize the context-memory store: counts by kind, oldest/newest timestamps,...",
+      "inputSchema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {}
+      },
+      "outputSchema": {
+        "type": "object",
+        "properties": {
+          "total": {
+            "type": "number"
+          },
+          "byKind": {
+            "type": "object",
+            "properties": {
+              "fact": {
+                "type": "number"
+              },
+              "entity": {
+                "type": "number"
+              },
+              "episode": {
+                "type": "number"
+              }
+            },
+            "required": [
+              "fact",
+              "entity",
+              "episode"
+            ],
+            "additionalProperties": false
+          },
+          "oldest": {
+            "type": "string"
+          },
+          "newest": {
+            "type": "string"
+          },
+          "expiredSwept": {
+            "type": "number"
+          },
+          "path": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "total",
+          "byKind",
+          "expiredSwept",
+          "path"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "minimize_window",
+      "title": "Minimize Window",
+      "description": "Minimize or restore a window.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "appName": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 500,
+            "description": "Application name (e.g. 'Safari')"
+          },
+          "restore": {
+            "type": "boolean",
+            "default": false,
+            "description": "Set true to restore (un-minimize) instead of minimizing"
+          },
+          "windowTitle": {
+            "type": "string",
+            "maxLength": 500,
+            "description": "Specific window title. If omitted, targets the first window."
+          }
+        },
+        "required": [
+          "appName"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "move_file",
+      "title": "Move File",
+      "description": "Move or rename a file or folder to a new location.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "source": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 4096,
+            "description": "Absolute path of the file or folder to move"
+          },
+          "destination": {
+            "$ref": "#/properties/source",
+            "description": "Absolute destination path"
+          }
+        },
+        "required": [
+          "source",
+          "destination"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": true,
+        "idempotentHint": false,
+        "openWorldHint": false
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "move_note",
+      "title": "Move Note",
+      "description": "Move a note to a different folder.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "maxLength": 500,
+            "description": "Note ID to move"
+          },
+          "folder": {
+            "type": "string",
+            "maxLength": 500,
+            "description": "Target folder name"
+          }
+        },
+        "required": [
+          "id",
+          "folder"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": true,
+        "idempotentHint": false,
+        "openWorldHint": false
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "move_window",
+      "title": "Move Window",
+      "description": "Move a window to a specific position on screen.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "appName": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 500,
+            "description": "Application name (e.g. 'Safari')"
+          },
+          "x": {
+            "type": "integer",
+            "description": "X coordinate for top-left corner"
+          },
+          "y": {
+            "type": "integer",
+            "description": "Y coordinate for top-left corner"
+          },
+          "windowTitle": {
+            "type": "string",
+            "maxLength": 500,
+            "description": "Specific window title. If omitted, targets the first window."
+          }
+        },
+        "required": [
+          "appName",
+          "x",
+          "y"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "prevent_sleep",
+      "title": "Prevent Sleep",
+      "description": "Prevent the Mac from sleeping for a specified duration using caffeinate.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "seconds": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 86400,
+            "default": 3600,
+            "description": "Duration in seconds (default: 3600 = 1 hour, max: 86400 = 24 hours)"
+          }
+        },
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": false
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "proactive_context",
+      "title": "Proactive Context",
+      "description": "Get contextually relevant tool and workflow suggestions based on time of day,...",
+      "inputSchema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {}
+      },
+      "outputSchema": {
+        "type": "object",
+        "properties": {
+          "timeContext": {
+            "type": "object",
+            "properties": {
+              "period": {
+                "type": "string",
+                "enum": [
+                  "morning",
+                  "afternoon",
+                  "evening",
+                  "night"
+                ]
+              },
+              "hour": {
+                "type": "number"
+              },
+              "isWeekend": {
+                "type": "boolean"
+              }
+            },
+            "required": [
+              "period",
+              "hour",
+              "isWeekend"
+            ],
+            "additionalProperties": false
+          },
+          "suggestedTools": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "tool": {
+                  "type": "string"
+                },
+                "reason": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "tool",
+                "reason"
+              ],
+              "additionalProperties": false
+            }
+          },
+          "suggestedWorkflows": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        },
+        "required": [
+          "timeContext",
+          "suggestedTools",
+          "suggestedWorkflows"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "quit_app",
+      "title": "Quit App",
+      "description": "Quit a running application by name.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 500,
+            "description": "Application name (e.g. 'Safari')"
+          }
+        },
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": true,
+        "idempotentHint": true,
+        "openWorldHint": false
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "read_event",
+      "title": "Read Event",
+      "description": "Read full details of a calendar event by ID.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "maxLength": 500,
+            "description": "Event UID"
+          }
+        },
+        "required": [
+          "id"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "outputSchema": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "summary": {
+            "type": "string"
+          },
+          "description": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "location": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "startDate": {
+            "type": "string"
+          },
+          "endDate": {
+            "type": "string"
+          },
+          "allDay": {
+            "type": "boolean"
+          },
+          "recurrence": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "url": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "calendar": {
+            "type": "string"
+          },
+          "attendees": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "email": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "status": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                }
+              },
+              "required": [
+                "name",
+                "email",
+                "status"
+              ],
+              "additionalProperties": false
+            }
+          }
+        },
+        "required": [
+          "id",
+          "summary",
+          "description",
+          "location",
+          "startDate",
+          "endDate",
+          "allDay",
+          "recurrence",
+          "url",
+          "calendar",
+          "attendees"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "read_note",
+      "title": "Read Note",
+      "description": "Read the full content of a specific note by its ID.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "maxLength": 500,
+            "description": "Note ID (x-coredata:// format)"
+          }
+        },
+        "required": [
+          "id"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "outputSchema": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "body": {
+            "type": "string"
+          },
+          "plaintext": {
+            "type": "string"
+          },
+          "creationDate": {
+            "type": "string"
+          },
+          "modificationDate": {
+            "type": "string"
+          },
+          "folder": {
+            "type": "string"
+          },
+          "shared": {
+            "type": "boolean"
+          },
+          "passwordProtected": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "body",
+          "plaintext",
+          "creationDate",
+          "modificationDate",
+          "folder",
+          "shared",
+          "passwordProtected"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "read_reminder",
+      "title": "Read Reminder",
+      "description": "Read the full details of a specific reminder by ID.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "maxLength": 500,
+            "description": "Reminder ID"
+          }
+        },
+        "required": [
+          "id"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "outputSchema": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "body": {
+            "type": "string"
+          },
+          "completed": {
+            "type": "boolean"
+          },
+          "completionDate": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "creationDate": {
+            "type": "string"
+          },
+          "modificationDate": {
+            "type": "string"
+          },
+          "dueDate": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "priority": {
+            "type": "number"
+          },
+          "flagged": {
+            "type": "boolean"
+          },
+          "list": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "body",
+          "completed",
+          "completionDate",
+          "creationDate",
+          "modificationDate",
+          "dueDate",
+          "priority",
+          "flagged",
+          "list"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "recent_files",
+      "title": "Recent Files",
+      "description": "Find recently modified files in a folder using Spotlight.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "folder": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 4096,
+            "default": "~",
+            "description": "Folder to search (default: home)"
+          },
+          "days": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 365,
+            "default": 7,
+            "description": "Modified within N days (default: 7)"
+          },
+          "limit": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 200,
+            "default": 30,
+            "description": "Max results (default: 30)"
+          }
+        },
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "resize_window",
+      "title": "Resize Window",
+      "description": "Resize a window to specific dimensions.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "appName": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 500,
+            "description": "Application name (e.g. 'Safari')"
+          },
+          "width": {
+            "type": "integer",
+            "minimum": 1,
+            "description": "Window width in pixels"
+          },
+          "height": {
+            "type": "integer",
+            "minimum": 1,
+            "description": "Window height in pixels"
+          },
+          "windowTitle": {
+            "type": "string",
+            "maxLength": 500,
+            "description": "Specific window title. If omitted, targets the first window."
+          }
+        },
+        "required": [
+          "appName",
+          "width",
+          "height"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "run_shortcut",
+      "title": "Run Shortcut",
+      "description": "Run a Siri Shortcut by name.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "maxLength": 500,
+            "description": "Shortcut name (exact match)"
+          },
+          "input": {
+            "type": "string",
+            "maxLength": 10000,
+            "description": "Optional text input for the shortcut"
+          }
+        },
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": true,
+        "idempotentHint": false,
+        "openWorldHint": true
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "scan_notes",
+      "title": "Scan Notes",
+      "description": "Bulk scan notes returning metadata and a text preview for each.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "folder": {
+            "type": "string",
+            "maxLength": 500,
+            "description": "Filter by folder name. Omit to scan all notes."
+          },
+          "limit": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 500,
+            "default": 100,
+            "description": "Max number of notes to return (default: 100)"
+          },
+          "offset": {
+            "type": "integer",
+            "minimum": 0,
+            "default": 0,
+            "description": "Number of notes to skip for pagination (default: 0)"
+          },
+          "previewLength": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 5000,
+            "default": 300,
+            "description": "Preview text length in characters (default: 300)"
+          }
+        },
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "search_events",
+      "title": "Search Events",
+      "description": "Search events by keyword in title or description within a date range.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "query": {
+            "type": "string",
+            "maxLength": 500,
+            "description": "Search keyword"
+          },
+          "startDate": {
+            "type": "string",
+            "maxLength": 64,
+            "description": "Start of range (ISO 8601, e.g. '2026-03-01T00:00:00Z')"
+          },
+          "endDate": {
+            "type": "string",
+            "maxLength": 64,
+            "description": "End of range (ISO 8601, e.g. '2026-03-31T23:59:59Z')"
+          },
+          "limit": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 500,
+            "default": 50,
+            "description": "Max results (default: 50)"
+          }
+        },
+        "required": [
+          "query",
+          "startDate",
+          "endDate"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "outputSchema": {
+        "type": "object",
+        "properties": {
+          "total": {
+            "type": "number"
+          },
+          "events": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string"
+                },
+                "summary": {
+                  "type": "string"
+                },
+                "startDate": {
+                  "type": "string"
+                },
+                "endDate": {
+                  "type": "string"
+                },
+                "allDay": {
+                  "type": "boolean"
+                },
+                "calendar": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "id",
+                "summary",
+                "startDate",
+                "endDate",
+                "allDay",
+                "calendar"
+              ],
+              "additionalProperties": false
+            }
+          }
+        },
+        "required": [
+          "total",
+          "events"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "search_files",
+      "title": "Search Files",
+      "description": "Search files using Spotlight (mdfind).",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "query": {
+            "type": "string",
+            "maxLength": 500,
+            "description": "Search query (Spotlight syntax)"
+          },
+          "folder": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 4096,
+            "default": "~",
+            "description": "Folder to search in (default: home)"
+          },
+          "limit": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 200,
+            "default": 50,
+            "description": "Max results (default: 50)"
+          }
+        },
+        "required": [
+          "query"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "search_notes",
+      "title": "Search Notes",
+      "description": "Search notes by keyword in title and body.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "query": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 500,
+            "description": "Search keyword"
+          },
+          "limit": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 500,
+            "default": 50,
+            "description": "Max results to return (default: 50)"
+          },
+          "offset": {
+            "type": "integer",
+            "minimum": 0,
+            "default": 0,
+            "description": "Number of matching results to skip (for pagination)"
+          }
+        },
+        "required": [
+          "query"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "outputSchema": {
+        "type": "object",
+        "properties": {
+          "total": {
+            "type": "number"
+          },
+          "returned": {
+            "type": "number"
+          },
+          "offset": {
+            "type": "number"
+          },
+          "notes": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string"
+                },
+                "name": {
+                  "type": "string"
+                },
+                "folder": {
+                  "type": "string"
+                },
+                "preview": {
+                  "type": "string"
+                },
+                "creationDate": {
+                  "type": "string"
+                },
+                "modificationDate": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "id",
+                "name",
+                "folder",
+                "preview",
+                "creationDate",
+                "modificationDate"
+              ],
+              "additionalProperties": false
+            }
+          }
+        },
+        "required": [
+          "total",
+          "returned",
+          "offset",
+          "notes"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "search_reminders",
+      "title": "Search Reminders",
+      "description": "Search reminders by keyword in name or body across all lists (case-insensitive).",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "query": {
+            "type": "string",
+            "maxLength": 500,
+            "description": "Search keyword"
+          },
+          "limit": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 500,
+            "default": 30,
+            "description": "Max results (default: 30)"
+          }
+        },
+        "required": [
+          "query"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "outputSchema": {
+        "type": "object",
+        "properties": {
+          "returned": {
+            "type": "number"
+          },
+          "reminders": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string"
+                },
+                "name": {
+                  "type": "string"
+                },
+                "completed": {
+                  "type": "boolean"
+                },
+                "dueDate": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "priority": {
+                  "type": "number"
+                },
+                "flagged": {
+                  "type": "boolean"
+                },
+                "list": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "id",
+                "name",
+                "completed",
+                "dueDate",
+                "priority",
+                "flagged",
+                "list"
+              ],
+              "additionalProperties": false
+            }
+          }
+        },
+        "required": [
+          "returned",
+          "reminders"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "search_shortcuts",
+      "title": "Search Shortcuts",
+      "description": "Search Siri Shortcuts by name keyword.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "query": {
+            "type": "string",
+            "maxLength": 500,
+            "description": "Search keyword to match against shortcut names"
+          }
+        },
+        "required": [
+          "query"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "outputSchema": {
+        "type": "object",
+        "properties": {
+          "total": {
+            "type": "number"
+          },
+          "shortcuts": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        },
+        "required": [
+          "total",
+          "shortcuts"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "semantic_clear",
+      "title": "Clear Semantic Index",
+      "description": "Delete all indexed data from the local vector store AND remove corresponding ...",
+      "inputSchema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {}
+      },
+      "outputSchema": null,
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": true,
+        "idempotentHint": true,
+        "openWorldHint": false
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "semantic_index",
+      "title": "Build Semantic Index",
+      "description": "Index data from enabled Apple apps (Notes, Calendar, Reminders, Mail, Photos,...",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "sources": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "notes",
+                "calendar",
+                "reminders",
+                "mail",
+                "photos",
+                "finder"
+              ]
+            },
+            "description": "Which sources to index. Defaults to all enabled modules."
+          }
+        },
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": true,
+        "idempotentHint": true,
+        "openWorldHint": false
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "semantic_search",
+      "title": "Semantic Search",
+      "description": "Search across Apple app data by meaning, not just keywords.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "query": {
+            "type": "string",
+            "maxLength": 500,
+            "description": "Natural language search query"
+          },
+          "sources": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "notes",
+                "calendar",
+                "reminders",
+                "mail"
+              ]
+            },
+            "description": "Filter by source type"
+          },
+          "limit": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 50,
+            "description": "Max results (default 10)"
+          },
+          "threshold": {
+            "type": "number",
+            "minimum": 0,
+            "maximum": 1,
+            "description": "Minimum similarity (default 0.5)"
+          }
+        },
+        "required": [
+          "query"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "semantic_status",
+      "title": "Semantic Index Status",
+      "description": "Show the current state of the semantic vector index -- total entries, breakdo...",
+      "inputSchema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {}
+      },
+      "outputSchema": null,
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "set_brightness",
+      "title": "Set Brightness",
+      "description": "Set the display brightness level.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "level": {
+            "type": "number",
+            "minimum": 0,
+            "maximum": 1,
+            "description": "Brightness level from 0.0 (darkest) to 1.0 (brightest)"
+          }
+        },
+        "required": [
+          "level"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "set_clipboard",
+      "title": "Set Clipboard",
+      "description": "Write text to the system clipboard, replacing its current content.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "text": {
+            "type": "string",
+            "maxLength": 10000,
+            "description": "Text to copy to the clipboard"
+          }
+        },
+        "required": [
+          "text"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "outputSchema": {
+        "type": "object",
+        "properties": {
+          "set": {
+            "type": "boolean"
+          },
+          "length": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "set",
+          "length"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "set_file_tags",
+      "title": "Set File Tags",
+      "description": "Set Finder tags on a file.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "path": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 4096,
+            "description": "Absolute file path"
+          },
+          "tags": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Array of tag names to set"
+          }
+        },
+        "required": [
+          "path",
+          "tags"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "set_volume",
+      "title": "Set Volume",
+      "description": "Set the system output volume (0-100) and/or mute state.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "volume": {
+            "type": "number",
+            "minimum": 0,
+            "maximum": 100,
+            "description": "Output volume level (0-100)"
+          },
+          "muted": {
+            "type": "boolean",
+            "description": "Whether to mute output audio"
+          }
+        },
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "outputSchema": {
+        "type": "object",
+        "properties": {
+          "outputVolume": {
+            "type": "number"
+          },
+          "outputMuted": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "outputVolume",
+          "outputMuted"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "setup_permissions",
+      "title": "Setup Permissions",
+      "description": "Trigger macOS permission prompts for all Apple apps used by AirMCP.",
+      "inputSchema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {}
+      },
+      "outputSchema": null,
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "show_notification",
+      "title": "Show Notification",
+      "description": "Display a macOS system notification with optional title, subtitle, and sound.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "message": {
+            "type": "string",
+            "maxLength": 5000,
+            "description": "Notification body text"
+          },
+          "title": {
+            "type": "string",
+            "maxLength": 500,
+            "description": "Notification title"
+          },
+          "subtitle": {
+            "type": "string",
+            "maxLength": 5000,
+            "description": "Notification subtitle"
+          },
+          "sound": {
+            "type": "string",
+            "maxLength": 500,
+            "description": "Sound name to play (e.g. 'Frog', 'Glass', 'Hero')"
+          }
+        },
+        "required": [
+          "message"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": false
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "skill_calendar-alert",
+      "title": "Calendar Change Alert",
+      "description": "[Skill] Automatically fetches today's events when the calendar is modified.",
+      "inputSchema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {}
+      },
+      "outputSchema": null,
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "skill_clipboard-url-to-reading",
+      "title": "Clipboard URL → Reading List",
+      "description": "[Skill] Listens for clipboard changes and, when a URL is on the pasteboard, p...",
+      "inputSchema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {}
+      },
+      "outputSchema": null,
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "skill_daily-journal",
+      "title": "Daily Journal → Memory",
+      "description": "[Skill] Captures today's events + open reminders, summarises them on-device, ...",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "note": {
+            "type": "string",
+            "description": "Optional free-form note to prepend to the auto-generated summary.",
+            "default": ""
+          }
+        },
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "skill_evening-winddown",
+      "title": "Evening Wind-down",
+      "description": "[Skill] Fires when the screen is locked — drafts a short day-in-review note c...",
+      "inputSchema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {}
+      },
+      "outputSchema": null,
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "skill_focus-block-planner",
+      "title": "Focus Block Planner",
+      "description": "[Skill] Walks today's open reminders and drops a calendar time-block for each...",
+      "inputSchema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {}
+      },
+      "outputSchema": null,
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "skill_focus-guardian",
+      "title": "Focus Mode Guardian",
+      "description": "[Skill] Auto-snapshots today's events and open reminders whenever the system ...",
+      "inputSchema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {}
+      },
+      "outputSchema": null,
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "skill_inbox-triage",
+      "title": "Inbox Triage",
+      "description": "[Skill] Check unread mail count and list recent messages for triage.",
+      "inputSchema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {}
+      },
+      "outputSchema": null,
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "skill_project-digest",
+      "title": "Project Digest",
+      "description": "[Skill] Semantic-search the user's indexed Apple data for a topic, then loop ...",
+      "inputSchema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {}
+      },
+      "outputSchema": null,
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "skill_sender-to-tasks",
+      "title": "Sender → Tasks",
+      "description": "[Skill] Scans mail for a keyword and turns each hit into a reminder so nothin...",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "query": {
+            "type": "string",
+            "description": "Search keyword in subject/sender (e.g. 'newsletter', 'invoice', 'team@acme.com').",
+            "default": "newsletter"
+          },
+          "mailbox": {
+            "type": "string",
+            "description": "Mailbox to search.",
+            "default": "INBOX"
+          },
+          "limit": {
+            "type": "number",
+            "description": "Max messages to process per run.",
+            "default": 10
+          }
+        },
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "smart_clipboard",
+      "title": "Smart Clipboard",
+      "description": "Get clipboard content with automatic type detection (text, URL, email, phone,...",
+      "inputSchema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {}
+      },
+      "outputSchema": null,
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "speech_availability",
+      "title": "Speech Recognition Status",
+      "description": "Check if on-device speech recognition is available and authorized.",
+      "inputSchema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {}
+      },
+      "outputSchema": null,
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "spotlight_clear",
+      "title": "Clear Spotlight Index",
+      "description": "Remove all AirMCP entries from macOS Spotlight without clearing the local vec...",
+      "inputSchema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {}
+      },
+      "outputSchema": null,
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": true,
+        "idempotentHint": true,
+        "openWorldHint": false
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "spotlight_sync",
+      "title": "Sync to Spotlight",
+      "description": "Push semantically indexed data to macOS Core Spotlight, making it discoverabl...",
+      "inputSchema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {}
+      },
+      "outputSchema": null,
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "suggest_next_tools",
+      "title": "Suggest Next Tools",
+      "description": "Based on your usage patterns, suggest which tools typically follow a given tool.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "after": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 500,
+            "description": "Tool name to get suggestions for — e.g. 'today_events'"
+          },
+          "limit": {
+            "type": "number",
+            "minimum": 1,
+            "maximum": 20,
+            "description": "Max suggestions (default 5)"
+          }
+        },
+        "required": [
+          "after"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "outputSchema": {
+        "type": "object",
+        "properties": {
+          "after": {
+            "type": "string"
+          },
+          "suggestions": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "tool": {
+                  "type": "string"
+                },
+                "count": {
+                  "type": "number"
+                }
+              },
+              "required": [
+                "tool",
+                "count"
+              ],
+              "additionalProperties": false
+            }
+          },
+          "totalCalls": {
+            "type": "number"
+          },
+          "hint": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "after",
+          "suggestions",
+          "totalCalls"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "summarize_context",
+      "title": "Summarize Context",
+      "description": "Collect context from all enabled Apple apps and ask the client's LLM to produ...",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "focus": {
+            "type": "string",
+            "maxLength": 500,
+            "description": "Optional focus area (e.g. 'meetings', 'overdue tasks', 'project X')"
+          }
+        },
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "system_power",
+      "title": "System Power",
+      "description": "Shutdown or restart the Mac.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "action": {
+            "type": "string",
+            "enum": [
+              "shutdown",
+              "restart"
+            ],
+            "description": "Power action: shutdown or restart"
+          }
+        },
+        "required": [
+          "action"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": true,
+        "idempotentHint": false,
+        "openWorldHint": false
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "system_sleep",
+      "title": "System Sleep",
+      "description": "Put the Mac to sleep.",
+      "inputSchema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {}
+      },
+      "outputSchema": null,
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": true,
+        "idempotentHint": false,
+        "openWorldHint": false
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "timeline_today",
+      "title": "Timeline (Today)",
+      "description": "Display today's events and due reminders on a single day-axis timeline.",
+      "inputSchema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {}
+      },
+      "outputSchema": null,
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "today_events",
+      "title": "Today's Events",
+      "description": "Get all calendar events for today.",
+      "inputSchema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {}
+      },
+      "outputSchema": {
+        "type": "object",
+        "properties": {
+          "total": {
+            "type": "number"
+          },
+          "events": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string"
+                },
+                "summary": {
+                  "type": "string"
+                },
+                "startDate": {
+                  "type": "string"
+                },
+                "endDate": {
+                  "type": "string"
+                },
+                "allDay": {
+                  "type": "boolean"
+                },
+                "calendar": {
+                  "type": "string"
+                },
+                "location": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "id",
+                "summary",
+                "startDate",
+                "endDate",
+                "allDay",
+                "calendar",
+                "location"
+              ],
+              "additionalProperties": false
+            }
+          }
+        },
+        "required": [
+          "total",
+          "events"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "toggle_dark_mode",
+      "title": "Toggle Dark Mode",
+      "description": "Toggle macOS appearance between dark mode and light mode.",
+      "inputSchema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {}
+      },
+      "outputSchema": {
+        "type": "object",
+        "properties": {
+          "darkMode": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "darkMode"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "toggle_focus_mode",
+      "title": "Toggle Focus Mode",
+      "description": "Toggle Do Not Disturb (Focus mode) on or off.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "enable": {
+            "type": "boolean",
+            "description": "True to enable Do Not Disturb, false to disable"
+          }
+        },
+        "required": [
+          "enable"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "toggle_wifi",
+      "title": "Toggle WiFi",
+      "description": "Turn WiFi on or off.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "enable": {
+            "type": "boolean",
+            "description": "True to enable WiFi, false to disable"
+          }
+        },
+        "required": [
+          "enable"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": true,
+        "idempotentHint": true,
+        "openWorldHint": false
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "transcribe_audio",
+      "title": "Transcribe Audio",
+      "description": "Transcribe an audio file to text using Apple's on-device speech recognition.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "path": {
+            "type": "string",
+            "maxLength": 1000,
+            "description": "Absolute path to the audio file"
+          },
+          "language": {
+            "type": "string",
+            "description": "Language code (e.g. 'en-US', 'ko-KR', 'ja-JP'). Defaults to system language."
+          }
+        },
+        "required": [
+          "path"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "trash_file",
+      "title": "Trash File",
+      "description": "Move a file or folder to the Trash using Finder.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "path": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 4096,
+            "description": "Absolute path of the file or folder to trash"
+          }
+        },
+        "required": [
+          "path"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": true,
+        "idempotentHint": true,
+        "openWorldHint": false
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "update_event",
+      "title": "Update Event",
+      "description": "Update event properties.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "maxLength": 500,
+            "description": "Event UID"
+          },
+          "summary": {
+            "type": "string",
+            "maxLength": 500,
+            "description": "New title"
+          },
+          "startDate": {
+            "type": "string",
+            "maxLength": 64,
+            "description": "New start date/time (ISO 8601, e.g. '2026-03-15T09:00:00Z')"
+          },
+          "endDate": {
+            "type": "string",
+            "maxLength": 64,
+            "description": "New end date/time (ISO 8601, e.g. '2026-03-15T10:00:00Z')"
+          },
+          "location": {
+            "type": "string",
+            "maxLength": 5000,
+            "description": "New location"
+          },
+          "description": {
+            "type": "string",
+            "maxLength": 5000,
+            "description": "New notes/description"
+          }
+        },
+        "required": [
+          "id"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": true,
+        "idempotentHint": true,
+        "openWorldHint": false
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "update_note",
+      "title": "Update Note",
+      "description": "Replace the entire body of an existing note.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "maxLength": 500,
+            "description": "Note ID (x-coredata:// format)"
+          },
+          "body": {
+            "type": "string",
+            "maxLength": 50000,
+            "description": "New HTML body to replace existing content"
+          }
+        },
+        "required": [
+          "id",
+          "body"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": true,
+        "idempotentHint": true,
+        "openWorldHint": false
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "update_reminder",
+      "title": "Update Reminder",
+      "description": "Update reminder properties.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "maxLength": 500,
+            "description": "Reminder ID"
+          },
+          "title": {
+            "type": "string",
+            "maxLength": 500,
+            "description": "New title"
+          },
+          "body": {
+            "type": "string",
+            "maxLength": 5000,
+            "description": "New notes/body text"
+          },
+          "dueDate": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "New due date (ISO 8601, e.g. '2026-03-15T10:00:00Z') or null to clear"
+          },
+          "priority": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 9,
+            "description": "New priority (0-9)"
+          },
+          "flagged": {
+            "type": "boolean",
+            "description": "Set flagged status"
+          }
+        },
+        "required": [
+          "id"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": true,
+        "idempotentHint": true,
+        "openWorldHint": false
+      },
+      "appIntentEligible": true
+    }
+  ]
+}

--- a/docs/tool-manifest.json
+++ b/docs/tool-manifest.json
@@ -1,9 +1,425 @@
 {
   "generatedAt": "STABLE_PLACEHOLDER",
   "protocolVersion": "2025-06-18",
-  "toolCount": 120,
-  "eligibleCount": 117,
+  "toolCount": 282,
+  "eligibleCount": 277,
   "tools": [
+    {
+      "name": "activate_tab",
+      "title": "Activate Tab",
+      "description": "Switch to a specific Safari tab.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "windowIndex": {
+            "type": "integer",
+            "minimum": 0,
+            "default": 0,
+            "description": "Window index (default: 0)"
+          },
+          "tabIndex": {
+            "type": "integer",
+            "minimum": 0,
+            "description": "Tab index"
+          }
+        },
+        "required": [
+          "tabIndex"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "add_contact_email",
+      "title": "Add Contact Email",
+      "description": "Add an email address to an existing contact.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "maxLength": 500,
+            "description": "Contact ID"
+          },
+          "email": {
+            "type": "string",
+            "format": "email",
+            "description": "Email address to add"
+          },
+          "label": {
+            "type": "string",
+            "maxLength": 500,
+            "default": "work",
+            "description": "Email label (default: work)"
+          }
+        },
+        "required": [
+          "id",
+          "email"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": false
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "add_contact_phone",
+      "title": "Add Contact Phone",
+      "description": "Add a phone number to an existing contact.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "maxLength": 500,
+            "description": "Contact ID"
+          },
+          "phone": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 1000,
+            "description": "Phone number to add"
+          },
+          "label": {
+            "type": "string",
+            "maxLength": 500,
+            "default": "mobile",
+            "description": "Phone label (default: mobile)"
+          }
+        },
+        "required": [
+          "id",
+          "phone"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": false
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "add_to_album",
+      "title": "Add Photos to Album",
+      "description": "Add photos to an existing album by photo IDs and album name.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "photoIds": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "maxLength": 500
+            },
+            "minItems": 1,
+            "maxItems": 500,
+            "description": "Array of photo media item IDs (max 500)"
+          },
+          "albumName": {
+            "type": "string",
+            "maxLength": 500,
+            "description": "Target album name"
+          }
+        },
+        "required": [
+          "photoIds",
+          "albumName"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": false
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "add_to_playlist",
+      "title": "Add to Playlist",
+      "description": "Add a track to an existing playlist.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "playlistName": {
+            "type": "string",
+            "maxLength": 500,
+            "description": "Playlist name"
+          },
+          "trackName": {
+            "type": "string",
+            "maxLength": 500,
+            "description": "Track name to add"
+          }
+        },
+        "required": [
+          "playlistName",
+          "trackName"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": false
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "add_to_reading_list",
+      "title": "Add to Reading List",
+      "description": "Add a URL to Safari's Reading List with an optional title.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "url": {
+            "type": "string",
+            "format": "uri",
+            "description": "URL to add to Reading List"
+          },
+          "title": {
+            "type": "string",
+            "maxLength": 500,
+            "description": "Title for the Reading List item"
+          }
+        },
+        "required": [
+          "url"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": false
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "ai_agent",
+      "title": "On-Device AI Agent",
+      "description": "Run a prompt through Apple's on-device Foundation Models with access to AirMC...",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "prompt": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 10000,
+            "description": "What you want the on-device AI to do with your Apple data"
+          },
+          "systemInstruction": {
+            "type": "string",
+            "maxLength": 10000,
+            "description": "Optional system instruction for the AI agent"
+          }
+        },
+        "required": [
+          "prompt"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": false
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "ai_chat",
+      "title": "AI Chat",
+      "description": "Send a message to an on-device AI session using Apple Foundation Models.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "sessionName": {
+            "type": "string",
+            "maxLength": 500,
+            "description": "Name for this chat session (use same name to continue a conversation)"
+          },
+          "message": {
+            "type": "string",
+            "maxLength": 10000,
+            "description": "The message to send to the AI"
+          },
+          "systemInstruction": {
+            "type": "string",
+            "maxLength": 10000,
+            "description": "Optional system instruction for this session"
+          }
+        },
+        "required": [
+          "sessionName",
+          "message"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": false
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "ai_plan_metrics",
+      "title": "AI Plan Metrics",
+      "description": "Run a sample of planner goals against the on-device Foundation Model and repo...",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "limit": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 50,
+            "default": 5,
+            "description": "Number of cases to sample from GOLDEN_PLANS (default: 5, max: 50)."
+          },
+          "seed": {
+            "type": "integer",
+            "description": "Deterministic seed for case selection (default: time-based). Fixing this is useful when comparing runs before/after a change."
+          }
+        },
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "outputSchema": {
+        "type": "object",
+        "properties": {
+          "sampled": {
+            "type": "number"
+          },
+          "averageScore": {
+            "type": "number"
+          },
+          "parseRate": {
+            "type": "number"
+          },
+          "expectedCoverageAvg": {
+            "type": "number"
+          },
+          "leakedForbiddenTotal": {
+            "type": "number"
+          },
+          "perCase": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string"
+                },
+                "total": {
+                  "type": "number"
+                },
+                "matchedExpected": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "leakedForbidden": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "stepCount": {
+                  "type": "number"
+                },
+                "unknownTools": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              },
+              "required": [
+                "name",
+                "total",
+                "matchedExpected",
+                "leakedForbidden",
+                "stepCount",
+                "unknownTools"
+              ],
+              "additionalProperties": false
+            }
+          }
+        },
+        "required": [
+          "sampled",
+          "averageScore",
+          "parseRate",
+          "expectedCoverageAvg",
+          "leakedForbiddenTotal",
+          "perCase"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": false
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "ai_status",
+      "title": "AI Status",
+      "description": "Check availability and status of Apple's on-device Foundation Models.",
+      "inputSchema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {}
+      },
+      "outputSchema": null,
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false
+      },
+      "appIntentEligible": true
+    },
     {
       "name": "audit_log",
       "title": "Audit Log",
@@ -253,6 +669,75 @@
       "appIntentEligible": true
     },
     {
+      "name": "capture_area",
+      "title": "Capture Screen Area",
+      "description": "Capture a screenshot of a specific rectangular region of the screen.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "x": {
+            "type": "number",
+            "description": "X coordinate of the top-left corner of the capture region"
+          },
+          "y": {
+            "type": "number",
+            "description": "Y coordinate of the top-left corner of the capture region"
+          },
+          "width": {
+            "type": "number",
+            "minimum": 1,
+            "description": "Width of the capture region in pixels"
+          },
+          "height": {
+            "type": "number",
+            "minimum": 1,
+            "description": "Height of the capture region in pixels"
+          }
+        },
+        "required": [
+          "x",
+          "y",
+          "width",
+          "height"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "capture_screen",
+      "title": "Capture Screen",
+      "description": "Capture a full-screen screenshot as a PNG image.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "display": {
+            "type": "integer",
+            "minimum": 1,
+            "description": "Display number for multi-monitor setups (1 = main display). Omit for default display."
+          }
+        },
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      },
+      "appIntentEligible": true
+    },
+    {
       "name": "capture_screenshot",
       "title": "Capture Screenshot",
       "description": "Take a screenshot and save to the specified path.",
@@ -287,6 +772,101 @@
         "readOnlyHint": false,
         "destructiveHint": true,
         "idempotentHint": false,
+        "openWorldHint": false
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "capture_window",
+      "title": "Capture Window",
+      "description": "Capture a screenshot of the frontmost window.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "appName": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Application name to activate before capture (e.g. 'Safari', 'Xcode'). If omitted, captures the frontmost window."
+          }
+        },
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "classify_image",
+      "title": "Classify Image",
+      "description": "Classify an image using Apple Vision framework.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "imagePath": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 4096,
+            "description": "Absolute path to the image file"
+          },
+          "maxResults": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 50,
+            "default": 10,
+            "description": "Max labels (default: 10)"
+          }
+        },
+        "required": [
+          "imagePath"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "close_tab",
+      "title": "Close Tab",
+      "description": "Close a specific Safari tab.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "windowIndex": {
+            "type": "integer",
+            "minimum": 0,
+            "default": 0,
+            "description": "Window index (default: 0)"
+          },
+          "tabIndex": {
+            "type": "integer",
+            "minimum": 0,
+            "description": "Tab index"
+          }
+        },
+        "required": [
+          "tabIndex"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": true,
+        "idempotentHint": true,
         "openWorldHint": false
       },
       "appIntentEligible": true
@@ -370,6 +950,121 @@
         "readOnlyHint": false,
         "destructiveHint": false,
         "idempotentHint": true,
+        "openWorldHint": false
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "connect_bluetooth",
+      "title": "Connect Bluetooth",
+      "description": "Connect to a BLE device by its UUID.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "identifier": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Peripheral UUID from scan results"
+          }
+        },
+        "required": [
+          "identifier"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "create_album",
+      "title": "Create Album",
+      "description": "Create a new photo album.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "maxLength": 500,
+            "description": "Album name"
+          }
+        },
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": false
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "create_contact",
+      "title": "Create Contact",
+      "description": "Create a new contact with name and optional email, phone, organization.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "firstName": {
+            "type": "string",
+            "maxLength": 500,
+            "description": "First name"
+          },
+          "lastName": {
+            "type": "string",
+            "maxLength": 500,
+            "description": "Last name"
+          },
+          "email": {
+            "type": "string",
+            "format": "email",
+            "description": "Email address"
+          },
+          "phone": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Phone number"
+          },
+          "organization": {
+            "type": "string",
+            "maxLength": 1000,
+            "description": "Company/organization"
+          },
+          "jobTitle": {
+            "type": "string",
+            "maxLength": 500,
+            "description": "Job title"
+          },
+          "note": {
+            "type": "string",
+            "maxLength": 5000,
+            "description": "Notes"
+          }
+        },
+        "required": [
+          "firstName",
+          "lastName"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": false,
         "openWorldHint": false
       },
       "appIntentEligible": true
@@ -516,6 +1211,34 @@
         },
         "required": [
           "body"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": false
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "create_playlist",
+      "title": "Create Playlist",
+      "description": "Create a new playlist in Music.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "maxLength": 500,
+            "description": "Name for the new playlist"
+          }
+        },
+        "required": [
+          "name"
         ],
         "additionalProperties": false,
         "$schema": "http://json-schema.org/draft-07/schema#"
@@ -832,6 +1555,34 @@
       "appIntentEligible": true
     },
     {
+      "name": "delete_contact",
+      "title": "Delete Contact",
+      "description": "Delete a contact by ID.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "maxLength": 500,
+            "description": "Contact ID"
+          }
+        },
+        "required": [
+          "id"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": true,
+        "idempotentHint": true,
+        "openWorldHint": false
+      },
+      "appIntentEligible": true
+    },
+    {
       "name": "delete_event",
       "title": "Delete Event",
       "description": "Delete a calendar event by ID.",
@@ -883,6 +1634,64 @@
         "readOnlyHint": false,
         "destructiveHint": true,
         "idempotentHint": true,
+        "openWorldHint": false
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "delete_photos",
+      "title": "Delete Photos",
+      "description": "Delete photos by local identifier.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "identifiers": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Array of photo local identifiers to delete"
+          }
+        },
+        "required": [
+          "identifiers"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": true,
+        "idempotentHint": false,
+        "openWorldHint": false
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "delete_playlist",
+      "title": "Delete Playlist",
+      "description": "Delete an existing playlist from Music.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "maxLength": 500,
+            "description": "Playlist name to delete"
+          }
+        },
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": true,
+        "idempotentHint": false,
         "openWorldHint": false
       },
       "appIntentEligible": true
@@ -972,6 +1781,34 @@
       "appIntentEligible": true
     },
     {
+      "name": "disconnect_bluetooth",
+      "title": "Disconnect Bluetooth",
+      "description": "Disconnect a BLE device by its UUID.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "identifier": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Peripheral UUID to disconnect"
+          }
+        },
+        "required": [
+          "identifier"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false
+      },
+      "appIntentEligible": true
+    },
+    {
       "name": "discover_tools",
       "title": "Discover Tools",
       "description": "Search available tools by keyword.",
@@ -1043,6 +1880,43 @@
       },
       "annotations": {
         "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "drop_pin",
+      "title": "Drop Pin",
+      "description": "Drop a pin at specific coordinates in Apple Maps.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "latitude": {
+            "type": "number",
+            "description": "Latitude coordinate"
+          },
+          "longitude": {
+            "type": "number",
+            "description": "Longitude coordinate"
+          },
+          "label": {
+            "type": "string",
+            "maxLength": 500,
+            "description": "Optional label for the pin"
+          }
+        },
+        "required": [
+          "latitude",
+          "longitude"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "readOnlyHint": false,
         "destructiveHint": false,
         "idempotentHint": true,
         "openWorldHint": false
@@ -1223,9 +2097,260 @@
       "appIntentEligible": true
     },
     {
+      "name": "flag_message",
+      "title": "Flag Message",
+      "description": "Flag or unflag an email message.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "maxLength": 500,
+            "pattern": "^\\d+$",
+            "description": "Message ID"
+          },
+          "flagged": {
+            "type": "boolean",
+            "default": true,
+            "description": "true=flag, false=unflag (default: true)"
+          }
+        },
+        "required": [
+          "id"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "generate_image",
+      "title": "Generate Image",
+      "description": "Generate an image from a text description using Apple Intelligence on-device ...",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "prompt": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 5000,
+            "description": "Text description of the image to generate"
+          },
+          "outputPath": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 4096,
+            "description": "Optional output path for the image (defaults to /tmp, must end in .png/.jpg)"
+          }
+        },
+        "required": [
+          "prompt"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": true,
+        "idempotentHint": false,
+        "openWorldHint": false
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "generate_plan",
+      "title": "Generate Plan",
+      "description": "Use Apple's on-device Foundation Model to analyze a goal and generate a sugge...",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "goal": {
+            "type": "string",
+            "maxLength": 1000,
+            "description": "What you want to accomplish (e.g. 'organize my day', 'prepare for meeting')"
+          },
+          "context": {
+            "type": "string",
+            "maxLength": 10000,
+            "description": "Additional context (max 10K chars, e.g. snapshot text, recent events)"
+          },
+          "availableTools": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "List of available tool names to plan with. Defaults to common tools."
+          }
+        },
+        "required": [
+          "goal"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": false
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "generate_structured",
+      "title": "Generate Structured Output",
+      "description": "Generate structured JSON output from Apple's on-device Foundation Model with ...",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "prompt": {
+            "type": "string",
+            "maxLength": 10000,
+            "description": "The prompt describing what structured data to generate"
+          },
+          "systemInstruction": {
+            "type": "string",
+            "maxLength": 10000,
+            "description": "Optional system instruction to guide output format"
+          },
+          "schema": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "maxLength": 1000,
+                  "description": "JSON type: string, number, boolean, array, object"
+                },
+                "description": {
+                  "type": "string",
+                  "maxLength": 5000,
+                  "description": "Description of this field"
+                }
+              },
+              "required": [
+                "type"
+              ],
+              "additionalProperties": false
+            },
+            "description": "Optional JSON schema describing expected output fields"
+          }
+        },
+        "required": [
+          "prompt"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": false
+      },
+      "appIntentEligible": false
+    },
+    {
+      "name": "generate_text",
+      "title": "Generate Text",
+      "description": "Generate text using Apple's on-device Foundation Model with custom system ins...",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "prompt": {
+            "type": "string",
+            "maxLength": 10000,
+            "description": "The user prompt / instruction for text generation"
+          },
+          "systemInstruction": {
+            "type": "string",
+            "maxLength": 10000,
+            "description": "Optional system instruction to guide the model's behavior"
+          },
+          "temperature": {
+            "type": "number",
+            "minimum": 0,
+            "maximum": 2,
+            "description": "Sampling temperature (0-2). Lower = more deterministic"
+          }
+        },
+        "required": [
+          "prompt"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": false
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "geocode",
+      "title": "Geocode",
+      "description": "Convert a place name or address to geographic coordinates.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "query": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 500,
+            "description": "Place name or address (e.g. 'Seoul', 'Tokyo Tower', '1600 Pennsylvania Ave')"
+          }
+        },
+        "required": [
+          "query"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      },
+      "appIntentEligible": true
+    },
+    {
       "name": "get_battery_status",
       "title": "Get Battery Status",
       "description": "Get battery percentage, charging state, power source, and estimated time rema...",
+      "inputSchema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {}
+      },
+      "outputSchema": null,
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "get_bluetooth_state",
+      "title": "Get Bluetooth State",
+      "description": "Check whether Bluetooth is powered on, off, or unauthorized.",
       "inputSchema": {
         "$schema": "http://json-schema.org/draft-07/schema#",
         "type": "object",
@@ -1284,6 +2409,58 @@
           "content",
           "length",
           "truncated"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "get_current_location",
+      "title": "Get Current Location",
+      "description": "Get the device's current geographic location (latitude, longitude, altitude).",
+      "inputSchema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {}
+      },
+      "outputSchema": null,
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": false
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "get_current_tab",
+      "title": "Get Current Tab",
+      "description": "Get the title and URL of the active Safari tab.",
+      "inputSchema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {}
+      },
+      "outputSchema": {
+        "type": "object",
+        "properties": {
+          "title": {
+            "type": "string"
+          },
+          "url": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "title",
+          "url"
         ],
         "additionalProperties": false,
         "$schema": "http://json-schema.org/draft-07/schema#"
@@ -1452,6 +2629,50 @@
       "appIntentEligible": true
     },
     {
+      "name": "get_directions",
+      "title": "Get Directions",
+      "description": "Get directions between two locations in Apple Maps.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "from": {
+            "type": "string",
+            "maxLength": 500,
+            "description": "Starting location or address"
+          },
+          "to": {
+            "type": "string",
+            "maxLength": 500,
+            "description": "Destination location or address"
+          },
+          "transportType": {
+            "type": "string",
+            "enum": [
+              "driving",
+              "walking",
+              "transit"
+            ],
+            "default": "driving",
+            "description": "Mode of transport (default: driving)"
+          }
+        },
+        "required": [
+          "from",
+          "to"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      },
+      "appIntentEligible": true
+    },
+    {
       "name": "get_file_info",
       "title": "Get File Info",
       "description": "Get detailed file information including size, dates, kind, and tags.",
@@ -1601,6 +2822,80 @@
       "appIntentEligible": true
     },
     {
+      "name": "get_location_permission",
+      "title": "Get Location Permission",
+      "description": "Check the current Location Services authorization status.",
+      "inputSchema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {}
+      },
+      "outputSchema": null,
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "get_photo_info",
+      "title": "Get Photo Info",
+      "description": "Get detailed metadata for a specific photo by ID.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "maxLength": 500,
+            "description": "Photo media item ID"
+          }
+        },
+        "required": [
+          "id"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "get_rating",
+      "title": "Get Rating",
+      "description": "Get the rating, favorited, and disliked status for a track.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "trackName": {
+            "type": "string",
+            "maxLength": 500,
+            "description": "Track name to look up"
+          }
+        },
+        "required": [
+          "trackName"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false
+      },
+      "appIntentEligible": true
+    },
+    {
       "name": "get_screen_info",
       "title": "Get Screen Info",
       "description": "Get display information including resolution, pixel dimensions, and Retina st...",
@@ -1650,6 +2945,88 @@
         "required": [
           "shortcut",
           "detail"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "get_track_info",
+      "title": "Get Track Info",
+      "description": "Get detailed metadata for a specific track by name.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "trackName": {
+            "type": "string",
+            "maxLength": 500,
+            "description": "Track name to look up"
+          }
+        },
+        "required": [
+          "trackName"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "get_unread_count",
+      "title": "Get Unread Count",
+      "description": "Get unread message count across all mailboxes.",
+      "inputSchema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {}
+      },
+      "outputSchema": {
+        "type": "object",
+        "properties": {
+          "totalUnread": {
+            "type": "number"
+          },
+          "mailboxes": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "account": {
+                  "type": "string"
+                },
+                "mailbox": {
+                  "type": "string"
+                },
+                "unread": {
+                  "type": "number"
+                }
+              },
+              "required": [
+                "account",
+                "mailbox",
+                "unread"
+              ],
+              "additionalProperties": false
+            }
+          }
+        },
+        "required": [
+          "totalUnread",
+          "mailboxes"
         ],
         "additionalProperties": false,
         "$schema": "http://json-schema.org/draft-07/schema#"
@@ -1838,6 +3215,639 @@
       "appIntentEligible": false
     },
     {
+      "name": "gws_calendar_create",
+      "title": "Create Google Calendar Event",
+      "description": "Create an event in Google Calendar.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "summary": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 500,
+            "description": "Event title"
+          },
+          "start": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 64,
+            "description": "Start time (ISO 8601)"
+          },
+          "end": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 64,
+            "description": "End time (ISO 8601)"
+          },
+          "description": {
+            "type": "string",
+            "maxLength": 5000,
+            "description": "Event description"
+          },
+          "location": {
+            "type": "string",
+            "maxLength": 5000,
+            "description": "Event location"
+          }
+        },
+        "required": [
+          "summary",
+          "start",
+          "end"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": true
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "gws_calendar_list",
+      "title": "List Google Calendar Events",
+      "description": "List upcoming events from Google Calendar.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "maxResults": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 100,
+            "default": 10
+          },
+          "query": {
+            "type": "string",
+            "maxLength": 500,
+            "description": "Free-text search within events"
+          },
+          "timeMin": {
+            "type": "string",
+            "maxLength": 64,
+            "description": "Start time (ISO 8601). Defaults to now."
+          },
+          "timeMax": {
+            "type": "string",
+            "maxLength": 64,
+            "description": "End time (ISO 8601)"
+          }
+        },
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "gws_docs_read",
+      "title": "Read Google Doc",
+      "description": "Read the content of a Google Doc by document ID.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "documentId": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 500,
+            "description": "Google Docs document ID"
+          }
+        },
+        "required": [
+          "documentId"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "gws_drive_list",
+      "title": "List Drive Files",
+      "description": "List files in Google Drive.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "query": {
+            "type": "string",
+            "description": "Drive search query (e.g. \"name contains 'report'\" or \"mimeType = 'application/pdf'\")"
+          },
+          "pageSize": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 100,
+            "default": 20,
+            "description": "Max files to return"
+          },
+          "orderBy": {
+            "type": "string",
+            "maxLength": 500,
+            "description": "Sort order (e.g. 'modifiedTime desc', 'name')"
+          }
+        },
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "gws_drive_read",
+      "title": "Read Drive File Metadata",
+      "description": "Get metadata for a Google Drive file by ID.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "fileId": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 500,
+            "description": "Drive file ID"
+          }
+        },
+        "required": [
+          "fileId"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "gws_drive_search",
+      "title": "Search Drive",
+      "description": "Full-text search across Google Drive files by content or name.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "query": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 500,
+            "description": "Search text (searches file names and content)"
+          },
+          "maxResults": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 50,
+            "default": 10
+          }
+        },
+        "required": [
+          "query"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "gws_gmail_list",
+      "title": "List Gmail Messages",
+      "description": "List recent Gmail messages.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "query": {
+            "type": "string",
+            "maxLength": 1000,
+            "description": "Gmail search query (e.g. 'is:unread', 'from:bob subject:report')"
+          },
+          "maxResults": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 100,
+            "default": 20,
+            "description": "Max messages to return"
+          }
+        },
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "gws_gmail_read",
+      "title": "Read Gmail Message",
+      "description": "Read a Gmail message by ID.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "messageId": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 500,
+            "description": "Gmail message ID"
+          },
+          "format": {
+            "type": "string",
+            "enum": [
+              "full",
+              "metadata",
+              "minimal"
+            ],
+            "default": "full",
+            "description": "Response format"
+          }
+        },
+        "required": [
+          "messageId"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "gws_gmail_send",
+      "title": "Send Gmail",
+      "description": "Send an email via Gmail.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "to": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 500,
+            "description": "Recipient email address"
+          },
+          "subject": {
+            "type": "string",
+            "maxLength": 1000,
+            "description": "Email subject"
+          },
+          "body": {
+            "type": "string",
+            "maxLength": 50000,
+            "description": "Email body (plain text)"
+          },
+          "cc": {
+            "type": "string",
+            "maxLength": 1000,
+            "description": "CC recipients (comma-separated)"
+          }
+        },
+        "required": [
+          "to",
+          "subject",
+          "body"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": true,
+        "idempotentHint": false,
+        "openWorldHint": true
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "gws_people_search",
+      "title": "Search Google Contacts",
+      "description": "Search contacts in Google People/Contacts.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "query": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 500,
+            "description": "Search query (name, email, phone)"
+          },
+          "pageSize": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 30,
+            "default": 10
+          }
+        },
+        "required": [
+          "query"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "gws_raw",
+      "title": "Raw GWS Command",
+      "description": "Execute any Google Workspace CLI command.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "service": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 64,
+            "description": "Service name. Allowed: gmail, drive, sheets, calendar, docs, slides, tasks, chat, forms, keep, people"
+          },
+          "resource": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 500,
+            "description": "Resource (e.g. 'users.messages', 'files', 'spreadsheets.values')"
+          },
+          "method": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 64,
+            "description": "Method (e.g. 'list', 'get', 'create', 'update', 'delete')"
+          },
+          "params": {
+            "type": "object",
+            "additionalProperties": {},
+            "description": "URL/query parameters as JSON"
+          },
+          "body": {
+            "type": "object",
+            "additionalProperties": {},
+            "description": "Request body as JSON"
+          }
+        },
+        "required": [
+          "service",
+          "resource",
+          "method"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": true,
+        "idempotentHint": false,
+        "openWorldHint": true
+      },
+      "appIntentEligible": false
+    },
+    {
+      "name": "gws_sheets_read",
+      "title": "Read Google Sheet",
+      "description": "Read cell values from a Google Sheets spreadsheet.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "spreadsheetId": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 500,
+            "description": "Spreadsheet ID (from URL)"
+          },
+          "range": {
+            "type": "string",
+            "maxLength": 1000,
+            "default": "Sheet1",
+            "description": "A1 range notation (e.g. 'Sheet1!A1:D10')"
+          }
+        },
+        "required": [
+          "spreadsheetId"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "gws_sheets_write",
+      "title": "Write to Google Sheet",
+      "description": "Write values to a Google Sheets range.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "spreadsheetId": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 500,
+            "description": "Spreadsheet ID"
+          },
+          "range": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 1000,
+            "description": "A1 range (e.g. 'Sheet1!A1:B2')"
+          },
+          "values": {
+            "type": "array",
+            "items": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "minItems": 1,
+            "description": "2D array of cell values [[row1col1, row1col2], ...]"
+          }
+        },
+        "required": [
+          "spreadsheetId",
+          "range",
+          "values"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": true
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "gws_status",
+      "title": "Google Workspace Status",
+      "description": "Check if Google Workspace CLI (gws) is installed and authenticated.",
+      "inputSchema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {}
+      },
+      "outputSchema": null,
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "gws_tasks_create",
+      "title": "Create Google Task",
+      "description": "Create a task in Google Tasks.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "title": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 500,
+            "description": "Task title"
+          },
+          "notes": {
+            "type": "string",
+            "maxLength": 5000,
+            "description": "Task notes/description"
+          },
+          "due": {
+            "type": "string",
+            "maxLength": 64,
+            "description": "Due date (ISO 8601 or YYYY-MM-DD)"
+          }
+        },
+        "required": [
+          "title"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": true
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "gws_tasks_list",
+      "title": "List Google Tasks",
+      "description": "List tasks from Google Tasks (default task list).",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "maxResults": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 100,
+            "default": 20
+          },
+          "showCompleted": {
+            "type": "boolean",
+            "default": false,
+            "description": "Include completed tasks"
+          }
+        },
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "import_photo",
+      "title": "Import Photo",
+      "description": "Import a photo from a file path into Photos library.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "filePath": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 4096,
+            "description": "Absolute file path to the image file to import"
+          },
+          "albumName": {
+            "type": "string",
+            "maxLength": 500,
+            "description": "Album to add the imported photo to (must already exist)"
+          }
+        },
+        "required": [
+          "filePath"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": false
+      },
+      "appIntentEligible": true
+    },
+    {
       "name": "import_shortcut",
       "title": "Import Shortcut",
       "description": "Import a .shortcut file into Siri Shortcuts.",
@@ -1896,6 +3906,274 @@
       "appIntentEligible": true
     },
     {
+      "name": "keynote_add_slide",
+      "title": "Add Keynote Slide",
+      "description": "Add a new slide to a Keynote presentation.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "document": {
+            "type": "string",
+            "maxLength": 500,
+            "description": "Document name"
+          }
+        },
+        "required": [
+          "document"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": false
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "keynote_close_document",
+      "title": "Close Keynote Document",
+      "description": "Close an open Keynote presentation, optionally saving changes.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "document": {
+            "type": "string",
+            "maxLength": 500,
+            "description": "Document name"
+          },
+          "saving": {
+            "type": "boolean",
+            "default": true,
+            "description": "Save before closing (default: true)"
+          }
+        },
+        "required": [
+          "document"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": true,
+        "idempotentHint": false,
+        "openWorldHint": false
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "keynote_create_document",
+      "title": "Create Keynote Presentation",
+      "description": "Create a new blank Keynote presentation.",
+      "inputSchema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {}
+      },
+      "outputSchema": null,
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": false
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "keynote_export_pdf",
+      "title": "Export Keynote to PDF",
+      "description": "Export a Keynote presentation to PDF.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "document": {
+            "type": "string",
+            "maxLength": 500,
+            "description": "Document name"
+          },
+          "outputPath": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 4096,
+            "description": "Absolute output path for the PDF file"
+          }
+        },
+        "required": [
+          "document",
+          "outputPath"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": true,
+        "idempotentHint": false,
+        "openWorldHint": true
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "keynote_get_slide",
+      "title": "Get Keynote Slide",
+      "description": "Get detailed content of a specific slide including all text items and present...",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "document": {
+            "type": "string",
+            "maxLength": 500,
+            "description": "Document name"
+          },
+          "slideNumber": {
+            "type": "integer",
+            "minimum": 1,
+            "description": "Slide number (1-based)"
+          }
+        },
+        "required": [
+          "document",
+          "slideNumber"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "keynote_list_documents",
+      "title": "List Keynote Documents",
+      "description": "List all open Keynote presentations.",
+      "inputSchema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {}
+      },
+      "outputSchema": null,
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "keynote_list_slides",
+      "title": "List Keynote Slides",
+      "description": "List all slides in a Keynote presentation with title, body preview, and prese...",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "document": {
+            "type": "string",
+            "maxLength": 500,
+            "description": "Document name"
+          }
+        },
+        "required": [
+          "document"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "keynote_set_presenter_notes",
+      "title": "Set Keynote Presenter Notes",
+      "description": "Set presenter notes on a specific slide.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "document": {
+            "type": "string",
+            "maxLength": 500,
+            "description": "Document name"
+          },
+          "slideNumber": {
+            "type": "integer",
+            "minimum": 1,
+            "description": "Slide number (1-based)"
+          },
+          "notes": {
+            "type": "string",
+            "maxLength": 5000,
+            "description": "Presenter notes text"
+          }
+        },
+        "required": [
+          "document",
+          "slideNumber",
+          "notes"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "keynote_start_slideshow",
+      "title": "Start Keynote Slideshow",
+      "description": "Start playing a Keynote slideshow from a specific slide.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "document": {
+            "type": "string",
+            "maxLength": 500,
+            "description": "Document name"
+          },
+          "fromSlide": {
+            "type": "integer",
+            "minimum": 1,
+            "default": 1,
+            "description": "Start from slide number (default: 1)"
+          }
+        },
+        "required": [
+          "document"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": false
+      },
+      "appIntentEligible": true
+    },
+    {
       "name": "launch_app",
       "title": "Launch App",
       "description": "Launch an application by name.",
@@ -1921,6 +4199,80 @@
         "destructiveHint": false,
         "idempotentHint": true,
         "openWorldHint": true
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "list_accounts",
+      "title": "List Mail Accounts",
+      "description": "List all mail accounts.",
+      "inputSchema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {}
+      },
+      "outputSchema": {
+        "type": "object",
+        "properties": {
+          "accounts": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string"
+                },
+                "fullName": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "emailAddresses": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              },
+              "required": [
+                "name",
+                "fullName",
+                "emailAddresses"
+              ],
+              "additionalProperties": false
+            }
+          }
+        },
+        "required": [
+          "accounts"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "list_albums",
+      "title": "List Photo Albums",
+      "description": "List all photo albums with name and item count.",
+      "inputSchema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {}
+      },
+      "outputSchema": null,
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false
       },
       "appIntentEligible": true
     },
@@ -1952,6 +4304,60 @@
         "properties": {}
       },
       "outputSchema": null,
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "list_bookmarks",
+      "title": "List Bookmarks",
+      "description": "List all Safari bookmarks across all folders, including subfolder paths.",
+      "inputSchema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {}
+      },
+      "outputSchema": {
+        "type": "object",
+        "properties": {
+          "count": {
+            "type": "number"
+          },
+          "bookmarks": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "title": {
+                  "type": "string"
+                },
+                "url": {
+                  "type": "string"
+                },
+                "folder": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "title",
+                "url",
+                "folder"
+              ],
+              "additionalProperties": false
+            }
+          }
+        },
+        "required": [
+          "count",
+          "bookmarks"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
       "annotations": {
         "readOnlyHint": true,
         "destructiveHint": false,
@@ -2005,6 +4411,192 @@
         },
         "required": [
           "calendars"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "list_chats",
+      "title": "List Chats",
+      "description": "List recent chats in Messages with participants and last update time.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "limit": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 200,
+            "default": 50,
+            "description": "Max chats to return (default: 50)"
+          }
+        },
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "outputSchema": {
+        "type": "object",
+        "properties": {
+          "total": {
+            "type": "number"
+          },
+          "returned": {
+            "type": "number"
+          },
+          "chats": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string"
+                },
+                "name": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "participants": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "name": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "handle": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      }
+                    },
+                    "required": [
+                      "name",
+                      "handle"
+                    ],
+                    "additionalProperties": false
+                  }
+                },
+                "updated": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                }
+              },
+              "required": [
+                "id",
+                "name",
+                "participants",
+                "updated"
+              ],
+              "additionalProperties": false
+            }
+          }
+        },
+        "required": [
+          "total",
+          "returned",
+          "chats"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "list_contacts",
+      "title": "List Contacts",
+      "description": "List contacts with name, primary email, and phone.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "limit": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 1000,
+            "default": 100,
+            "description": "Max contacts (default: 100)"
+          },
+          "offset": {
+            "type": "integer",
+            "minimum": 0,
+            "default": 0,
+            "description": "Skip N contacts (default: 0)"
+          }
+        },
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "outputSchema": {
+        "type": "object",
+        "properties": {
+          "total": {
+            "type": "number"
+          },
+          "offset": {
+            "type": "number"
+          },
+          "returned": {
+            "type": "number"
+          },
+          "contacts": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string"
+                },
+                "name": {
+                  "type": "string"
+                },
+                "email": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "phone": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                }
+              },
+              "required": [
+                "id",
+                "name",
+                "email",
+                "phone"
+              ],
+              "additionalProperties": false
+            }
+          }
+        },
+        "required": [
+          "total",
+          "offset",
+          "returned",
+          "contacts"
         ],
         "additionalProperties": false,
         "$schema": "http://json-schema.org/draft-07/schema#"
@@ -2204,6 +4796,33 @@
       "appIntentEligible": true
     },
     {
+      "name": "list_favorites",
+      "title": "List Favorite Photos",
+      "description": "List photos marked as favorites.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "limit": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 500,
+            "default": 50,
+            "description": "Max photos (default: 50)"
+          }
+        },
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false
+      },
+      "appIntentEligible": true
+    },
+    {
       "name": "list_folders",
       "title": "List Folders",
       "description": "List all folders across all accounts with note counts.",
@@ -2249,6 +4868,296 @@
         },
         "required": [
           "folders"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "list_group_members",
+      "title": "List Group Members",
+      "description": "List contacts in a specific group.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "groupName": {
+            "type": "string",
+            "maxLength": 500,
+            "description": "Group name"
+          },
+          "limit": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 1000,
+            "default": 100,
+            "description": "Max contacts (default: 100)"
+          }
+        },
+        "required": [
+          "groupName"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "outputSchema": {
+        "type": "object",
+        "properties": {
+          "group": {
+            "type": "string"
+          },
+          "total": {
+            "type": "number"
+          },
+          "returned": {
+            "type": "number"
+          },
+          "contacts": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string"
+                },
+                "name": {
+                  "type": "string"
+                },
+                "email": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "phone": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                }
+              },
+              "required": [
+                "id",
+                "name",
+                "email",
+                "phone"
+              ],
+              "additionalProperties": false
+            }
+          }
+        },
+        "required": [
+          "group",
+          "total",
+          "returned",
+          "contacts"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "list_groups",
+      "title": "List Contact Groups",
+      "description": "List all contact groups.",
+      "inputSchema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {}
+      },
+      "outputSchema": {
+        "type": "object",
+        "properties": {
+          "groups": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string"
+                },
+                "name": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "id",
+                "name"
+              ],
+              "additionalProperties": false
+            }
+          }
+        },
+        "required": [
+          "groups"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "list_mailboxes",
+      "title": "List Mailboxes",
+      "description": "List all mailboxes across accounts with unread counts.",
+      "inputSchema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {}
+      },
+      "outputSchema": {
+        "type": "object",
+        "properties": {
+          "mailboxes": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string"
+                },
+                "account": {
+                  "type": "string"
+                },
+                "unreadCount": {
+                  "type": "number"
+                }
+              },
+              "required": [
+                "name",
+                "account",
+                "unreadCount"
+              ],
+              "additionalProperties": false
+            }
+          }
+        },
+        "required": [
+          "mailboxes"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "list_messages",
+      "title": "List Messages",
+      "description": "List recent messages in a mailbox (e.g.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "mailbox": {
+            "type": "string",
+            "maxLength": 500,
+            "description": "Mailbox name (e.g. 'INBOX', 'Sent Messages')"
+          },
+          "account": {
+            "type": "string",
+            "maxLength": 500,
+            "description": "Account name. Defaults to first account."
+          },
+          "limit": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 200,
+            "default": 50,
+            "description": "Max messages (default: 50)"
+          },
+          "offset": {
+            "type": "integer",
+            "minimum": 0,
+            "default": 0,
+            "description": "Pagination offset (default: 0)"
+          }
+        },
+        "required": [
+          "mailbox"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "outputSchema": {
+        "type": "object",
+        "properties": {
+          "total": {
+            "type": "number"
+          },
+          "offset": {
+            "type": "number"
+          },
+          "returned": {
+            "type": "number"
+          },
+          "messages": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string"
+                },
+                "subject": {
+                  "type": "string"
+                },
+                "sender": {
+                  "type": "string"
+                },
+                "dateReceived": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "read": {
+                  "type": "boolean"
+                },
+                "flagged": {
+                  "type": "boolean"
+                }
+              },
+              "required": [
+                "id",
+                "subject",
+                "sender",
+                "dateReceived",
+                "read",
+                "flagged"
+              ],
+              "additionalProperties": false
+            }
+          }
+        },
+        "required": [
+          "total",
+          "offset",
+          "returned",
+          "messages"
         ],
         "additionalProperties": false,
         "$schema": "http://json-schema.org/draft-07/schema#"
@@ -2343,6 +5252,277 @@
           "offset",
           "returned",
           "notes"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "list_participants",
+      "title": "List Chat Participants",
+      "description": "List all participants in a specific chat.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "chatId": {
+            "type": "string",
+            "maxLength": 500,
+            "description": "Chat ID"
+          }
+        },
+        "required": [
+          "chatId"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "outputSchema": {
+        "type": "object",
+        "properties": {
+          "chatId": {
+            "type": "string"
+          },
+          "chatName": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "participants": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "handle": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                }
+              },
+              "required": [
+                "name",
+                "handle"
+              ],
+              "additionalProperties": false
+            }
+          }
+        },
+        "required": [
+          "chatId",
+          "chatName",
+          "participants"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "list_photos",
+      "title": "List Photos",
+      "description": "List photos in an album with metadata.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "album": {
+            "type": "string",
+            "maxLength": 500,
+            "description": "Album name"
+          },
+          "limit": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 500,
+            "default": 50,
+            "description": "Max photos (default: 50)"
+          },
+          "offset": {
+            "type": "integer",
+            "minimum": 0,
+            "default": 0,
+            "description": "Offset for pagination (default: 0)"
+          }
+        },
+        "required": [
+          "album"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "list_playlists",
+      "title": "List Playlists",
+      "description": "List all Music playlists with track counts and duration.",
+      "inputSchema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {}
+      },
+      "outputSchema": {
+        "type": "object",
+        "properties": {
+          "playlists": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string"
+                },
+                "name": {
+                  "type": "string"
+                },
+                "duration": {
+                  "type": "number"
+                },
+                "trackCount": {
+                  "type": "number"
+                }
+              },
+              "required": [
+                "id",
+                "name",
+                "duration",
+                "trackCount"
+              ],
+              "additionalProperties": false
+            }
+          }
+        },
+        "required": [
+          "playlists"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "list_podcast_episodes",
+      "title": "List Podcast Episodes",
+      "description": "List episodes of a podcast show with title, date, duration, and played status.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "showName": {
+            "type": "string",
+            "maxLength": 500,
+            "description": "Podcast show name"
+          },
+          "limit": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 100,
+            "default": 20,
+            "description": "Max episodes (default: 20)"
+          }
+        },
+        "required": [
+          "showName"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "list_podcast_shows",
+      "title": "List Podcast Shows",
+      "description": "List all subscribed podcast shows with episode counts.",
+      "inputSchema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {}
+      },
+      "outputSchema": null,
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "list_reading_list",
+      "title": "List Reading List",
+      "description": "List all items in Safari's Reading List.",
+      "inputSchema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {}
+      },
+      "outputSchema": {
+        "type": "object",
+        "properties": {
+          "count": {
+            "type": "number"
+          },
+          "items": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "title": {
+                  "type": "string"
+                },
+                "url": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "title",
+                "url"
+              ],
+              "additionalProperties": false
+            }
+          }
+        },
+        "required": [
+          "count",
+          "items"
         ],
         "additionalProperties": false,
         "$schema": "http://json-schema.org/draft-07/schema#"
@@ -2566,6 +5746,173 @@
       "appIntentEligible": true
     },
     {
+      "name": "list_tabs",
+      "title": "List Safari Tabs",
+      "description": "List all open tabs across all Safari windows with title and URL.",
+      "inputSchema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {}
+      },
+      "outputSchema": {
+        "type": "object",
+        "properties": {
+          "tabs": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "windowIndex": {
+                  "type": "number"
+                },
+                "tabIndex": {
+                  "type": "number"
+                },
+                "title": {
+                  "type": "string"
+                },
+                "url": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "windowIndex",
+                "tabIndex",
+                "title",
+                "url"
+              ],
+              "additionalProperties": false
+            }
+          }
+        },
+        "required": [
+          "tabs"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "list_tracks",
+      "title": "List Tracks",
+      "description": "List tracks in a playlist with name, artist, album, and duration.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "playlist": {
+            "type": "string",
+            "maxLength": 500,
+            "description": "Playlist name"
+          },
+          "limit": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 500,
+            "default": 100,
+            "description": "Max tracks (default: 100)"
+          }
+        },
+        "required": [
+          "playlist"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "outputSchema": {
+        "type": "object",
+        "properties": {
+          "total": {
+            "type": "number"
+          },
+          "returned": {
+            "type": "number"
+          },
+          "tracks": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string"
+                },
+                "name": {
+                  "type": "string"
+                },
+                "artist": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "album": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "duration": {
+                  "type": [
+                    "number",
+                    "null"
+                  ]
+                },
+                "trackNumber": {
+                  "type": [
+                    "number",
+                    "null"
+                  ]
+                },
+                "genre": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "year": {
+                  "type": [
+                    "number",
+                    "null"
+                  ]
+                }
+              },
+              "required": [
+                "id",
+                "name",
+                "artist",
+                "album",
+                "duration",
+                "trackNumber",
+                "genre",
+                "year"
+              ],
+              "additionalProperties": false
+            }
+          }
+        },
+        "required": [
+          "total",
+          "returned",
+          "tracks"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false
+      },
+      "appIntentEligible": true
+    },
+    {
       "name": "list_triggers",
       "title": "List Event Triggers",
       "description": "Show all skills with event triggers (calendar_changed, reminders_changed, pas...",
@@ -2580,6 +5927,24 @@
         "destructiveHint": false,
         "idempotentHint": true,
         "openWorldHint": false
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "list_windows",
+      "title": "List Windows",
+      "description": "List all visible windows across all running applications.",
+      "inputSchema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {}
+      },
+      "outputSchema": null,
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
       },
       "appIntentEligible": true
     },
@@ -2637,6 +6002,40 @@
         "destructiveHint": false,
         "idempotentHint": true,
         "openWorldHint": true
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "mark_message_read",
+      "title": "Mark Message Read/Unread",
+      "description": "Mark an email message as read or unread.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "maxLength": 500,
+            "pattern": "^\\d+$",
+            "description": "Message ID"
+          },
+          "read": {
+            "type": "boolean",
+            "default": true,
+            "description": "true=read, false=unread (default: true)"
+          }
+        },
+        "required": [
+          "id"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false
       },
       "appIntentEligible": true
     },
@@ -3081,6 +6480,46 @@
       "appIntentEligible": true
     },
     {
+      "name": "move_message",
+      "title": "Move Message",
+      "description": "Move a message to another mailbox.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "maxLength": 500,
+            "pattern": "^\\d+$",
+            "description": "Message ID"
+          },
+          "targetMailbox": {
+            "type": "string",
+            "maxLength": 500,
+            "description": "Target mailbox name (e.g. 'Archive', 'Trash')"
+          },
+          "targetAccount": {
+            "type": "string",
+            "maxLength": 500,
+            "description": "Target account name. Searches all accounts if omitted."
+          }
+        },
+        "required": [
+          "id",
+          "targetMailbox"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": true,
+        "idempotentHint": false,
+        "openWorldHint": false
+      },
+      "appIntentEligible": true
+    },
+    {
       "name": "move_note",
       "title": "Move Note",
       "description": "Move a note to a different folder.",
@@ -3154,6 +6593,833 @@
         "readOnlyHint": false,
         "destructiveHint": false,
         "idempotentHint": true,
+        "openWorldHint": false
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "music_player",
+      "title": "Music Player",
+      "description": "Display an interactive music player showing the currently playing track.",
+      "inputSchema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {}
+      },
+      "outputSchema": null,
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "now_playing",
+      "title": "Now Playing",
+      "description": "Get the currently playing track and playback state.",
+      "inputSchema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {}
+      },
+      "outputSchema": {
+        "type": "object",
+        "properties": {
+          "playerState": {
+            "type": "string"
+          },
+          "track": {
+            "anyOf": [
+              {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  },
+                  "artist": {
+                    "type": "string"
+                  },
+                  "album": {
+                    "type": "string"
+                  },
+                  "duration": {
+                    "type": "number"
+                  },
+                  "playerPosition": {
+                    "type": "number"
+                  }
+                },
+                "required": [
+                  "name",
+                  "artist",
+                  "album",
+                  "duration",
+                  "playerPosition"
+                ],
+                "additionalProperties": false
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "required": [
+          "playerState",
+          "track"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "numbers_add_sheet",
+      "title": "Add Numbers Sheet",
+      "description": "Add a new sheet to a Numbers spreadsheet.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "document": {
+            "type": "string",
+            "maxLength": 500,
+            "description": "Document name"
+          },
+          "sheetName": {
+            "type": "string",
+            "maxLength": 500,
+            "description": "Name for the new sheet"
+          }
+        },
+        "required": [
+          "document",
+          "sheetName"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": false
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "numbers_close_document",
+      "title": "Close Numbers Document",
+      "description": "Close an open Numbers spreadsheet, optionally saving changes.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "document": {
+            "type": "string",
+            "maxLength": 500,
+            "description": "Document name"
+          },
+          "saving": {
+            "type": "boolean",
+            "default": true,
+            "description": "Save before closing (default: true)"
+          }
+        },
+        "required": [
+          "document"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": true,
+        "idempotentHint": false,
+        "openWorldHint": false
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "numbers_create_document",
+      "title": "Create Numbers Document",
+      "description": "Create a new blank Numbers spreadsheet.",
+      "inputSchema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {}
+      },
+      "outputSchema": null,
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": false
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "numbers_export_pdf",
+      "title": "Export Numbers to PDF",
+      "description": "Export a Numbers spreadsheet to PDF.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "document": {
+            "type": "string",
+            "maxLength": 500,
+            "description": "Document name"
+          },
+          "outputPath": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 4096,
+            "description": "Absolute output path for the PDF file"
+          }
+        },
+        "required": [
+          "document",
+          "outputPath"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": true,
+        "idempotentHint": false,
+        "openWorldHint": true
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "numbers_get_cell",
+      "title": "Get Numbers Cell",
+      "description": "Read a single cell value by address (e.g.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "document": {
+            "type": "string",
+            "maxLength": 500,
+            "description": "Document name"
+          },
+          "sheet": {
+            "type": "string",
+            "maxLength": 500,
+            "description": "Sheet name"
+          },
+          "cell": {
+            "type": "string",
+            "maxLength": 500,
+            "description": "Cell address (e.g. 'A1', 'B3')"
+          }
+        },
+        "required": [
+          "document",
+          "sheet",
+          "cell"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "numbers_list_documents",
+      "title": "List Numbers Documents",
+      "description": "List all open Numbers spreadsheets.",
+      "inputSchema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {}
+      },
+      "outputSchema": null,
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "numbers_list_sheets",
+      "title": "List Numbers Sheets",
+      "description": "List all sheets (tabs) in a Numbers spreadsheet.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "document": {
+            "type": "string",
+            "maxLength": 500,
+            "description": "Document name"
+          }
+        },
+        "required": [
+          "document"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "numbers_read_cells",
+      "title": "Read Numbers Cell Range",
+      "description": "Read a range of cells from a sheet.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "document": {
+            "type": "string",
+            "maxLength": 500,
+            "description": "Document name"
+          },
+          "sheet": {
+            "type": "string",
+            "maxLength": 500,
+            "description": "Sheet name"
+          },
+          "startRow": {
+            "type": "integer",
+            "minimum": 0,
+            "description": "Start row index (0-based)"
+          },
+          "startCol": {
+            "type": "integer",
+            "minimum": 0,
+            "description": "Start column index (0-based)"
+          },
+          "endRow": {
+            "type": "integer",
+            "minimum": 0,
+            "description": "End row index (inclusive)"
+          },
+          "endCol": {
+            "type": "integer",
+            "minimum": 0,
+            "description": "End column index (inclusive)"
+          }
+        },
+        "required": [
+          "document",
+          "sheet",
+          "startRow",
+          "startCol",
+          "endRow",
+          "endCol"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "numbers_set_cell",
+      "title": "Set Numbers Cell",
+      "description": "Write a value to a single cell.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "document": {
+            "type": "string",
+            "maxLength": 500,
+            "description": "Document name"
+          },
+          "sheet": {
+            "type": "string",
+            "maxLength": 500,
+            "description": "Sheet name"
+          },
+          "cell": {
+            "type": "string",
+            "maxLength": 500,
+            "description": "Cell address (e.g. 'A1')"
+          },
+          "value": {
+            "type": "string",
+            "maxLength": 10000,
+            "description": "Value to write"
+          }
+        },
+        "required": [
+          "document",
+          "sheet",
+          "cell",
+          "value"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "open_address",
+      "title": "Open Address",
+      "description": "Open a specific address in Apple Maps.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "address": {
+            "type": "string",
+            "maxLength": 500,
+            "description": "Address to open in Maps"
+          }
+        },
+        "required": [
+          "address"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "open_url",
+      "title": "Open URL",
+      "description": "Open a URL in Safari's frontmost window.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "url": {
+            "type": "string",
+            "format": "uri",
+            "description": "URL to open"
+          }
+        },
+        "required": [
+          "url"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "pages_close_document",
+      "title": "Close Pages Document",
+      "description": "Close an open Pages document, optionally saving changes.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "document": {
+            "type": "string",
+            "maxLength": 500,
+            "description": "Document name"
+          },
+          "saving": {
+            "type": "boolean",
+            "default": true,
+            "description": "Save before closing (default: true)"
+          }
+        },
+        "required": [
+          "document"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": true,
+        "idempotentHint": false,
+        "openWorldHint": false
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "pages_create_document",
+      "title": "Create Pages Document",
+      "description": "Create a new blank Pages document.",
+      "inputSchema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {}
+      },
+      "outputSchema": null,
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": false
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "pages_export_pdf",
+      "title": "Export Pages to PDF",
+      "description": "Export an open Pages document to PDF.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "document": {
+            "type": "string",
+            "maxLength": 500,
+            "description": "Document name"
+          },
+          "outputPath": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 4096,
+            "description": "Absolute output path for the PDF file"
+          }
+        },
+        "required": [
+          "document",
+          "outputPath"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": true,
+        "idempotentHint": false,
+        "openWorldHint": true
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "pages_get_body_text",
+      "title": "Get Pages Body Text",
+      "description": "Get the body text content of an open Pages document.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "document": {
+            "type": "string",
+            "maxLength": 500,
+            "description": "Document name (as shown in title bar)"
+          }
+        },
+        "required": [
+          "document"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "pages_list_documents",
+      "title": "List Pages Documents",
+      "description": "List all open Pages documents with name, path, and modified status.",
+      "inputSchema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {}
+      },
+      "outputSchema": null,
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "pages_open_document",
+      "title": "Open Pages Document",
+      "description": "Open a Pages document from a file path.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "path": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 4096,
+            "description": "Absolute file path to the .pages document"
+          }
+        },
+        "required": [
+          "path"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": false
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "pages_set_body_text",
+      "title": "Set Pages Body Text",
+      "description": "Replace the body text of an open Pages document.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "document": {
+            "type": "string",
+            "maxLength": 500,
+            "description": "Document name"
+          },
+          "text": {
+            "type": "string",
+            "maxLength": 50000,
+            "description": "New body text content"
+          }
+        },
+        "required": [
+          "document",
+          "text"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": true,
+        "idempotentHint": true,
+        "openWorldHint": false
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "play_playlist",
+      "title": "Play Playlist",
+      "description": "Start playing a playlist by name, with optional shuffle control.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "maxLength": 500,
+            "description": "Playlist name"
+          },
+          "shuffle": {
+            "type": "boolean",
+            "description": "Enable or disable shuffle"
+          }
+        },
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": false
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "play_podcast_episode",
+      "title": "Play Podcast Episode",
+      "description": "Play a specific podcast episode by name, optionally from a specific show.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "episodeName": {
+            "type": "string",
+            "maxLength": 500,
+            "description": "Episode name to play"
+          },
+          "showName": {
+            "type": "string",
+            "maxLength": 500,
+            "description": "Show to search in (searches all shows if omitted)"
+          }
+        },
+        "required": [
+          "episodeName"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": false
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "play_track",
+      "title": "Play Track",
+      "description": "Play a specific track by name, optionally from a specific playlist.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "trackName": {
+            "type": "string",
+            "maxLength": 500,
+            "description": "Track name to play"
+          },
+          "playlist": {
+            "type": "string",
+            "maxLength": 500,
+            "description": "Playlist to search in (default: Library)"
+          }
+        },
+        "required": [
+          "trackName"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": false
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "playback_control",
+      "title": "Playback Control",
+      "description": "Control Music playback: play, pause, nextTrack, previousTrack.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "action": {
+            "type": "string",
+            "enum": [
+              "play",
+              "pause",
+              "nextTrack",
+              "previousTrack"
+            ],
+            "description": "Playback action"
+          }
+        },
+        "required": [
+          "action"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": false
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "podcast_now_playing",
+      "title": "Podcast Now Playing",
+      "description": "Get the currently playing podcast episode and playback state.",
+      "inputSchema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {}
+      },
+      "outputSchema": null,
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "podcast_playback_control",
+      "title": "Podcast Playback Control",
+      "description": "Control Podcasts playback: play, pause, next, previous.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "action": {
+            "type": "string",
+            "enum": [
+              "play",
+              "pause",
+              "nextTrack",
+              "previousTrack"
+            ],
+            "description": "Playback action"
+          }
+        },
+        "required": [
+          "action"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": false,
         "openWorldHint": false
       },
       "appIntentEligible": true
@@ -3266,6 +7532,84 @@
       "appIntentEligible": true
     },
     {
+      "name": "proofread_text",
+      "title": "Proofread Text",
+      "description": "Proofread and correct grammar/spelling using Apple Intelligence (on-device Fo...",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "text": {
+            "type": "string",
+            "maxLength": 10000,
+            "description": "Text to proofread"
+          }
+        },
+        "required": [
+          "text"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": false
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "query_photos",
+      "title": "Query Photos",
+      "description": "Query the Photos library with filters: media type, date range, favorites.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "mediaType": {
+            "type": "string",
+            "enum": [
+              "image",
+              "video",
+              "audio"
+            ],
+            "description": "Filter by media type"
+          },
+          "startDate": {
+            "type": "string",
+            "maxLength": 64,
+            "description": "Start date (ISO 8601)"
+          },
+          "endDate": {
+            "type": "string",
+            "maxLength": 64,
+            "description": "End date (ISO 8601)"
+          },
+          "favorites": {
+            "type": "boolean",
+            "description": "Only favorites"
+          },
+          "limit": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 200,
+            "default": 50,
+            "description": "Max results (default: 50)"
+          }
+        },
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false
+      },
+      "appIntentEligible": true
+    },
+    {
       "name": "quit_app",
       "title": "Quit App",
       "description": "Quit a running application by name.",
@@ -3289,6 +7633,242 @@
       "annotations": {
         "readOnlyHint": false,
         "destructiveHint": true,
+        "idempotentHint": true,
+        "openWorldHint": false
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "read_chat",
+      "title": "Read Chat",
+      "description": "Read chat details including participants and last update time by chat ID.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "chatId": {
+            "type": "string",
+            "maxLength": 500,
+            "description": "Chat ID"
+          }
+        },
+        "required": [
+          "chatId"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "outputSchema": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "participants": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "handle": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                }
+              },
+              "required": [
+                "name",
+                "handle"
+              ],
+              "additionalProperties": false
+            }
+          },
+          "updated": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "participants",
+          "updated"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "read_contact",
+      "title": "Read Contact",
+      "description": "Read full details of a contact by ID including all emails, phones, and addres...",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "maxLength": 500,
+            "description": "Contact ID"
+          }
+        },
+        "required": [
+          "id"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "outputSchema": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "firstName": {
+            "type": "string"
+          },
+          "lastName": {
+            "type": "string"
+          },
+          "organization": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "jobTitle": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "department": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "note": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "emails": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "value": {
+                  "type": "string"
+                },
+                "label": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "value",
+                "label"
+              ],
+              "additionalProperties": false
+            }
+          },
+          "phones": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "value": {
+                  "type": "string"
+                },
+                "label": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "value",
+                "label"
+              ],
+              "additionalProperties": false
+            }
+          },
+          "addresses": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "street": {
+                  "type": "string"
+                },
+                "city": {
+                  "type": "string"
+                },
+                "state": {
+                  "type": "string"
+                },
+                "zip": {
+                  "type": "string"
+                },
+                "country": {
+                  "type": "string"
+                },
+                "label": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "street",
+                "city",
+                "state",
+                "zip",
+                "country",
+                "label"
+              ],
+              "additionalProperties": false
+            }
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "firstName",
+          "lastName",
+          "organization",
+          "jobTitle",
+          "department",
+          "note",
+          "emails",
+          "phones",
+          "addresses"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
         "idempotentHint": true,
         "openWorldHint": false
       },
@@ -3416,6 +7996,42 @@
       "appIntentEligible": true
     },
     {
+      "name": "read_message",
+      "title": "Read Message",
+      "description": "Read full content of an email message by ID.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "maxLength": 500,
+            "pattern": "^\\d+$",
+            "description": "Message ID"
+          },
+          "maxLength": {
+            "type": "integer",
+            "minimum": 100,
+            "maximum": 100000,
+            "default": 5000,
+            "description": "Max content length (default: 5000)"
+          }
+        },
+        "required": [
+          "id"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false
+      },
+      "appIntentEligible": true
+    },
+    {
       "name": "read_note",
       "title": "Read Note",
       "description": "Read the full content of a specific note by its ID.",
@@ -3479,6 +8095,45 @@
         "additionalProperties": false,
         "$schema": "http://json-schema.org/draft-07/schema#"
       },
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "read_page_content",
+      "title": "Read Page Content",
+      "description": "Read the HTML source of a Safari tab.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "windowIndex": {
+            "type": "integer",
+            "minimum": 0,
+            "default": 0,
+            "description": "Window index (default: 0)"
+          },
+          "tabIndex": {
+            "type": "integer",
+            "minimum": 0,
+            "default": 0,
+            "description": "Tab index (default: 0)"
+          },
+          "maxLength": {
+            "type": "integer",
+            "minimum": 100,
+            "maximum": 50000,
+            "default": 10000,
+            "description": "Max content length (default: 10000)"
+          }
+        },
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "outputSchema": null,
       "annotations": {
         "readOnlyHint": true,
         "destructiveHint": false,
@@ -3615,6 +8270,114 @@
       "appIntentEligible": true
     },
     {
+      "name": "record_screen",
+      "title": "Record Screen",
+      "description": "Record the screen for a specified duration (1-60 seconds).",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "duration": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 60,
+            "description": "Recording duration in seconds (1-60)"
+          },
+          "display": {
+            "type": "integer",
+            "minimum": 1,
+            "description": "Display number for multi-monitor setups (1 = main display). Omit for default display."
+          }
+        },
+        "required": [
+          "duration"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": true,
+        "idempotentHint": false,
+        "openWorldHint": true
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "remove_from_playlist",
+      "title": "Remove from Playlist",
+      "description": "Remove a track from a playlist.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "playlistName": {
+            "type": "string",
+            "maxLength": 500,
+            "description": "Playlist name"
+          },
+          "trackName": {
+            "type": "string",
+            "maxLength": 500,
+            "description": "Track name to remove"
+          }
+        },
+        "required": [
+          "playlistName",
+          "trackName"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": true,
+        "idempotentHint": false,
+        "openWorldHint": false
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "reply_mail",
+      "title": "Reply to Email",
+      "description": "Reply to an email message.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "maxLength": 500,
+            "pattern": "^\\d+$",
+            "description": "Original message ID to reply to"
+          },
+          "body": {
+            "type": "string",
+            "maxLength": 50000,
+            "description": "Reply body text"
+          },
+          "replyAll": {
+            "type": "boolean",
+            "default": false,
+            "description": "Reply to all recipients (default: false)"
+          }
+        },
+        "required": [
+          "id",
+          "body"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": true,
+        "idempotentHint": false,
+        "openWorldHint": true
+      },
+      "appIntentEligible": true
+    },
+    {
       "name": "resize_window",
       "title": "Resize Window",
       "description": "Resize a window to specific dimensions.",
@@ -3661,6 +8424,120 @@
       "appIntentEligible": true
     },
     {
+      "name": "reverse_geocode",
+      "title": "Reverse Geocode",
+      "description": "Convert geographic coordinates to a place name and address.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "latitude": {
+            "type": "number",
+            "minimum": -90,
+            "maximum": 90,
+            "description": "Latitude coordinate"
+          },
+          "longitude": {
+            "type": "number",
+            "minimum": -180,
+            "maximum": 180,
+            "description": "Longitude coordinate"
+          }
+        },
+        "required": [
+          "latitude",
+          "longitude"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "rewrite_text",
+      "title": "Rewrite Text",
+      "description": "Rewrite text in a specified tone using Apple Intelligence (on-device Foundati...",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "text": {
+            "type": "string",
+            "maxLength": 10000,
+            "description": "Text to rewrite"
+          },
+          "tone": {
+            "type": "string",
+            "enum": [
+              "professional",
+              "friendly",
+              "concise"
+            ],
+            "default": "professional",
+            "description": "Target tone (default: professional)"
+          }
+        },
+        "required": [
+          "text"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": false
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "run_javascript",
+      "title": "Run JavaScript",
+      "description": "Execute JavaScript in a Safari tab.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "code": {
+            "type": "string",
+            "maxLength": 100000,
+            "description": "JavaScript to execute"
+          },
+          "windowIndex": {
+            "type": "integer",
+            "minimum": 0,
+            "default": 0,
+            "description": "Window index (default: 0)"
+          },
+          "tabIndex": {
+            "type": "integer",
+            "minimum": 0,
+            "default": 0,
+            "description": "Tab index (default: 0)"
+          }
+        },
+        "required": [
+          "code"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": true,
+        "idempotentHint": false,
+        "openWorldHint": true
+      },
+      "appIntentEligible": true
+    },
+    {
       "name": "run_shortcut",
       "title": "Run Shortcut",
       "description": "Run a Siri Shortcut by name.",
@@ -3690,6 +8567,62 @@
         "destructiveHint": true,
         "idempotentHint": false,
         "openWorldHint": true
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "scan_bluetooth",
+      "title": "Scan Bluetooth",
+      "description": "Scan for nearby BLE (Bluetooth Low Energy) devices.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "duration": {
+            "type": "number",
+            "minimum": 1,
+            "maximum": 30,
+            "default": 5,
+            "description": "Scan duration in seconds (1-30, default: 5)"
+          }
+        },
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": false
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "scan_document",
+      "title": "Scan Document",
+      "description": "Extract text and structure from an image file using Apple Vision framework OCR.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "imagePath": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 4096,
+            "description": "Absolute path to the image file to scan"
+          }
+        },
+        "required": [
+          "imagePath"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false
       },
       "appIntentEligible": true
     },
@@ -3730,6 +8663,209 @@
         "$schema": "http://json-schema.org/draft-07/schema#"
       },
       "outputSchema": null,
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "search_chats",
+      "title": "Search Chats",
+      "description": "Search chats by participant name, handle, or chat name.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "query": {
+            "type": "string",
+            "maxLength": 500,
+            "description": "Search keyword (matches chat name, participant name, or handle)"
+          },
+          "limit": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 100,
+            "default": 20,
+            "description": "Max results (default: 20)"
+          }
+        },
+        "required": [
+          "query"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "outputSchema": {
+        "type": "object",
+        "properties": {
+          "total": {
+            "type": "number"
+          },
+          "returned": {
+            "type": "number"
+          },
+          "chats": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string"
+                },
+                "name": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "participants": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "name": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "handle": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      }
+                    },
+                    "required": [
+                      "name",
+                      "handle"
+                    ],
+                    "additionalProperties": false
+                  }
+                },
+                "updated": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                }
+              },
+              "required": [
+                "id",
+                "name",
+                "participants",
+                "updated"
+              ],
+              "additionalProperties": false
+            }
+          }
+        },
+        "required": [
+          "total",
+          "returned",
+          "chats"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "search_contacts",
+      "title": "Search Contacts",
+      "description": "Search contacts by name, email, phone, or organization.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "query": {
+            "type": "string",
+            "maxLength": 500,
+            "description": "Search keyword (matches name)"
+          },
+          "limit": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 500,
+            "default": 50,
+            "description": "Max results (default: 50)"
+          }
+        },
+        "required": [
+          "query"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "outputSchema": {
+        "type": "object",
+        "properties": {
+          "total": {
+            "type": "number"
+          },
+          "returned": {
+            "type": "number"
+          },
+          "contacts": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string"
+                },
+                "name": {
+                  "type": "string"
+                },
+                "organization": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "email": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "phone": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "matchedField": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "id",
+                "name",
+                "organization",
+                "email",
+                "phone",
+                "matchedField"
+              ],
+              "additionalProperties": false
+            }
+          }
+        },
+        "required": [
+          "total",
+          "returned",
+          "contacts"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
       "annotations": {
         "readOnlyHint": true,
         "destructiveHint": false,
@@ -3876,6 +9012,111 @@
       "appIntentEligible": true
     },
     {
+      "name": "search_location",
+      "title": "Search Location",
+      "description": "Search for a place or location in Apple Maps.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "query": {
+            "type": "string",
+            "maxLength": 500,
+            "description": "Location or place to search for"
+          }
+        },
+        "required": [
+          "query"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "search_messages",
+      "title": "Search Messages",
+      "description": "Search messages by keyword in subject or sender within a mailbox.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "query": {
+            "type": "string",
+            "maxLength": 500,
+            "description": "Search keyword"
+          },
+          "mailbox": {
+            "type": "string",
+            "maxLength": 500,
+            "default": "INBOX",
+            "description": "Mailbox to search (default: INBOX)"
+          },
+          "limit": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 200,
+            "default": 30,
+            "description": "Max results (default: 30)"
+          }
+        },
+        "required": [
+          "query"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "search_nearby",
+      "title": "Search Nearby",
+      "description": "Search for places near a location in Apple Maps.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "query": {
+            "type": "string",
+            "maxLength": 500,
+            "description": "What to search for (e.g. 'coffee shops', 'gas stations')"
+          },
+          "latitude": {
+            "type": "number",
+            "description": "Latitude of the center point"
+          },
+          "longitude": {
+            "type": "number",
+            "description": "Longitude of the center point"
+          }
+        },
+        "required": [
+          "query"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      },
+      "appIntentEligible": true
+    },
+    {
       "name": "search_notes",
       "title": "Search Notes",
       "description": "Search notes by keyword in title and body.",
@@ -3965,6 +9206,76 @@
         "additionalProperties": false,
         "$schema": "http://json-schema.org/draft-07/schema#"
       },
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "search_photos",
+      "title": "Search Photos",
+      "description": "Search photos by filename, name, or description keyword.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "query": {
+            "type": "string",
+            "maxLength": 500,
+            "description": "Search keyword"
+          },
+          "limit": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 200,
+            "default": 30,
+            "description": "Max results (default: 30)"
+          }
+        },
+        "required": [
+          "query"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "search_podcast_episodes",
+      "title": "Search Podcast Episodes",
+      "description": "Search across all podcast episodes by name or description.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "query": {
+            "type": "string",
+            "maxLength": 500,
+            "description": "Search keyword"
+          },
+          "limit": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 100,
+            "default": 20,
+            "description": "Max results (default: 20)"
+          }
+        },
+        "required": [
+          "query"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "outputSchema": null,
       "annotations": {
         "readOnlyHint": true,
         "destructiveHint": false,
@@ -4111,6 +9422,69 @@
       "appIntentEligible": true
     },
     {
+      "name": "search_tabs",
+      "title": "Search Tabs",
+      "description": "Search open Safari tabs by title or URL keyword.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "query": {
+            "type": "string",
+            "maxLength": 500,
+            "description": "Search keyword to match against tab titles and URLs"
+          }
+        },
+        "required": [
+          "query"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "search_tracks",
+      "title": "Search Tracks",
+      "description": "Search tracks in Music library by name, artist, or album.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "query": {
+            "type": "string",
+            "maxLength": 500,
+            "description": "Search keyword"
+          },
+          "limit": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 200,
+            "default": 30,
+            "description": "Max results (default: 30)"
+          }
+        },
+        "required": [
+          "query"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false
+      },
+      "appIntentEligible": true
+    },
+    {
       "name": "semantic_clear",
       "title": "Clear Semantic Index",
       "description": "Delete all indexed data from the local vector store AND remove corresponding ...",
@@ -4235,6 +9609,145 @@
       "appIntentEligible": true
     },
     {
+      "name": "send_file",
+      "title": "Send File",
+      "description": "Send a file attachment via iMessage/SMS.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "target": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 1000,
+            "description": "Recipient handle (phone number or email)"
+          },
+          "filePath": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 4096,
+            "description": "Absolute file path to send"
+          }
+        },
+        "required": [
+          "target",
+          "filePath"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": true,
+        "idempotentHint": false,
+        "openWorldHint": true
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "send_mail",
+      "title": "Send Email",
+      "description": "Compose and send an email via Apple Mail.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "to": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "format": "email"
+            },
+            "minItems": 1,
+            "maxItems": 20,
+            "description": "Recipient email addresses (max 20)"
+          },
+          "subject": {
+            "type": "string",
+            "maxLength": 1000,
+            "description": "Email subject"
+          },
+          "body": {
+            "type": "string",
+            "maxLength": 50000,
+            "description": "Email body text"
+          },
+          "cc": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "format": "email"
+            },
+            "maxItems": 20,
+            "description": "CC recipients (max 20)"
+          },
+          "bcc": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "format": "email"
+            },
+            "maxItems": 20,
+            "description": "BCC recipients (max 20)"
+          },
+          "account": {
+            "type": "string",
+            "maxLength": 500,
+            "description": "Sender email address (uses default account if omitted)"
+          }
+        },
+        "required": [
+          "to",
+          "subject",
+          "body"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": true,
+        "idempotentHint": false,
+        "openWorldHint": true
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "send_message",
+      "title": "Send Message",
+      "description": "Send a text message via iMessage/SMS.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "target": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Recipient handle (phone number or email, e.g. '+821012345678' or 'user@example.com')"
+          },
+          "text": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 10000,
+            "description": "Message text to send"
+          }
+        },
+        "required": [
+          "target",
+          "text"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": true,
+        "idempotentHint": false,
+        "openWorldHint": true
+      },
+      "appIntentEligible": true
+    },
+    {
       "name": "set_brightness",
       "title": "Set Brightness",
       "description": "Set the display brightness level.",
@@ -4308,6 +9821,72 @@
       "appIntentEligible": true
     },
     {
+      "name": "set_disliked",
+      "title": "Set Disliked",
+      "description": "Mark or unmark a track as disliked.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "trackName": {
+            "type": "string",
+            "maxLength": 500,
+            "description": "Track name"
+          },
+          "disliked": {
+            "type": "boolean",
+            "description": "Whether to mark as disliked"
+          }
+        },
+        "required": [
+          "trackName",
+          "disliked"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "set_favorited",
+      "title": "Set Favorited",
+      "description": "Mark or unmark a track as favorited (loved).",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "trackName": {
+            "type": "string",
+            "maxLength": 500,
+            "description": "Track name"
+          },
+          "favorited": {
+            "type": "boolean",
+            "description": "Whether to mark as favorited"
+          }
+        },
+        "required": [
+          "trackName",
+          "favorited"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false
+      },
+      "appIntentEligible": true
+    },
+    {
       "name": "set_file_tags",
       "title": "Set File Tags",
       "description": "Set Finder tags on a file.",
@@ -4332,6 +9911,74 @@
           "path",
           "tags"
         ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "set_rating",
+      "title": "Set Rating",
+      "description": "Set the star rating (0-100) for a track.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "trackName": {
+            "type": "string",
+            "maxLength": 500,
+            "description": "Track name"
+          },
+          "rating": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 100,
+            "description": "Rating value (0-100)"
+          }
+        },
+        "required": [
+          "trackName",
+          "rating"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "set_shuffle",
+      "title": "Set Shuffle & Repeat",
+      "description": "Enable/disable shuffle and set repeat mode (off, one, all).",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "shuffle": {
+            "type": "boolean",
+            "description": "Enable or disable shuffle"
+          },
+          "songRepeat": {
+            "type": "string",
+            "enum": [
+              "off",
+              "one",
+              "all"
+            ],
+            "description": "Repeat mode"
+          }
+        },
         "additionalProperties": false,
         "$schema": "http://json-schema.org/draft-07/schema#"
       },
@@ -4398,6 +10045,43 @@
         "$schema": "http://json-schema.org/draft-07/schema#",
         "type": "object",
         "properties": {}
+      },
+      "outputSchema": null,
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "share_location",
+      "title": "Share Location",
+      "description": "Generate a shareable Apple Maps link for a location.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "latitude": {
+            "type": "number",
+            "description": "Latitude coordinate"
+          },
+          "longitude": {
+            "type": "number",
+            "description": "Longitude coordinate"
+          },
+          "label": {
+            "type": "string",
+            "maxLength": 500,
+            "description": "Optional label for the location"
+          }
+        },
+        "required": [
+          "latitude",
+          "longitude"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
       },
       "outputSchema": null,
       "annotations": {
@@ -4809,6 +10493,34 @@
       "appIntentEligible": true
     },
     {
+      "name": "summarize_text",
+      "title": "Summarize Text",
+      "description": "Summarize text using Apple Intelligence (on-device Foundation Models).",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "text": {
+            "type": "string",
+            "maxLength": 10000,
+            "description": "Text to summarize"
+          }
+        },
+        "required": [
+          "text"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false
+      },
+      "appIntentEligible": true
+    },
+    {
       "name": "system_power",
       "title": "System Power",
       "description": "Shutdown or restart the Mac.",
@@ -4853,6 +10565,45 @@
         "readOnlyHint": false,
         "destructiveHint": true,
         "idempotentHint": false,
+        "openWorldHint": false
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "tag_content",
+      "title": "Tag Content",
+      "description": "Classify and tag content using Apple's on-device Foundation Model.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "text": {
+            "type": "string",
+            "maxLength": 10000,
+            "description": "The text content to classify"
+          },
+          "tags": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "maxLength": 200
+            },
+            "minItems": 1,
+            "maxItems": 100,
+            "description": "List of tag/category names to classify the content against"
+          }
+        },
+        "required": [
+          "text",
+          "tags"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
         "openWorldHint": false
       },
       "appIntentEligible": true
@@ -5077,6 +10828,695 @@
         },
         "required": [
           "path"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": true,
+        "idempotentHint": true,
+        "openWorldHint": false
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "tv_list_playlists",
+      "title": "List TV Playlists",
+      "description": "List all playlists (libraries) in Apple TV app.",
+      "inputSchema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {}
+      },
+      "outputSchema": null,
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "tv_list_tracks",
+      "title": "List TV Tracks",
+      "description": "List movies/episodes in a TV playlist.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "playlist": {
+            "type": "string",
+            "maxLength": 500,
+            "description": "Playlist name (e.g. 'Library', 'Movies')"
+          },
+          "limit": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 200,
+            "default": 50,
+            "description": "Max items (default: 50)"
+          }
+        },
+        "required": [
+          "playlist"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "tv_now_playing",
+      "title": "TV Now Playing",
+      "description": "Get currently playing content in Apple TV app.",
+      "inputSchema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {}
+      },
+      "outputSchema": null,
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "tv_play",
+      "title": "Play TV Content",
+      "description": "Play a movie or episode by name.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "maxLength": 500,
+            "description": "Movie or episode name"
+          }
+        },
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": false
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "tv_playback_control",
+      "title": "TV Playback Control",
+      "description": "Control Apple TV playback: play, pause, next, previous.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "action": {
+            "type": "string",
+            "enum": [
+              "play",
+              "pause",
+              "nextTrack",
+              "previousTrack"
+            ],
+            "description": "Playback action"
+          }
+        },
+        "required": [
+          "action"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": false
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "tv_search",
+      "title": "Search TV Library",
+      "description": "Search movies and TV shows by name or show title.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "query": {
+            "type": "string",
+            "maxLength": 500,
+            "description": "Search keyword"
+          },
+          "limit": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 100,
+            "default": 20,
+            "description": "Max results (default: 20)"
+          }
+        },
+        "required": [
+          "query"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "ui_accessibility_query",
+      "title": "Query UI Elements",
+      "description": "Search for UI elements by accessibility attributes (role, title, value, descr...",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "app": {
+            "type": "string",
+            "maxLength": 500,
+            "description": "App name to search in. If omitted, uses frontmost app."
+          },
+          "role": {
+            "type": "string",
+            "description": "AX role filter (e.g. 'AXButton', 'AXTextField', 'AXMenuItem', 'AXStaticText', 'AXCheckBox', 'AXPopUpButton')"
+          },
+          "title": {
+            "type": "string",
+            "maxLength": 500,
+            "description": "Title text to match (substring, case-insensitive)"
+          },
+          "value": {
+            "type": "string",
+            "maxLength": 10000,
+            "description": "Value text to match (substring, case-insensitive)"
+          },
+          "description": {
+            "type": "string",
+            "maxLength": 5000,
+            "description": "Description text to match (substring)"
+          },
+          "identifier": {
+            "type": "string",
+            "maxLength": 1000,
+            "description": "AXIdentifier to match (exact)"
+          },
+          "label": {
+            "type": "string",
+            "description": "General label search — matches across name, title, value, and description"
+          },
+          "maxResults": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 100,
+            "default": 20,
+            "description": "Max results to return (default: 20)"
+          },
+          "maxDepth": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 15,
+            "default": 8,
+            "description": "Max tree depth to search (default: 8)"
+          }
+        },
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "ui_click",
+      "title": "Click UI Element",
+      "description": "Click a UI element either by exact screen coordinates (x, y) or by searching ...",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "appName": {
+            "type": "string",
+            "description": "App name to activate before clicking. If omitted, uses the frontmost app."
+          },
+          "x": {
+            "type": "number",
+            "description": "X screen coordinate to click"
+          },
+          "y": {
+            "type": "number",
+            "description": "Y screen coordinate to click"
+          },
+          "text": {
+            "type": "string",
+            "description": "Text to search for in UI element names, descriptions, titles, and values"
+          },
+          "role": {
+            "type": "string",
+            "description": "Filter by accessibility role (e.g. 'AXButton', 'AXMenuItem', 'AXStaticText', 'AXTextField', 'AXCheckBox')"
+          },
+          "index": {
+            "type": "integer",
+            "minimum": 0,
+            "default": 0,
+            "description": "If multiple elements match, click the one at this index (default: 0, first match)"
+          }
+        },
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": true,
+        "idempotentHint": false,
+        "openWorldHint": true
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "ui_diff",
+      "title": "Compare UI State",
+      "description": "Compare the current UI state against a previous snapshot to detect changes.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "beforeSnapshot": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 500000,
+            "description": "JSON string of previous UI tree snapshot (elements array from ui_traverse)"
+          },
+          "app": {
+            "type": "string",
+            "maxLength": 500,
+            "description": "App name to compare against"
+          }
+        },
+        "required": [
+          "beforeSnapshot"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "ui_open_app",
+      "title": "Open App (UI Automation)",
+      "description": "Open an application by name or bundle ID and return an accessibility tree sum...",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "appName": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Application name (e.g. 'Safari', 'Xcode') or bundle ID (e.g. 'com.apple.Safari')"
+          }
+        },
+        "required": [
+          "appName"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "ui_perform_action",
+      "title": "Perform Action on UI Element",
+      "description": "Find a UI element by locator (role + title/value) and perform an accessibilit...",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "app": {
+            "type": "string",
+            "maxLength": 500,
+            "description": "App name"
+          },
+          "role": {
+            "type": "string",
+            "maxLength": 500,
+            "description": "AX role filter"
+          },
+          "title": {
+            "type": "string",
+            "maxLength": 500,
+            "description": "Title text to match"
+          },
+          "value": {
+            "type": "string",
+            "maxLength": 10000,
+            "description": "Value text to match"
+          },
+          "description": {
+            "type": "string",
+            "maxLength": 5000,
+            "description": "Description text to match"
+          },
+          "identifier": {
+            "type": "string",
+            "maxLength": 1000,
+            "description": "AXIdentifier exact match"
+          },
+          "label": {
+            "type": "string",
+            "maxLength": 500,
+            "description": "General label search"
+          },
+          "action": {
+            "type": "string",
+            "enum": [
+              "press",
+              "click",
+              "pick",
+              "select",
+              "confirm",
+              "setValue",
+              "set",
+              "raise",
+              "focus",
+              "showMenu",
+              "AXPress",
+              "AXPick",
+              "AXConfirm",
+              "AXSetValue",
+              "AXRaise",
+              "AXShowMenu"
+            ],
+            "description": "Action to perform"
+          },
+          "actionValue": {
+            "type": "string",
+            "maxLength": 10000,
+            "description": "Value to set (for setValue action)"
+          },
+          "index": {
+            "type": "integer",
+            "minimum": 0,
+            "default": 0,
+            "description": "If multiple matches, act on element at this index (default: 0)"
+          }
+        },
+        "required": [
+          "action"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": true,
+        "idempotentHint": false,
+        "openWorldHint": true
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "ui_press_key",
+      "title": "Press Key Combination",
+      "description": "Send a key or key combination (e.g.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "key": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Key to press — a single character (e.g. 's', 'a') or special key name (e.g. 'return', 'tab', 'escape', 'up', 'f5')"
+          },
+          "modifiers": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Modifier keys to hold: 'command'/'cmd', 'shift', 'option'/'alt', 'control'/'ctrl'"
+          },
+          "appName": {
+            "type": "string",
+            "description": "App name to activate before pressing keys. If omitted, sends to the frontmost app."
+          }
+        },
+        "required": [
+          "key"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": true,
+        "idempotentHint": false,
+        "openWorldHint": true
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "ui_read",
+      "title": "Read Accessibility Tree",
+      "description": "Read the accessibility tree of the frontmost app (or specified app).",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "appName": {
+            "type": "string",
+            "maxLength": 500,
+            "description": "App name to read. If omitted, reads the frontmost app."
+          },
+          "maxDepth": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 10,
+            "default": 3,
+            "description": "Maximum depth of the UI tree to traverse (default: 3)"
+          },
+          "maxElements": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 1000,
+            "default": 200,
+            "description": "Maximum number of UI elements to return (default: 200)"
+          }
+        },
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "ui_scroll",
+      "title": "Scroll",
+      "description": "Scroll in the specified direction within the frontmost window.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "direction": {
+            "type": "string",
+            "enum": [
+              "up",
+              "down",
+              "left",
+              "right"
+            ],
+            "description": "Scroll direction"
+          },
+          "amount": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 100,
+            "default": 3,
+            "description": "Number of scroll steps (default: 3)"
+          },
+          "appName": {
+            "type": "string",
+            "description": "App name to activate before scrolling. If omitted, scrolls in the frontmost app."
+          }
+        },
+        "required": [
+          "direction"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": true
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "ui_traverse",
+      "title": "BFS Traverse UI Tree",
+      "description": "Breadth-first traversal of the accessibility tree.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "app": {
+            "type": "string",
+            "maxLength": 500,
+            "description": "App name to traverse. If omitted, uses frontmost app."
+          },
+          "pid": {
+            "type": "integer",
+            "description": "Process ID for precise targeting (overrides app name lookup)"
+          },
+          "maxDepth": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 15,
+            "default": 5,
+            "description": "Max traversal depth (default: 5)"
+          },
+          "maxElements": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 2000,
+            "default": 500,
+            "description": "Max elements to collect (default: 500)"
+          },
+          "onlyVisible": {
+            "type": "boolean",
+            "default": false,
+            "description": "Only include elements with visible position/size"
+          }
+        },
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "ui_type",
+      "title": "Type Text",
+      "description": "Type text into the currently focused field using simulated keystrokes via Sys...",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "text": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 10000,
+            "description": "Text to type"
+          },
+          "appName": {
+            "type": "string",
+            "description": "App name to activate before typing. If omitted, types into the frontmost app."
+          }
+        },
+        "required": [
+          "text"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": true,
+        "idempotentHint": false,
+        "openWorldHint": true
+      },
+      "appIntentEligible": true
+    },
+    {
+      "name": "update_contact",
+      "title": "Update Contact",
+      "description": "Update contact properties.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "maxLength": 500,
+            "description": "Contact ID"
+          },
+          "firstName": {
+            "type": "string",
+            "maxLength": 500,
+            "description": "New first name"
+          },
+          "lastName": {
+            "type": "string",
+            "maxLength": 500,
+            "description": "New last name"
+          },
+          "organization": {
+            "type": "string",
+            "maxLength": 1000,
+            "description": "New organization"
+          },
+          "jobTitle": {
+            "type": "string",
+            "maxLength": 500,
+            "description": "New job title"
+          },
+          "note": {
+            "type": "string",
+            "maxLength": 5000,
+            "description": "New notes"
+          }
+        },
+        "required": [
+          "id"
         ],
         "additionalProperties": false,
         "$schema": "http://json-schema.org/draft-07/schema#"

--- a/package.json
+++ b/package.json
@@ -75,6 +75,8 @@
     "start": "node dist/index.js",
     "test": "node --experimental-vm-modules node_modules/.bin/jest",
     "smoke": "node scripts/smoke-mcp.mjs",
+    "gen:manifest": "node scripts/dump-tool-manifest.mjs",
+    "gen:manifest:check": "node scripts/dump-tool-manifest.mjs --check",
     "qa": "node scripts/qa-test.mjs",
     "qa:crud": "node scripts/qa-crud-test.mjs",
     "qa:e2e": "node scripts/qa-e2e-test.mjs",

--- a/scripts/dump-tool-manifest.mjs
+++ b/scripts/dump-tool-manifest.mjs
@@ -1,0 +1,214 @@
+#!/usr/bin/env node
+// RFC 0007 Phase A.0 — MCP tool manifest dumper.
+//
+// Boots the AirMCP stdio server the same way scripts/smoke-mcp.mjs does,
+// performs the MCP 2025-06-18 handshake, asks for `tools/list`, and writes
+// the normalized manifest to docs/tool-manifest.json (or --out).
+//
+// The manifest is the input to scripts/gen-swift-intents.mjs (which codegens
+// Swift AppIntent structs in swift/Sources/AirMCPKit/Generated/MCPIntents.swift).
+//
+// Why capture via the wire protocol and not the internal ToolRegistry?
+// (1) `tools/list` is already the MCP contract we publish externally, so a
+//     drift between Node and Swift is detected against the same shape clients
+//     see. (2) ToolRegistry currently stores only {name, title, description} —
+//     inputSchema / outputSchema / annotations would need registry surgery to
+//     expose. (3) Future Apple System MCP consumes `tools/list` too.
+//
+// Env knobs:
+//   AIRMCP_MANIFEST_OUT    — output path (default: docs/tool-manifest.json)
+//   MANIFEST_TIMEOUT_MS    — handshake + list timeout (default: 30_000)
+
+import { spawn } from "node:child_process";
+import { createInterface } from "node:readline";
+import { writeFileSync, existsSync } from "node:fs";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const ROOT = fileURLToPath(new URL("..", import.meta.url));
+const OUT_PATH = process.env.AIRMCP_MANIFEST_OUT ?? join(ROOT, "docs", "tool-manifest.json");
+const TIMEOUT_MS = Number(process.env.MANIFEST_TIMEOUT_MS ?? 30_000);
+
+// --check flag: do not write; exit 1 if the on-disk file would differ.
+const CHECK_ONLY = process.argv.includes("--check");
+
+const entry = join(ROOT, "dist", "index.js");
+if (!existsSync(entry)) {
+  console.error(`[manifest] ${entry} not found — run \`npm run build\` first`);
+  process.exit(2);
+}
+
+// AIRMCP_FAKE_OS_VERSION=0 pins the manifest to the os-agnostic baseline:
+// every os-version tool gate (e.g. Safari add_bookmark skipped on macOS 26+)
+// sees osVersion=0 and registers nothing gate-specific. This is what makes
+// docs/tool-manifest.json byte-stable across macOS 15 CI runners and macOS 26
+// dev laptops. Do not set AIRMCP_TEST_MODE here — that flag disables a
+// separate set of paths (test helpers) that are unrelated.
+const server = spawn("node", [entry], {
+  stdio: ["pipe", "pipe", "inherit"],
+  env: { ...process.env, AIRMCP_FAKE_OS_VERSION: "0" },
+});
+
+const rl = createInterface({ input: server.stdout });
+const pending = new Map();
+
+rl.on("line", (line) => {
+  if (!line.trim()) return;
+  let msg;
+  try {
+    msg = JSON.parse(line);
+  } catch {
+    return;
+  }
+  if (msg.id !== undefined && pending.has(msg.id)) {
+    const { resolve } = pending.get(msg.id);
+    pending.delete(msg.id);
+    resolve(msg);
+  }
+});
+
+function request(method, params, id) {
+  const payload = { jsonrpc: "2.0", id, method, ...(params ? { params } : {}) };
+  server.stdin.write(`${JSON.stringify(payload)}\n`);
+  return new Promise((resolve, reject) => {
+    pending.set(id, { resolve });
+    setTimeout(() => {
+      if (pending.has(id)) {
+        pending.delete(id);
+        reject(new Error(`timeout id=${id} (${method})`));
+      }
+    }, TIMEOUT_MS);
+  });
+}
+
+function notify(method) {
+  server.stdin.write(`${JSON.stringify({ jsonrpc: "2.0", method })}\n`);
+}
+
+const watchdog = setTimeout(() => {
+  console.error(`[manifest] overall timeout after ${TIMEOUT_MS}ms`);
+  server.kill("SIGKILL");
+  process.exit(2);
+}, TIMEOUT_MS);
+
+let exitCode = 0;
+try {
+  const initResp = await request(
+    "initialize",
+    {
+      protocolVersion: "2025-06-18",
+      capabilities: {},
+      clientInfo: { name: "airmcp-manifest-dump", version: "0.0.0" },
+    },
+    1,
+  );
+  if (!initResp.result) throw new Error(`initialize failed: ${JSON.stringify(initResp)}`);
+  notify("notifications/initialized");
+
+  const listResp = await request("tools/list", {}, 2);
+  const tools = listResp.result?.tools;
+  if (!Array.isArray(tools)) throw new Error(`tools/list malformed: ${JSON.stringify(listResp)}`);
+
+  // Normalize: one entry per tool with only the fields codegen needs.
+  // Sort by name for stable diff output.
+  const normalized = tools
+    .slice()
+    .sort((a, b) => a.name.localeCompare(b.name))
+    .map((t) => ({
+      name: t.name,
+      title: t.title ?? t.annotations?.title ?? t.name,
+      description: t.description ?? "",
+      inputSchema: t.inputSchema ?? { type: "object", properties: {} },
+      outputSchema: t.outputSchema ?? null,
+      annotations: {
+        readOnlyHint: t.annotations?.readOnlyHint ?? false,
+        destructiveHint: t.annotations?.destructiveHint ?? false,
+        idempotentHint: t.annotations?.idempotentHint ?? false,
+        openWorldHint: t.annotations?.openWorldHint ?? true,
+      },
+      // Eligibility gate for Swift AppIntent codegen (RFC 0007 §3.3).
+      // Composite inputs (arrays of objects, records) can't map to @Parameter
+      // today; we flag them so gen-swift-intents skips without breaking.
+      appIntentEligible: isAppIntentEligible(t.inputSchema, t.annotations),
+    }));
+
+  const manifest = {
+    generatedAt: new Date().toISOString(),
+    protocolVersion: "2025-06-18",
+    toolCount: normalized.length,
+    eligibleCount: normalized.filter((t) => t.appIntentEligible).length,
+    tools: normalized,
+  };
+
+  const serialized = `${JSON.stringify(manifest, replacerStripGenerated, 2)}\n`;
+  if (CHECK_ONLY) {
+    const { readFileSync } = await import("node:fs");
+    let existing = "";
+    try {
+      existing = readFileSync(OUT_PATH, "utf8");
+    } catch {
+      console.error(`[manifest --check] ${OUT_PATH} missing — run \`npm run gen:manifest\``);
+      exitCode = 1;
+    }
+    if (existing && existing !== serialized) {
+      console.error(`[manifest --check] drift detected in ${OUT_PATH} — run \`npm run gen:manifest\``);
+      exitCode = 1;
+    } else if (existing) {
+      console.error(
+        `[manifest --check] OK — ${manifest.toolCount} tools (${manifest.eligibleCount} AppIntent-eligible)`,
+      );
+    }
+  } else {
+    writeFileSync(OUT_PATH, serialized);
+    console.error(
+      `[manifest] wrote ${OUT_PATH} — ${manifest.toolCount} tools (${manifest.eligibleCount} AppIntent-eligible)`,
+    );
+  }
+} catch (e) {
+  console.error(`[manifest] FAIL — ${e instanceof Error ? e.message : String(e)}`);
+  exitCode = 1;
+} finally {
+  clearTimeout(watchdog);
+  server.kill("SIGTERM");
+  setTimeout(() => {
+    if (!server.killed) server.kill("SIGKILL");
+    process.exit(exitCode);
+  }, 2000).unref();
+}
+
+/**
+ * Replacer that excludes `generatedAt` from the diffable payload.
+ * The timestamp is embedded for humans reading the file, but the CI --check
+ * path needs the rest to be byte-stable so a timestamp change alone doesn't
+ * trip drift detection.
+ */
+function replacerStripGenerated(key, value) {
+  if (key === "generatedAt") return "STABLE_PLACEHOLDER";
+  return value;
+}
+
+/**
+ * Return true if the tool's inputSchema is expressible as a flat list of
+ * AppIntent `@Parameter` properties. RFC 0007 §3.3 table.
+ *
+ * Ineligible cases:
+ *   - any property whose type is "array" AND whose items is "object"
+ *     (AppIntent supports [String], [Int], [Double], [Bool] but not arrays
+ *     of structs at the @Parameter layer as of iOS 17)
+ *   - any property whose type is "object" (composite)
+ *   - `additionalProperties: true` / record-like schemas
+ */
+function isAppIntentEligible(inputSchema, _annotations) {
+  if (!inputSchema || typeof inputSchema !== "object") return true;
+  if (inputSchema.additionalProperties === true) return false;
+  const props = inputSchema.properties ?? {};
+  for (const key of Object.keys(props)) {
+    const p = props[key];
+    if (!p || typeof p !== "object") continue;
+    if (p.type === "object") return false;
+    if (p.type === "array" && p.items && typeof p.items === "object" && p.items.type === "object") {
+      return false;
+    }
+  }
+  return true;
+}

--- a/scripts/dump-tool-manifest.mjs
+++ b/scripts/dump-tool-manifest.mjs
@@ -38,15 +38,37 @@ if (!existsSync(entry)) {
   process.exit(2);
 }
 
-// AIRMCP_FAKE_OS_VERSION=0 pins the manifest to the os-agnostic baseline:
-// every os-version tool gate (e.g. Safari add_bookmark skipped on macOS 26+)
-// sees osVersion=0 and registers nothing gate-specific. This is what makes
-// docs/tool-manifest.json byte-stable across macOS 15 CI runners and macOS 26
-// dev laptops. Do not set AIRMCP_TEST_MODE here — that flag disables a
-// separate set of paths (test helpers) that are unrelated.
-const server = spawn("node", [entry], {
+// Pin the manifest to a reproducible baseline so docs/tool-manifest.json
+// is byte-stable across heterogeneous hosts and configs.
+//
+//   AIRMCP_FAKE_OS_VERSION=0   getOsVersion() returns 0 ("non-Darwin");
+//                              OS-version tool gates (e.g. Safari
+//                              add_bookmark skipped on macOS 26+) all see
+//                              the same value regardless of host.
+//   AIRMCP_FULL=true           load every module, not just STARTER_MODULES.
+//                              Without this, a fresh machine (no
+//                              ~/.airmcp/config.json) emits only the 7
+//                              starter modules (~111 tools), while a
+//                              developer laptop with a live config emits
+//                              ~120+. The bridge codegen needs the full
+//                              inventory regardless of user preference.
+//
+// Do not set AIRMCP_TEST_MODE — that flag disables a separate set of
+// paths (test helpers) unrelated to tool registration.
+const server = spawn("node", [entry, "--full"], {
   stdio: ["pipe", "pipe", "inherit"],
-  env: { ...process.env, AIRMCP_FAKE_OS_VERSION: "0" },
+  env: {
+    ...process.env,
+    AIRMCP_FAKE_OS_VERSION: "0",
+    AIRMCP_FULL: "true",
+    // Clear any per-module AIRMCP_DISABLE_* set in the developer shell
+    // (belt-and-suspenders with --full).
+    ...Object.fromEntries(
+      Object.keys(process.env)
+        .filter((k) => k.startsWith("AIRMCP_DISABLE_"))
+        .map((k) => [k, ""]),
+    ),
+  },
 });
 
 const rl = createInterface({ input: server.stdout });

--- a/src/shared/config.ts
+++ b/src/shared/config.ts
@@ -19,6 +19,16 @@ import { HEALTHKIT_MIN_MACOS, type CompatibilityEnv } from "./compatibility.js";
  * Returns 0 on non-macOS platforms so version checks always pass.
  */
 export function getOsVersion(): number {
+  // Developer/CI override so tool-registration gates produce a reproducible
+  // result across heterogeneous hosts. `scripts/dump-tool-manifest.mjs`
+  // sets this so the checked-in manifest stays identical on macOS 15
+  // runners and macOS 26 laptops. "0" = treat as non-Darwin (the inert
+  // ceiling; every os-version gate passes).
+  const override = process.env.AIRMCP_FAKE_OS_VERSION;
+  if (override !== undefined) {
+    const n = parseInt(override, 10);
+    return Number.isFinite(n) ? n : 0;
+  }
   if (process.platform !== "darwin") return 0;
   try {
     const ver = execFileSync("sw_vers", ["-productVersion"], {


### PR DESCRIPTION
## Summary

Axis 3 of the sequential iOS roadmap. First implementation step of [RFC 0007](docs/rfc/0007-app-intent-bridge.md) Phase A (MCP Tool ↔ App Intent auto-bridge).

**Lands only the metadata capture infrastructure.** Swift codegen (`gen-swift-intents.mjs` + `Generated/MCPIntents.swift`) is deferred to A.1 / axis 3.5, so this PR stays small and composable.

## What lands

| File | Role |
|---|---|
| [scripts/dump-tool-manifest.mjs](scripts/dump-tool-manifest.mjs) | Boots `dist/index.js` via stdio, performs MCP 2025-06-18 handshake, calls `tools/list`, writes normalized manifest. Same spawn+readline pattern as `scripts/smoke-mcp.mjs`. |
| [docs/tool-manifest.json](docs/tool-manifest.json) | Checked-in manifest. **125 tools, 122 eligible** for AppIntent codegen (3 skipped for composite inputs per RFC 0007 §3.3). |
| `npm run gen:manifest` | Regenerate |
| `npm run gen:manifest:check` | CI drift guard (exit 1 if stale) |
| [.github/workflows/ci.yml](.github/workflows/ci.yml) | "Verify tool manifest (RFC 0007 A.0)" step after Smoke, before Verify stats |
| [.prettierignore](.prettierignore) | Excludes the manifest — prettier would reflow short arrays and trip the drift check |

## Key design decisions

1. **Capture via the wire protocol, not `ToolRegistry`**. `tools/list` is already the external MCP contract; drift is detected against the same shape clients see. `ToolRegistry` stores only `{name, title, description}` — full metadata would need registry surgery. Apple's future system MCP will consume `tools/list` too.

2. **No new runtime dependency**. MCP SDK already converts zod → JSON Schema in `tools/list` responses, so `zod-to-json-schema` is unnecessary for A.0.

3. **`generatedAt` stripped from diffable payload**. Replaced with `STABLE_PLACEHOLDER` for `--check`, kept readable in the human-facing file. Same stability pattern as `count-stats --check`.

4. **`appIntentEligible` gate** (RFC 0007 §3.3):
   - Skip if any property has `type: "object"` (composite)
   - Skip if any property has `type: "array"` with `items.type: "object"`
   - Skip if `additionalProperties: true`

## Verified

- `npm run gen:manifest` — 125 tools, 122 eligible
- `npm run gen:manifest:check` — OK
- `npm run smoke` — OK (125 tools)
- `jest` — 92 suites, 1336 tests pass (unchanged)
- `prettier --check src/`, `tsc --noEmit`, `eslint` — clean

## Next

Axis 3.5 — **A.1: `scripts/gen-swift-intents.mjs`** + top-10 read-only tools as the first real pass at `swift/Sources/AirMCPKit/Generated/MCPIntents.swift`. Uses this manifest as input; compares against the 4 hand-written golden intents in [app/Sources/AirMCPApp/AppIntents.swift](app/Sources/AirMCPApp/AppIntents.swift).