### PR TITLE
feat(rfc-0007): a1 — swift appintent codegen + router placeholder

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,6 +86,14 @@ jobs:
           git --no-pager diff docs/tool-manifest.json | head -200 || true
           git diff --exit-code docs/tool-manifest.json
 
+      - name: Verify generated Swift intents (RFC 0007 A.1)
+        run: |
+          npm run gen:intents
+          echo "--- diff (should be empty) ---"
+          git --no-pager diff --stat swift/Sources/AirMCPKit/Generated/MCPIntents.swift || true
+          git --no-pager diff swift/Sources/AirMCPKit/Generated/MCPIntents.swift | head -200 || true
+          git diff --exit-code swift/Sources/AirMCPKit/Generated/MCPIntents.swift
+
       - name: Verify stats
         run: node scripts/count-stats.mjs --check
 

--- a/package.json
+++ b/package.json
@@ -77,6 +77,8 @@
     "smoke": "node scripts/smoke-mcp.mjs",
     "gen:manifest": "node scripts/dump-tool-manifest.mjs",
     "gen:manifest:check": "node scripts/dump-tool-manifest.mjs --check",
+    "gen:intents": "node scripts/gen-swift-intents.mjs",
+    "gen:intents:check": "node scripts/gen-swift-intents.mjs --check",
     "qa": "node scripts/qa-test.mjs",
     "qa:crud": "node scripts/qa-crud-test.mjs",
     "qa:e2e": "node scripts/qa-e2e-test.mjs",

--- a/scripts/gen-swift-intents.mjs
+++ b/scripts/gen-swift-intents.mjs
@@ -1,0 +1,238 @@
+#!/usr/bin/env node
+// RFC 0007 Phase A.1 — Swift AppIntent code generator.
+//
+// Reads docs/tool-manifest.json and writes
+// swift/Sources/AirMCPKit/Generated/MCPIntents.swift, emitting one Swift
+// `AppIntent` struct per selected tool.
+//
+// A.1 scope: a hand-picked list of 10 read-only tools with a small parameter
+// surface. Every selected tool MUST have `appIntentEligible: true` in the
+// manifest. A.2 broadens this to all read-only + idempotent eligible tools
+// (~150/282) and switches ReturnsValue from String to the tool's typed
+// outputSchema payload.
+//
+// Generated intents call `MCPIntentRouter.shared.call(...)` — see
+// swift/Sources/AirMCPKit/MCPIntentRouter.swift. Phase A.1 ships a stub
+// router (throws) so the file compiles and the system can still index the
+// intents for Shortcuts / Spotlight / golden-sample regression. A.2 lands
+// the macOS stdio + iOS in-process implementations.
+//
+// Env knobs:
+//   AIRMCP_INTENTS_OUT     — output path (default: swift/Sources/AirMCPKit/Generated/MCPIntents.swift)
+//   AIRMCP_INTENTS_MANIFEST — input manifest (default: docs/tool-manifest.json)
+//
+// Usage:
+//   node scripts/gen-swift-intents.mjs            # write
+//   node scripts/gen-swift-intents.mjs --check    # exit 1 if drift
+
+import { readFileSync, writeFileSync, mkdirSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const ROOT = fileURLToPath(new URL("..", import.meta.url));
+const MANIFEST_PATH = process.env.AIRMCP_INTENTS_MANIFEST ?? join(ROOT, "docs", "tool-manifest.json");
+const OUT_PATH =
+  process.env.AIRMCP_INTENTS_OUT ?? join(ROOT, "swift", "Sources", "AirMCPKit", "Generated", "MCPIntents.swift");
+const CHECK_ONLY = process.argv.includes("--check");
+
+// ── A.1 selection ────────────────────────────────────────────────────
+// Ten hand-picked read-only tools. Chosen for:
+//   (a) match with existing hand-written intents in
+//       app/Sources/AirMCPApp/AppIntents.swift (5 of the 10 have a golden
+//       sample we can diff against later)
+//   (b) small parameter surface (zero or one primitive @Parameter)
+//   (c) outputSchema already present (PR #95/97/98)
+// If A.2 broadens the list it can read from a declarative allow-list in the
+// manifest itself or skip this constant entirely and take every eligible.
+const SELECTED = [
+  "list_calendars",
+  "today_events",
+  "list_reminder_lists",
+  "list_folders",
+  "list_shortcuts",
+  "list_accounts",
+  "list_bookmarks",
+  "search_notes",
+  "search_contacts",
+  "get_upcoming_events",
+];
+// Note: health_summary was a natural fit (matches hand-written HealthSummaryIntent)
+// but the `health` module requires Apple Silicon + HealthKit at compat-resolve
+// time, so it's absent from the CI-generated manifest. list_bookmarks takes
+// its slot — same shape (no parameters, read-only, outputSchema present).
+
+// ── Load manifest ────────────────────────────────────────────────────
+let manifest;
+try {
+  manifest = JSON.parse(readFileSync(MANIFEST_PATH, "utf8"));
+} catch (e) {
+  console.error(`[gen-intents] cannot read ${MANIFEST_PATH}: ${e.message}`);
+  console.error("[gen-intents] run `npm run gen:manifest` first");
+  process.exit(2);
+}
+
+const byName = new Map(manifest.tools.map((t) => [t.name, t]));
+const picked = [];
+for (const name of SELECTED) {
+  const tool = byName.get(name);
+  if (!tool) {
+    console.error(`[gen-intents] selected tool not in manifest: ${name}`);
+    process.exit(2);
+  }
+  if (!tool.appIntentEligible) {
+    console.error(`[gen-intents] selected tool not AppIntent-eligible: ${name}`);
+    process.exit(2);
+  }
+  picked.push(tool);
+}
+
+// ── Swift codegen helpers ────────────────────────────────────────────
+
+function toPascalCase(snake) {
+  return snake
+    .split("_")
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1).toLowerCase())
+    .join("");
+}
+
+function intentStructName(toolName) {
+  // audit_log → AuditLogIntent; avoids collision with hand-written
+  // intents that live in app/Sources/AirMCPApp (different Swift module).
+  return `${toPascalCase(toolName)}Intent`;
+}
+
+/**
+ * Swift-safe string literal for a LocalizedStringResource / description.
+ * Escapes backslashes and double-quotes. Strips newlines to avoid breaking
+ * the single-line literal form AppIntent accepts.
+ */
+function swiftLit(s) {
+  return (s ?? "").replace(/\\/g, "\\\\").replace(/"/g, '\\"').replace(/\r?\n/g, " ").trim();
+}
+
+/**
+ * Map a JSON-Schema property to a Swift `@Parameter` declaration.
+ * A.1 only supports primitive types the 10 selected tools actually use
+ * (String, Int). A.2 adds Double/Bool/Date/enum/Array<String>.
+ */
+function swiftParamDecl(propName, propSchema) {
+  const title = propSchema.description ?? propName;
+  const safeTitle = swiftLit(title.slice(0, 60));
+
+  if (propSchema.type === "string") {
+    return `    @Parameter(title: "${safeTitle}")\n    public var ${propName}: String`;
+  }
+  if (propSchema.type === "integer") {
+    const dflt = typeof propSchema.default === "number" ? propSchema.default : undefined;
+    const range =
+      typeof propSchema.minimum === "number" && typeof propSchema.maximum === "number"
+        ? `, inclusiveRange: (${propSchema.minimum}, ${propSchema.maximum})`
+        : "";
+    if (dflt !== undefined) {
+      return `    @Parameter(title: "${safeTitle}", default: ${dflt}${range})\n    public var ${propName}: Int`;
+    }
+    return `    @Parameter(title: "${safeTitle}"${range})\n    public var ${propName}: Int`;
+  }
+  // Fallback — should not happen for the A.1 selected set; guards the
+  // codegen if the manifest drifts to add an unsupported type.
+  throw new Error(`[gen-intents] unsupported @Parameter type for ${propName}: ${JSON.stringify(propSchema)}`);
+}
+
+function buildArgsDict(properties) {
+  const keys = Object.keys(properties);
+  if (keys.length === 0) return "[:]";
+  const entries = keys.map((k) => `"${k}": ${k}`).join(", ");
+  return `[${entries}]`;
+}
+
+function generateIntent(tool) {
+  const structName = intentStructName(tool.name);
+  const title = swiftLit(tool.title ?? tool.name);
+  const description = swiftLit(tool.description ?? "");
+  const props = tool.inputSchema?.properties ?? {};
+  const required = new Set(tool.inputSchema?.required ?? []);
+
+  // Only emit `@Parameter` for required properties in A.1. Optionals add
+  // a whole mapping layer (Optional<T>, nil defaults) that isn't needed
+  // for the 10 selected tools; A.2 adds full optional support.
+  const requiredKeys = Object.keys(props).filter((k) => required.has(k));
+  const paramDecls = requiredKeys.map((k) => swiftParamDecl(k, props[k])).join("\n\n");
+  const argsDict = buildArgsDict(Object.fromEntries(requiredKeys.map((k) => [k, props[k]])));
+
+  return `// Tool: ${tool.name}
+public struct ${structName}: AppIntent {
+    nonisolated(unsafe) public static var title: LocalizedStringResource = "${title}"
+    nonisolated(unsafe) public static var description = IntentDescription("${description}")
+    nonisolated(unsafe) public static var openAppWhenRun: Bool = false
+
+    public init() {}
+
+${paramDecls ? paramDecls + "\n\n" : ""}    public func perform() async throws -> some IntentResult & ReturnsValue<String> {
+        let result = try await MCPIntentRouter.shared.call(
+            tool: "${tool.name}",
+            args: ${argsDict}
+        )
+        return .result(value: result)
+    }
+}`;
+}
+
+// ── Assemble output ──────────────────────────────────────────────────
+
+const header = `// GENERATED — do not edit.
+//
+// Source: docs/tool-manifest.json
+// Generator: scripts/gen-swift-intents.mjs
+// RFC 0007 Phase A.1 — ${picked.length} hand-picked read-only tools.
+// Run \`npm run gen:intents\` to refresh after tool metadata changes.
+// CI guards against drift via \`npm run gen:intents:check\`.
+//
+// Runtime behavior is stubbed in MCPIntentRouter until Phase A.2; these
+// structs compile and register with the system (for Shortcuts / Spotlight
+// indexing + golden-sample regression) but \`perform()\` will throw a
+// \`MCPIntentError.notImplementedOnPlatform\` until A.2 lands the macOS
+// execFile bridge and iOS in-process path.
+
+#if canImport(AppIntents)
+import AppIntents
+import Foundation
+
+`;
+
+const intents = picked.map(generateIntent).join("\n\n");
+
+const footer = `
+
+#endif
+`;
+
+const source = header + intents + footer;
+
+// ── Write / check ────────────────────────────────────────────────────
+
+if (CHECK_ONLY) {
+  let existing = "";
+  try {
+    existing = readFileSync(OUT_PATH, "utf8");
+  } catch {
+    console.error(`[gen-intents --check] ${OUT_PATH} missing — run \`npm run gen:intents\``);
+    process.exit(1);
+  }
+  if (existing !== source) {
+    console.error(`[gen-intents --check] drift detected in ${OUT_PATH} — run \`npm run gen:intents\``);
+    // For easier debugging on CI, write the intended output to /tmp so the
+    // failing job can diff against the checked-in file.
+    try {
+      writeFileSync("/tmp/airmcp-intents-expected.swift", source);
+      console.error(`[gen-intents --check] expected output written to /tmp/airmcp-intents-expected.swift`);
+    } catch {
+      /* best-effort */
+    }
+    process.exit(1);
+  }
+  console.error(`[gen-intents --check] OK — ${picked.length} intents`);
+} else {
+  mkdirSync(dirname(OUT_PATH), { recursive: true });
+  writeFileSync(OUT_PATH, source);
+  console.error(`[gen-intents] wrote ${OUT_PATH} — ${picked.length} intents`);
+}

--- a/swift/Sources/AirMCPKit/Generated/MCPIntents.swift
+++ b/swift/Sources/AirMCPKit/Generated/MCPIntents.swift
@@ -1,0 +1,195 @@
+// GENERATED — do not edit.
+//
+// Source: docs/tool-manifest.json
+// Generator: scripts/gen-swift-intents.mjs
+// RFC 0007 Phase A.1 — 10 hand-picked read-only tools.
+// Run `npm run gen:intents` to refresh after tool metadata changes.
+// CI guards against drift via `npm run gen:intents:check`.
+//
+// Runtime behavior is stubbed in MCPIntentRouter until Phase A.2; these
+// structs compile and register with the system (for Shortcuts / Spotlight
+// indexing + golden-sample regression) but `perform()` will throw a
+// `MCPIntentError.notImplementedOnPlatform` until A.2 lands the macOS
+// execFile bridge and iOS in-process path.
+
+#if canImport(AppIntents)
+import AppIntents
+import Foundation
+
+// Tool: list_calendars
+public struct ListCalendarsIntent: AppIntent {
+    nonisolated(unsafe) public static var title: LocalizedStringResource = "List Calendars"
+    nonisolated(unsafe) public static var description = IntentDescription("List all calendars with name, color, and writable status.")
+    nonisolated(unsafe) public static var openAppWhenRun: Bool = false
+
+    public init() {}
+
+    public func perform() async throws -> some IntentResult & ReturnsValue<String> {
+        let result = try await MCPIntentRouter.shared.call(
+            tool: "list_calendars",
+            args: [:]
+        )
+        return .result(value: result)
+    }
+}
+
+// Tool: today_events
+public struct TodayEventsIntent: AppIntent {
+    nonisolated(unsafe) public static var title: LocalizedStringResource = "Today's Events"
+    nonisolated(unsafe) public static var description = IntentDescription("Get all calendar events for today.")
+    nonisolated(unsafe) public static var openAppWhenRun: Bool = false
+
+    public init() {}
+
+    public func perform() async throws -> some IntentResult & ReturnsValue<String> {
+        let result = try await MCPIntentRouter.shared.call(
+            tool: "today_events",
+            args: [:]
+        )
+        return .result(value: result)
+    }
+}
+
+// Tool: list_reminder_lists
+public struct ListReminderListsIntent: AppIntent {
+    nonisolated(unsafe) public static var title: LocalizedStringResource = "List Reminder Lists"
+    nonisolated(unsafe) public static var description = IntentDescription("List all reminder lists with reminder counts.")
+    nonisolated(unsafe) public static var openAppWhenRun: Bool = false
+
+    public init() {}
+
+    public func perform() async throws -> some IntentResult & ReturnsValue<String> {
+        let result = try await MCPIntentRouter.shared.call(
+            tool: "list_reminder_lists",
+            args: [:]
+        )
+        return .result(value: result)
+    }
+}
+
+// Tool: list_folders
+public struct ListFoldersIntent: AppIntent {
+    nonisolated(unsafe) public static var title: LocalizedStringResource = "List Folders"
+    nonisolated(unsafe) public static var description = IntentDescription("List all folders across all accounts with note counts.")
+    nonisolated(unsafe) public static var openAppWhenRun: Bool = false
+
+    public init() {}
+
+    public func perform() async throws -> some IntentResult & ReturnsValue<String> {
+        let result = try await MCPIntentRouter.shared.call(
+            tool: "list_folders",
+            args: [:]
+        )
+        return .result(value: result)
+    }
+}
+
+// Tool: list_shortcuts
+public struct ListShortcutsIntent: AppIntent {
+    nonisolated(unsafe) public static var title: LocalizedStringResource = "List Shortcuts"
+    nonisolated(unsafe) public static var description = IntentDescription("List all available Siri Shortcuts on this Mac.")
+    nonisolated(unsafe) public static var openAppWhenRun: Bool = false
+
+    public init() {}
+
+    public func perform() async throws -> some IntentResult & ReturnsValue<String> {
+        let result = try await MCPIntentRouter.shared.call(
+            tool: "list_shortcuts",
+            args: [:]
+        )
+        return .result(value: result)
+    }
+}
+
+// Tool: list_accounts
+public struct ListAccountsIntent: AppIntent {
+    nonisolated(unsafe) public static var title: LocalizedStringResource = "List Mail Accounts"
+    nonisolated(unsafe) public static var description = IntentDescription("List all mail accounts.")
+    nonisolated(unsafe) public static var openAppWhenRun: Bool = false
+
+    public init() {}
+
+    public func perform() async throws -> some IntentResult & ReturnsValue<String> {
+        let result = try await MCPIntentRouter.shared.call(
+            tool: "list_accounts",
+            args: [:]
+        )
+        return .result(value: result)
+    }
+}
+
+// Tool: list_bookmarks
+public struct ListBookmarksIntent: AppIntent {
+    nonisolated(unsafe) public static var title: LocalizedStringResource = "List Bookmarks"
+    nonisolated(unsafe) public static var description = IntentDescription("List all Safari bookmarks across all folders, including subfolder paths.")
+    nonisolated(unsafe) public static var openAppWhenRun: Bool = false
+
+    public init() {}
+
+    public func perform() async throws -> some IntentResult & ReturnsValue<String> {
+        let result = try await MCPIntentRouter.shared.call(
+            tool: "list_bookmarks",
+            args: [:]
+        )
+        return .result(value: result)
+    }
+}
+
+// Tool: search_notes
+public struct SearchNotesIntent: AppIntent {
+    nonisolated(unsafe) public static var title: LocalizedStringResource = "Search Notes"
+    nonisolated(unsafe) public static var description = IntentDescription("Search notes by keyword in title and body.")
+    nonisolated(unsafe) public static var openAppWhenRun: Bool = false
+
+    public init() {}
+
+    @Parameter(title: "Search keyword")
+    public var query: String
+
+    public func perform() async throws -> some IntentResult & ReturnsValue<String> {
+        let result = try await MCPIntentRouter.shared.call(
+            tool: "search_notes",
+            args: ["query": query]
+        )
+        return .result(value: result)
+    }
+}
+
+// Tool: search_contacts
+public struct SearchContactsIntent: AppIntent {
+    nonisolated(unsafe) public static var title: LocalizedStringResource = "Search Contacts"
+    nonisolated(unsafe) public static var description = IntentDescription("Search contacts by name, email, phone, or organization.")
+    nonisolated(unsafe) public static var openAppWhenRun: Bool = false
+
+    public init() {}
+
+    @Parameter(title: "Search keyword (matches name)")
+    public var query: String
+
+    public func perform() async throws -> some IntentResult & ReturnsValue<String> {
+        let result = try await MCPIntentRouter.shared.call(
+            tool: "search_contacts",
+            args: ["query": query]
+        )
+        return .result(value: result)
+    }
+}
+
+// Tool: get_upcoming_events
+public struct GetUpcomingEventsIntent: AppIntent {
+    nonisolated(unsafe) public static var title: LocalizedStringResource = "Get Upcoming Events"
+    nonisolated(unsafe) public static var description = IntentDescription("Get the next N upcoming events from now (searches up to 30 days ahead).")
+    nonisolated(unsafe) public static var openAppWhenRun: Bool = false
+
+    public init() {}
+
+    public func perform() async throws -> some IntentResult & ReturnsValue<String> {
+        let result = try await MCPIntentRouter.shared.call(
+            tool: "get_upcoming_events",
+            args: [:]
+        )
+        return .result(value: result)
+    }
+}
+
+#endif

--- a/swift/Sources/AirMCPKit/MCPIntentRouter.swift
+++ b/swift/Sources/AirMCPKit/MCPIntentRouter.swift
@@ -1,0 +1,46 @@
+// RFC 0007 Phase A — shared entry point for every code-generated AppIntent.
+//
+// Generated/MCPIntents.swift calls `MCPIntentRouter.shared.call(...)`; this
+// file is the hand-written host-side implementation. In A.1 the macOS path
+// is a placeholder — the real execFile-based stdio bridge (already prototyped
+// in app/Sources/AirMCPApp/AppIntents.swift:runAirMCPTool) lands in A.2 so we
+// can keep the golden-sample intent untouched this round.
+//
+// iOS path is unimplemented; A.2 will wire the in-process AirMCPServer from
+// ios/Sources/AirMCPServer/MCPServer.swift.
+
+import Foundation
+
+public enum MCPIntentError: Error {
+    case notImplementedOnPlatform(String)
+    case toolCallFailed(String)
+}
+
+public actor MCPIntentRouter {
+    public static let shared = MCPIntentRouter()
+
+    private init() {}
+
+    /// Invoke an AirMCP tool and return its primary text content.
+    ///
+    /// Phase A.1 scope: throws `notImplementedOnPlatform` — codegen'd
+    /// AppIntents compile and register with the system (so Shortcuts /
+    /// Spotlight indexing + golden-sample regression works), but runtime
+    /// invocation will report a typed error until A.2 ports the stdio
+    /// bridge from `AppIntents.swift:runAirMCPTool` into this actor.
+    public func call(tool: String, args: [String: Any]) async throws -> String {
+        #if os(macOS)
+        throw MCPIntentError.notImplementedOnPlatform(
+            "macOS router stub — lands in RFC 0007 Phase A.2. Tool requested: \(tool)"
+        )
+        #elseif os(iOS)
+        throw MCPIntentError.notImplementedOnPlatform(
+            "iOS router stub — lands in RFC 0007 Phase A.2 (in-process AirMCPServer). Tool requested: \(tool)"
+        )
+        #else
+        throw MCPIntentError.notImplementedOnPlatform(
+            "MCPIntentRouter is only wired for Apple platforms. Tool requested: \(tool)"
+        )
+        #endif
+    }
+}


### PR DESCRIPTION
## Summary

Axis 3.5 — second implementation step of [RFC 0007](docs/rfc/0007-app-intent-bridge.md) Phase A. Consumes the manifest from [#101](https://github.com/heznpc/AirMCP/pull/101) and emits Swift `AppIntent` structs; ships a Router placeholder so the code compiles (for Shortcuts / Spotlight indexing + golden-sample regression) but run-time invocation throws a typed error until A.2.

## What lands

| File | Role |
|---|---|
| [scripts/gen-swift-intents.mjs](scripts/gen-swift-intents.mjs) | Reads `docs/tool-manifest.json`, emits the Generated Swift. Hand-picks 10 read-only tools per RFC 0007 §3.2. |
| [swift/Sources/AirMCPKit/MCPIntentRouter.swift](swift/Sources/AirMCPKit/MCPIntentRouter.swift) | Hand-written actor. API shape is stable across A.1 → A.2; `call(tool:args:)` throws `notImplementedOnPlatform` for now. |
| [swift/Sources/AirMCPKit/Generated/MCPIntents.swift](swift/Sources/AirMCPKit/Generated/MCPIntents.swift) | 10 `AppIntent` structs. `nonisolated(unsafe)` matching hand-written style in `app/Sources/AirMCPApp/AppIntents.swift`. `#if canImport(AppIntents)` guards the whole file. |
| `npm run gen:intents` / `gen:intents:check` | Regenerate / CI drift check |
| [.github/workflows/ci.yml](.github/workflows/ci.yml) | 'Verify generated Swift intents (RFC 0007 A.1)' step (mirrors A.0 drift-check pattern) |

## Selected tools (10)

| # | tool | params | hand-written golden (app/) |
|---|---|---|---|
| 1 | `list_calendars` | (none) | ListCalendarsIntent |
| 2 | `today_events` | (none) | CheckCalendarIntent |
| 3 | `list_reminder_lists` | (none) | — |
| 4 | `list_folders` | (none) | — |
| 5 | `list_shortcuts` | (none) | — |
| 6 | `list_accounts` | (none) | — |
| 7 | `list_bookmarks` | (none) | — |
| 8 | `search_notes` | query:String | SearchNotesIntent |
| 9 | `search_contacts` | query:String | SearchContactsIntent |
| 10 | `get_upcoming_events` | limit:Int? | — |

`health_summary` was the natural fifth golden match but the `health` module's `apple-silicon + healthkit` compat gate keeps it out of the CI-generated manifest. `list_bookmarks` takes its slot — same shape (no parameters, read-only, outputSchema present).

## Swift build verification

- `cd swift && swift build` — **green** (23 compile units, 97s cold)
- `cd ios && swift build` — **green** (AirMCPKit picked up transitively through AirMCPServer)
- `swift test` locally fails because of CommandLineTools lacking XCTest; CI runs with full Xcode

## Return type choice

`perform()` returns `ReturnsValue<String>` (raw tool text) in A.1. A.2 upgrades to typed `ReturnsValue<T>` with a decoder generated from each tool's `outputSchema` — the 10 selected tools all declare one, so the upgrade is mechanical.

## Test plan

- [x] `npm run gen:intents` → 10 intents written
- [x] `npm run gen:intents:check` — OK
- [x] `npm run gen:manifest:check` — OK (unchanged from A.0)
- [x] `npm run smoke` — OK (125 tools registered)
- [x] `jest` — 92 suites, **1336 tests** pass (unchanged)
- [x] `swift build` (both swift/ and ios/) — green
- [x] `tsc --noEmit`, `eslint src/`, `prettier --check src/ scripts/gen-*.mjs` — clean
- [ ] CI

## Next axes

- **Axis 3.6 / A.2** — wire `MCPIntentRouter` runtime: macOS execFile bridge (port from `AppIntents.swift:runAirMCPTool`) + iOS in-process via `AirMCPServer`. Broaden selected tools from 10 to all read-only eligible (~150/282). Switch `ReturnsValue<String>` to typed payload. Add top-10 `AppShortcutsProvider`.
- **Axis 4** — Interactive Snippets renderer (builds on Generated output shape).