### PR TITLE
feat(rfc-0007): axis 6 — AskAirMCPIntent natural-language agent (FoundationModels)

### DIFF
--- a/docs/rfc/0007-app-intent-bridge.md
+++ b/docs/rfc/0007-app-intent-bridge.md
@@ -1,11 +1,12 @@
 # RFC 0007 — MCP Tool ↔ App Intent Auto-Bridge (2-phase)
 
-- **Status**: Draft (amended 2026-04-23 · iOS 26.4.2 research pass)
+- **Status**: Draft (amended 2026-04-23 · iOS 26.4.2 research pass · axis-6 landed)
 - **Author**: heznpc + Claude
 - **Created**: 2026-04-23
 - **Target**: v2.13.0 (Phase A) · Apple-API-dependent (Phase B)
 - **Amendment history**:
   - 2026-04-23 — §R2 updated with confirmed `requestConfirmation(actionName:snippetIntent:)` API; §3.7 Interactive Snippets renderer added; rollout split into A.2a/A.2b/A.3 to match landed PRs #101-#103 and Interactive Snippets availability.
+  - 2026-04-23 (afternoon) — Axis 6 `AskAirMCPIntent` lands ahead of schedule: natural-language FoundationModels agent pinned as the first `AirMCPGeneratedShortcuts` entry on iOS 26+/macOS 26+ (gated by `#if canImport(FoundationModels) && compiler(>=6.3)`). Rollout row "Ax.6" added.
 - **Related**: [docs/ios-architecture.md §15.1](../ios-architecture.md), `app/Sources/AirMCPApp/AppIntents.swift`, `swift/Sources/AirMCPKit/`, `ios/Sources/AirMCPServer/`, RFC 0001 (error categories), RFC 0006 (Swift schema dump)
 
 ---
@@ -215,7 +216,9 @@ Phase B is a line of Xcode config, not a refactor.
 | A.0     | `scripts/dump-tool-manifest.mjs` + `scripts/gen-swift-intents.mjs` + `tool-manifest.json` codegen + CI drift check. **No Swift build change yet.**                                                                                                                                  | v2.13.0             |
 | A.1     | `MCPIntentRouter` + macOS route (execFile). **10 hand-picked read-only tools** (notes/calendar/reminders/contacts list+read). App builds + `swift test` passes.                                                                                                                     | v2.13.0             |
 | A.2a    | `MCPIntentRouter` handler-injection + macOS execFile handler + iOS in-process `MCPServer.callToolText` handler. Same 10 tools as A.1.                                                                                                                                               | v2.13.0             |
-| A.2b    | Broaden to all read-only eligible tools (~150 of 282). Typed `ReturnsValue<T>` from outputSchema codegen. AppShortcutsProvider top-10 (usage-based).                                                                                                                                | v2.14.0             |
+| A.2b.1  | Broaden to all read-only eligible tools (~154 of 282). Auto-filter + AppShortcutsProvider top-10.                                                                                                                                                                                   | v2.13.0 (PR #105)   |
+| A.2b.2  | Codable output structs as drift guards. `ReturnsValue<T>` deferred (AppIntent requires `_IntentValue`; AppEntity wrapper separate phase).                                                                                                                                           | v2.13.0 (PR #106)   |
+| Ax.6    | `AskAirMCPIntent` natural-language agent via `FoundationModelsBridge`. Pinned first in `AirMCPGeneratedShortcuts` on iOS 26+/macOS 26+.                                                                                                                                             | v2.13.0             |
 | A.3     | Destructive-tool support via iOS 26 `requestConfirmation(actionName:snippetIntent:)`. Codegen emits a confirmation-snippet branch for `destructiveHint: true` tools. **Write tools with `destructiveHint: false`** (~60) land in the same phase since they don't need confirmation. | v2.14.0             |
 | A.4     | **Write tools with `destructiveHint: true`** gated behind explicit config opt-in.                                                                                                                                                                                                   | v2.15.0             |
 | **B.1** | Inject `NSAppIntentsMCPExposure` (or whatever Apple ships) via `AIRMCP_EXPOSE_AS_MCP` build flag. **Triggered by Apple release note.**                                                                                                                                              | Apple-API-dependent |

--- a/scripts/gen-swift-intents.mjs
+++ b/scripts/gen-swift-intents.mjs
@@ -61,6 +61,13 @@ const SKIP_NAMES = new Set([]);
 // usage-tracker-derived data because the tracker runs on the user's
 // laptop and isn't available at codegen time. A future pass can read a
 // checked-in top-N hint file that's refreshed nightly from usage data.
+//
+// AskAirMCPIntent (natural-language agent, axis 6) is pinned as the
+// first entry on iOS 26+/macOS 26+ — it's the most prominent surface
+// AirMCP has on those OS versions. The codegen emits the rest of the
+// 10-slot cap from APP_SHORTCUTS_TOP, so a max of 9 tool-based entries
+// co-exist with it. The hand-written intent lives in
+// swift/Sources/AirMCPKit/AskAirMCPIntent.swift.
 const APP_SHORTCUTS_TOP = [
   "today_events",
   "list_calendars",
@@ -71,7 +78,6 @@ const APP_SHORTCUTS_TOP = [
   "list_bookmarks",
   "get_current_weather",
   "summarize_context",
-  "recent_files",
 ];
 
 // ── Load manifest ────────────────────────────────────────────────────
@@ -548,7 +554,7 @@ function systemImageFor(toolName) {
 }
 
 function generateAppShortcuts() {
-  const entries = appShortcutsPicks.map((tool) => {
+  const toolEntries = appShortcutsPicks.map((tool) => {
     const structName = intentStructName(tool.name);
     const title = swiftLit(tool.title ?? tool.name);
     const img = systemImageFor(tool.name);
@@ -566,9 +572,30 @@ function generateAppShortcuts() {
             systemImageName: "${img}"
         )`;
   });
+
+  // AskAirMCPIntent is the natural-language agent entry (axis 6 /
+  // FoundationModelsBridge). Pinned as the first Shortcuts suggestion
+  // on iOS 26+/macOS 26+ where FoundationModels is available. The
+  // #if guard matches AskAirMCPIntent.swift's availability conditions
+  // so the provider stays compileable on older SDKs.
+  const askShortcut = `        #if canImport(FoundationModels) && compiler(>=6.3)
+        if #available(macOS 26, iOS 26, *) {
+            AppShortcut(
+                intent: AskAirMCPIntent(),
+                phrases: [
+                    "Ask \\(.applicationName)",
+                    "Ask \\(.applicationName) about my day",
+                ],
+                shortTitle: "Ask AirMCP",
+                systemImageName: "brain.head.profile"
+            )
+        }
+        #endif`;
+
   return `public struct AirMCPGeneratedShortcuts: AppShortcutsProvider {
-    public static var appShortcuts: [AppShortcut] {
-${entries.join("\n")}
+    @AppShortcutsBuilder public static var appShortcuts: [AppShortcut] {
+${askShortcut}
+${toolEntries.join("\n")}
     }
 }`;
 }

--- a/swift/Sources/AirMCPKit/AskAirMCPIntent.swift
+++ b/swift/Sources/AirMCPKit/AskAirMCPIntent.swift
@@ -1,0 +1,56 @@
+// AirMCPKit — Ask AirMCP AppIntent (RFC 0007 axis 6).
+//
+// Natural-language entry point that wires Apple's on-device Foundation
+// Models LLM to AirMCP's EventKit/Contacts/Reminders/Notes/HealthKit
+// tools (see FoundationModelsBridge.swift). The whole loop — prompt,
+// model inference, tool calls, final response — runs on-device. No
+// data leaves the phone/Mac and no cloud account is required.
+//
+// Why a separate hand-written intent instead of codegen
+// - Codegen emits one AppIntent per MCP tool. This intent is different:
+//   it takes arbitrary prose and lets the model pick which tools to call.
+//   There's no JSON-Schema for it.
+// - It depends on FoundationModels + the #available(macOS 26, iOS 26, *)
+//   gate the codegen doesn't carry.
+// - A.2b's MCPIntentRouter isn't involved; the Foundation Models Tool
+//   conformances in FoundationModelsBridge.swift call AirMCPKit services
+//   directly, which keeps the on-device guarantee simple to prove.
+//
+// Siri phrase registration happens in the AirMCPGeneratedShortcuts
+// provider (gen-swift-intents.mjs pins this intent as the first entry).
+
+#if canImport(AppIntents) && canImport(FoundationModels) && compiler(>=6.3)
+import AppIntents
+import Foundation
+import FoundationModels
+
+@available(macOS 26, iOS 26, *)
+public struct AskAirMCPIntent: AppIntent {
+    nonisolated(unsafe) public static var title: LocalizedStringResource = "Ask AirMCP"
+    nonisolated(unsafe) public static var description = IntentDescription(
+        "Ask a question in plain language. AirMCP's on-device AI agent answers using your Apple apps (Calendar, Reminders, Contacts, Notes). Runs fully on-device — no cloud calls."
+    )
+    nonisolated(unsafe) public static var openAppWhenRun: Bool = false
+
+    public init() {}
+
+    @Parameter(
+        title: "Question",
+        description: "e.g. 'What's on my calendar today?' or 'Create a reminder to call mom tomorrow at 5pm'"
+    )
+    public var prompt: String
+
+    @Parameter(
+        title: "Instruction override",
+        description: "Optional system instruction that replaces the default assistant prompt"
+    )
+    public var instruction: String?
+
+    public func perform() async throws -> some IntentResult & ReturnsValue<String> {
+        let bridge = FoundationModelsBridge()
+        let answer = try await bridge.run(prompt: prompt, systemInstruction: instruction)
+        return .result(value: answer)
+    }
+}
+
+#endif

--- a/swift/Sources/AirMCPKit/Generated/MCPIntents.swift
+++ b/swift/Sources/AirMCPKit/Generated/MCPIntents.swift
@@ -4,7 +4,7 @@
 // Generator: scripts/gen-swift-intents.mjs
 // RFC 0007 Phase A.2b.2 — 154 auto-selected read-only tools
 // (50 with typed ReturnsValue<T> from outputSchema; the
-// rest stay on ReturnsValue<String>) + 10
+// rest stay on ReturnsValue<String>) + 9
 // AppShortcutsProvider entries (Apple's 10-entry cap).
 // Run `npm run gen:intents` to refresh after tool metadata changes.
 // CI guards against drift via `npm run gen:intents:check`.
@@ -4308,7 +4308,20 @@ public struct UiTraverseIntent: AppIntent {
 // MARK: - AppShortcutsProvider
 
 public struct AirMCPGeneratedShortcuts: AppShortcutsProvider {
-    public static var appShortcuts: [AppShortcut] {
+    @AppShortcutsBuilder public static var appShortcuts: [AppShortcut] {
+        #if canImport(FoundationModels) && compiler(>=6.3)
+        if #available(macOS 26, iOS 26, *) {
+            AppShortcut(
+                intent: AskAirMCPIntent(),
+                phrases: [
+                    "Ask \(.applicationName)",
+                    "Ask \(.applicationName) about my day",
+                ],
+                shortTitle: "Ask AirMCP",
+                systemImageName: "brain.head.profile"
+            )
+        }
+        #endif
         AppShortcut(
             intent: TodayEventsIntent(),
             phrases: [
@@ -4389,15 +4402,6 @@ public struct AirMCPGeneratedShortcuts: AppShortcutsProvider {
             ],
             shortTitle: "Summarize Context",
             systemImageName: "sparkles"
-        )
-        AppShortcut(
-            intent: RecentFilesIntent(),
-            phrases: [
-                "Recent Files in \(.applicationName)",
-                "recent files with \(.applicationName)",
-            ],
-            shortTitle: "Recent Files",
-            systemImageName: "folder"
         )
     }
 }


### PR DESCRIPTION
## Summary

Axis 6 of the sequential iOS roadmap. Lands ahead of A.3 because the offline-privacy wedge is the highest-leverage thing to ship given current market conditions (see 2026-04-23 market research: supermemoryai/apple-mcp archived, Apple absent from iCloud MCP).

## What lands

- **[swift/Sources/AirMCPKit/AskAirMCPIntent.swift](swift/Sources/AirMCPKit/AskAirMCPIntent.swift)** — single hand-written AppIntent "Ask AirMCP" with a prompt + optional instruction parameter. `perform()` routes to [`FoundationModelsBridge.run()`](swift/Sources/AirMCPKit/FoundationModelsBridge.swift) which already wires 5 AirMCP tools (TodayEvents / DueReminders / SearchContacts / CreateReminder / CreateNote) as Apple's `FoundationModels.Tool` conformances.

- **[scripts/gen-swift-intents.mjs](scripts/gen-swift-intents.mjs)** — `AirMCPGeneratedShortcuts` now pins `AskAirMCPIntent` as the first entry on iOS 26+/macOS 26+ (gated by `#if canImport(FoundationModels) && compiler(>=6.3)` + `if #available(macOS 26, iOS 26, *)`). `APP_SHORTCUTS_TOP` trimmed 10 → 9 to honor Apple's cap. System image `brain.head.profile` signals agent rather than direct tool.

- **[docs/rfc/0007-app-intent-bridge.md](docs/rfc/0007-app-intent-bridge.md)** — amendment history + new rollout row "Ax.6".

## Why out-of-order (before A.3)

- A.3 is destructive-tool HITL via `requestConfirmation` — orthogonal axis, doesn't block agent work.
- Market research (this session): offline-privacy is AirMCP's strongest wedge right now. Apple has no iCloud MCP; supermemoryai/apple-mcp archived 2026-01-01. Getting an agent surface out first ships that wedge before a competitor fills it.

## How it stays on-device

The whole loop — prompt, inference, tool calls, response — runs through `FoundationModelsBridge` → `LanguageModelSession(tools: [...])`. Tools use AirMCPKit services directly (`EventKitService`, `ContactsService`), **not** `MCPIntentRouter` execFile. No network, no cloud. Important for HealthKit privacy compliance and for App Store privacy manifest story.

## Verified

- `swift build` (swift/, app/, ios/) — **all green** (~12s warm)
- `npm run gen:intents` / `gen:intents:check` — 154 intents, no drift
- `jest` — 92 suites, **1336 tests** pass (unchanged)
- `npm run smoke` — OK

## Test plan

- [x] Triple Swift build
- [x] All drift guards pass
- [ ] CI
- [ ] Manual: on a macOS 26 + Apple Silicon machine, Siri phrase "Ask AirMCP about my day" surfaces the intent (post-install; not automatable in CI)

## Next

- **Axis 4** — Interactive Snippets renderer. Consumes the axis-6 agent loop for drill-down snippet buttons.
- **A.3** — destructive-tool HITL via `requestConfirmation`.
- **iOS UI surface** — minimal chat view in AirMCPiOS that invokes `AskAirMCPIntent` programmatically.