### PR TITLE
feat(rfc-0007): a2a — wire router runtime on macOS + iOS

### DIFF
--- a/app/Package.swift
+++ b/app/Package.swift
@@ -6,9 +6,17 @@ let package = Package(
     name: "AirMCPApp",
     defaultLocalization: "en",
     platforms: [.macOS(.v14)],
+    dependencies: [
+        // RFC 0007 A.2a: App needs AirMCPKit so it can install
+        // MCPIntentRouter's host handler at launch.
+        .package(path: "../swift"),
+    ],
     targets: [
         .executableTarget(
             name: "AirMCPApp",
+            dependencies: [
+                .product(name: "AirMCPKit", package: "swift"),
+            ],
             path: "Sources/AirMCPApp",
             resources: [
                 .copy("Resources/AppIcon.png"),

--- a/app/Sources/AirMCPApp/AirMCPApp.swift
+++ b/app/Sources/AirMCPApp/AirMCPApp.swift
@@ -29,6 +29,12 @@ struct AirMCPApp: App {
         }
         self.notificationDelegate = delegate
 
+        // RFC 0007 Phase A.2a: route generated AppIntents through the
+        // existing stdio bridge. Must run before any AppIntent fires,
+        // but AppIntents are resolved lazily by the system so this init
+        // location is early enough.
+        installMCPIntentRouterForMacOS()
+
         // Defer NSApp-dependent setup to after the application is fully initialized
         DispatchQueue.main.async {
             UNUserNotificationCenter.current().delegate = delegate

--- a/app/Sources/AirMCPApp/AppIntents.swift
+++ b/app/Sources/AirMCPApp/AppIntents.swift
@@ -1,5 +1,6 @@
 import AppIntents
 import Foundation
+import AirMCPKit
 
 // MARK: - AirMCP App Intents
 // These make AirMCP actions accessible via Siri, Spotlight, and Shortcuts.
@@ -196,6 +197,27 @@ struct AirMCPShortcuts: AppShortcutsProvider {
             systemImageName: "heart.text.square"
         )
         #endif
+    }
+}
+
+// MARK: - MCPIntentRouter wiring (RFC 0007 Phase A.2a)
+
+/// Install the macOS transport handler on `MCPIntentRouter.shared`. Called
+/// once from `AirMCPApp.init()` so every code-generated AppIntent in
+/// `swift/Sources/AirMCPKit/Generated/MCPIntents.swift` lands on the same
+/// execFile stdio bridge the hand-written intents already use.
+///
+/// Re-calling is safe — the router replaces the prior handler rather than
+/// stacking. Tests that swap in a fake can call `setHandler` again.
+func installMCPIntentRouterForMacOS() {
+    Task.detached(priority: .utility) {
+        await MCPIntentRouter.shared.setHandler { tool, args in
+            // Cast from [String: any Sendable] → [String: Any] for the
+            // existing runAirMCPTool(args:) signature. All inbound values
+            // come from @Parameter-wrapped primitives so the cast is safe.
+            let anyArgs: [String: Any] = args.reduce(into: [:]) { acc, kv in acc[kv.key] = kv.value }
+            return try await runAirMCPTool(tool, args: anyArgs)
+        }
     }
 }
 

--- a/ios/Sources/AirMCPServer/MCPServer.swift
+++ b/ios/Sources/AirMCPServer/MCPServer.swift
@@ -170,4 +170,31 @@ public actor MCPServer {
             ] as [String: Any])
         }
     }
+
+    // MARK: - Direct call (RFC 0007 Phase A.2a)
+
+    /// Invoke a registered tool without the JSON-RPC envelope and return
+    /// the primary text content. Used by `MCPIntentRouter` on iOS so
+    /// code-generated AppIntents can reach tools in-process (no HTTP hop).
+    ///
+    /// Throws `MCPIntentCallError` if the tool is absent or reports an
+    /// error. Non-throwing success returns the first text content block,
+    /// or empty string if the tool returns non-text-only content.
+    public func callToolText(name: String, args: [String: any Sendable]) async throws -> String {
+        guard let tool = tools[name] else {
+            throw MCPIntentCallError.unknownTool(name)
+        }
+        let anyArgs: [String: Any] = args.reduce(into: [:]) { acc, kv in acc[kv.key] = kv.value }
+        let result = try await tool.execute(anyArgs)
+        if result.isError {
+            let msg = result.content.first?.text ?? "tool returned isError with no content"
+            throw MCPIntentCallError.toolFailed(name: name, message: msg)
+        }
+        return result.content.first?.text ?? ""
+    }
+}
+
+public enum MCPIntentCallError: Error, Sendable {
+    case unknownTool(String)
+    case toolFailed(name: String, message: String)
 }

--- a/ios/Sources/AirMCPiOS/App.swift
+++ b/ios/Sources/AirMCPiOS/App.swift
@@ -46,6 +46,13 @@ final class ServerManager {
 
         toolCount = await mcp.toolCount
 
+        // RFC 0007 A.2a: route generated AppIntents directly into this
+        // in-process MCPServer. No HTTP hop; Siri / Shortcuts / Spotlight
+        // invocations become actor calls.
+        await MCPIntentRouter.shared.setHandler { [mcp] tool, args in
+            return try await mcp.callToolText(name: tool, args: args)
+        }
+
         let server = MCPHTTPServer(mcp: mcp, port: 3847)
         token = await server.authToken
 

--- a/scripts/gen-swift-intents.mjs
+++ b/scripts/gen-swift-intents.mjs
@@ -140,7 +140,10 @@ function swiftParamDecl(propName, propSchema) {
 
 function buildArgsDict(properties) {
   const keys = Object.keys(properties);
-  if (keys.length === 0) return "[:]";
+  // Empty-dict literal `[:]` is inferred as `[Never: Never]` in some
+  // contexts and can't satisfy `[String: any Sendable]`; spell out the
+  // type for the zero-param case.
+  if (keys.length === 0) return "[String: any Sendable]()";
   const entries = keys.map((k) => `"${k}": ${k}`).join(", ");
   return `[${entries}]`;
 }

--- a/swift/Sources/AirMCPKit/Generated/MCPIntents.swift
+++ b/swift/Sources/AirMCPKit/Generated/MCPIntents.swift
@@ -27,7 +27,7 @@ public struct ListCalendarsIntent: AppIntent {
     public func perform() async throws -> some IntentResult & ReturnsValue<String> {
         let result = try await MCPIntentRouter.shared.call(
             tool: "list_calendars",
-            args: [:]
+            args: [String: any Sendable]()
         )
         return .result(value: result)
     }
@@ -44,7 +44,7 @@ public struct TodayEventsIntent: AppIntent {
     public func perform() async throws -> some IntentResult & ReturnsValue<String> {
         let result = try await MCPIntentRouter.shared.call(
             tool: "today_events",
-            args: [:]
+            args: [String: any Sendable]()
         )
         return .result(value: result)
     }
@@ -61,7 +61,7 @@ public struct ListReminderListsIntent: AppIntent {
     public func perform() async throws -> some IntentResult & ReturnsValue<String> {
         let result = try await MCPIntentRouter.shared.call(
             tool: "list_reminder_lists",
-            args: [:]
+            args: [String: any Sendable]()
         )
         return .result(value: result)
     }
@@ -78,7 +78,7 @@ public struct ListFoldersIntent: AppIntent {
     public func perform() async throws -> some IntentResult & ReturnsValue<String> {
         let result = try await MCPIntentRouter.shared.call(
             tool: "list_folders",
-            args: [:]
+            args: [String: any Sendable]()
         )
         return .result(value: result)
     }
@@ -95,7 +95,7 @@ public struct ListShortcutsIntent: AppIntent {
     public func perform() async throws -> some IntentResult & ReturnsValue<String> {
         let result = try await MCPIntentRouter.shared.call(
             tool: "list_shortcuts",
-            args: [:]
+            args: [String: any Sendable]()
         )
         return .result(value: result)
     }
@@ -112,7 +112,7 @@ public struct ListAccountsIntent: AppIntent {
     public func perform() async throws -> some IntentResult & ReturnsValue<String> {
         let result = try await MCPIntentRouter.shared.call(
             tool: "list_accounts",
-            args: [:]
+            args: [String: any Sendable]()
         )
         return .result(value: result)
     }
@@ -129,7 +129,7 @@ public struct ListBookmarksIntent: AppIntent {
     public func perform() async throws -> some IntentResult & ReturnsValue<String> {
         let result = try await MCPIntentRouter.shared.call(
             tool: "list_bookmarks",
-            args: [:]
+            args: [String: any Sendable]()
         )
         return .result(value: result)
     }
@@ -186,7 +186,7 @@ public struct GetUpcomingEventsIntent: AppIntent {
     public func perform() async throws -> some IntentResult & ReturnsValue<String> {
         let result = try await MCPIntentRouter.shared.call(
             tool: "get_upcoming_events",
-            args: [:]
+            args: [String: any Sendable]()
         )
         return .result(value: result)
     }

--- a/swift/Sources/AirMCPKit/MCPIntentRouter.swift
+++ b/swift/Sources/AirMCPKit/MCPIntentRouter.swift
@@ -1,46 +1,71 @@
 // RFC 0007 Phase A — shared entry point for every code-generated AppIntent.
 //
-// Generated/MCPIntents.swift calls `MCPIntentRouter.shared.call(...)`; this
-// file is the hand-written host-side implementation. In A.1 the macOS path
-// is a placeholder — the real execFile-based stdio bridge (already prototyped
-// in app/Sources/AirMCPApp/AppIntents.swift:runAirMCPTool) lands in A.2 so we
-// can keep the golden-sample intent untouched this round.
+// Generated/MCPIntents.swift calls `MCPIntentRouter.shared.call(...)`. The
+// actual transport (execFile stdio on macOS, in-process on iOS) varies by
+// host, and the host owns components AirMCPKit can't depend on upward:
+//   macOS app → uses app/Sources/AirMCPApp/AppIntents.swift:runAirMCPTool
+//               (Process + Pipe machinery against the npx-installed airmcp)
+//   iOS app   → uses ios/Sources/AirMCPServer/MCPServer.swift in-process
+//               (no IPC; just an actor.call with JSONRPCRequest).
 //
-// iOS path is unimplemented; A.2 will wire the in-process AirMCPServer from
-// ios/Sources/AirMCPServer/MCPServer.swift.
+// Rather than conditional compilation against those upper modules
+// (which would introduce a circular dependency), the router accepts an
+// async handler that the host installs at launch. AirMCPKit stays
+// dependency-free; the host is responsible for wiring the transport.
+//
+// Phase A.2a (this file): handler injection + stable public API.
+// Phase A.2b (follow-up): broaden generated intents from 10 → ~150 and
+// switch ReturnsValue<String> to typed payload.
 
 import Foundation
 
-public enum MCPIntentError: Error {
-    case notImplementedOnPlatform(String)
-    case toolCallFailed(String)
+public enum MCPIntentError: Error, Sendable {
+    /// No host handler was registered before an AppIntent fired. Surfaced
+    /// verbatim in the AppIntent failure dialog so debugging is easy.
+    case handlerNotInstalled(tool: String)
+    /// The host handler ran but the tool reported a failure.
+    case toolCallFailed(tool: String, message: String)
 }
+
+/// Signature hosts must implement: take a tool name + plain-object args,
+/// return the tool's primary text output (string). Typed payloads arrive
+/// in Phase A.2b; A.2a keeps the interface minimal so A.1's generated
+/// file doesn't need to change when A.2b lands.
+///
+/// `args` is constrained to `any Sendable` rather than `Any` so the actor
+/// boundary check at `call(...)` passes under Swift 6 strict concurrency.
+/// The generated intents only pass primitives (String, Int, Double, Bool),
+/// each of which conforms to Sendable.
+public typealias MCPIntentHandler = @Sendable (
+    _ tool: String,
+    _ args: [String: any Sendable]
+) async throws -> String
 
 public actor MCPIntentRouter {
     public static let shared = MCPIntentRouter()
 
+    private var handler: MCPIntentHandler?
+
     private init() {}
+
+    /// Install the transport. Call exactly once at app launch. If called
+    /// more than once, the most recent handler wins — tests overriding
+    /// the production handler benefit from this (the prior handler is
+    /// discarded, not stacked).
+    public func setHandler(_ handler: @escaping MCPIntentHandler) {
+        self.handler = handler
+    }
 
     /// Invoke an AirMCP tool and return its primary text content.
     ///
-    /// Phase A.1 scope: throws `notImplementedOnPlatform` — codegen'd
-    /// AppIntents compile and register with the system (so Shortcuts /
-    /// Spotlight indexing + golden-sample regression works), but runtime
-    /// invocation will report a typed error until A.2 ports the stdio
-    /// bridge from `AppIntents.swift:runAirMCPTool` into this actor.
-    public func call(tool: String, args: [String: Any]) async throws -> String {
-        #if os(macOS)
-        throw MCPIntentError.notImplementedOnPlatform(
-            "macOS router stub — lands in RFC 0007 Phase A.2. Tool requested: \(tool)"
-        )
-        #elseif os(iOS)
-        throw MCPIntentError.notImplementedOnPlatform(
-            "iOS router stub — lands in RFC 0007 Phase A.2 (in-process AirMCPServer). Tool requested: \(tool)"
-        )
-        #else
-        throw MCPIntentError.notImplementedOnPlatform(
-            "MCPIntentRouter is only wired for Apple platforms. Tool requested: \(tool)"
-        )
-        #endif
+    /// Throws `MCPIntentError.handlerNotInstalled` if the host never
+    /// registered a handler — this is almost always a launch-order bug,
+    /// so the error includes the requested tool name to make the stack
+    /// trace obvious.
+    public func call(tool: String, args: [String: any Sendable]) async throws -> String {
+        guard let handler else {
+            throw MCPIntentError.handlerNotInstalled(tool: tool)
+        }
+        return try await handler(tool, args)
     }
 }


### PR DESCRIPTION
## Summary

Axis 3.6a — third implementation step of [RFC 0007](docs/rfc/0007-app-intent-bridge.md) Phase A. [PR #102](https://github.com/heznpc/AirMCP/pull/102) shipped generated AppIntent structs that called a **stub** `MCPIntentRouter`; this PR wires the **real transport** so those intents actually run.

## Design: handler injection

AirMCPKit is structurally below both `app/` (macOS menubar) and `ios/Sources/AirMCPServer` (iOS in-process server), so the router cannot import from them without a circular dependency. Instead the router is a tiny `Sendable` actor with a host-installed handler:

```swift
// swift/Sources/AirMCPKit/MCPIntentRouter.swift
public actor MCPIntentRouter {
    public static let shared = MCPIntentRouter()
    public func setHandler(_ h: @escaping MCPIntentHandler) { ... }
    public func call(tool: String, args: [String: any Sendable]) async throws -> String { ... }
}
```

Each host registers its own transport at launch; the generated intents never change shape when the host swaps implementations. Handler signature stays `String`-returning so A.1's codegen is untouched — A.2b broadens to typed `ReturnsValue<T>`.

## macOS transport

- [app/Sources/AirMCPApp/AirMCPApp.swift](app/Sources/AirMCPApp/AirMCPApp.swift): `init()` calls `installMCPIntentRouterForMacOS()` which hands the existing `runAirMCPTool` stdio bridge to the router.
- [app/Package.swift](app/Package.swift): now depends on `../swift` so `import AirMCPKit` resolves.

## iOS transport

- [ios/Sources/AirMCPServer/MCPServer.swift](ios/Sources/AirMCPServer/MCPServer.swift): new `callToolText(name:args:)` — direct invocation without the JSON-RPC envelope.
- [ios/Sources/AirMCPiOS/App.swift](ios/Sources/AirMCPiOS/App.swift): `ServerManager.start()` installs a handler that calls `callToolText` on the same `MCPServer` instance it just populated with EventKit / Contacts / Location / Health tools. **No HTTP hop** for AppIntent invocations.
- New `MCPIntentCallError` enum (`unknownTool` / `toolFailed`).

## Swift 6 concurrency

- `MCPIntentHandler` takes `[String: any Sendable]` rather than `[String: Any]` so the actor boundary check passes. The 10 selected tools only pass primitives (String, Int), all Sendable.
- Generated codegen updated: empty arg dicts spell out `[String: any Sendable]()` to dodge the `[Never: Never]` inference.

## Verified

- `swift build` (swift/, app/, ios/) — **all green**
- `npm run gen:intents` / `gen:intents:check` — OK (10 intents, regenerated against new router signature)
- `npm run gen:manifest:check` — OK (282 tools unchanged)
- `jest` — 92 suites, **1336 tests** pass (unchanged)
- `tsc`, `eslint`, `prettier src/ + scripts/gen-swift-intents.mjs` — clean

## Test plan

- [x] Local triple build green
- [x] Drift guards still OK
- [ ] CI (incl. Xcode-provisioned `swift test`)

## Next

- **A.2b** — broaden selected tools from 10 → ~150 eligible, switch `ReturnsValue<String>` to typed `ReturnsValue<T>` (outputSchema → Swift Codable codegen), add top-10 `AppShortcutsProvider` entries
- **Axis 4** — Interactive Snippets renderer (builds on typed payload from A.2b)