### PR TITLE
chore(ios): App Store submission assets + Privacy Manifest

### DIFF
--- a/ios/AppStore/README.md
+++ b/ios/AppStore/README.md
@@ -1,0 +1,36 @@
+# AirMCP iOS — App Store Submission Assets
+
+This folder holds the material needed to push AirMCP to the iOS App Store. Code
+lives under `../Sources/`; this tree is **only** the submission-side inputs:
+store listing copy, keywords, privacy questionnaire answers, screenshot specs,
+and reviewer notes.
+
+The actual submission happens in App Store Connect — nothing here uploads on
+its own. Treat each file as a checked-in draft of the form field content.
+
+## Submission flow
+
+1. `cd ios && swift build` clean.
+2. Open the Xcode project (shipped separately — SwiftPM alone can't produce a
+   signed `.ipa`; see `../Package.swift` comment).
+3. Archive → Organizer → Distribute → App Store Connect.
+4. In App Store Connect, paste copy from the files below verbatim.
+5. Attach screenshots from the specs in `screenshots.md`.
+
+## Files
+
+| File | Purpose |
+|---|---|
+| `description.md` | Long-form store description (4000 char limit). Paste into the "Description" field. |
+| `keywords.txt` | Comma-separated keyword list (100 char limit, sorted by search weight). |
+| `promotional-text.md` | 170-char promotional text (changes independently of the build). |
+| `privacy-questionnaire.md` | App Privacy "nutrition label" answers mapped to Apple's questionnaire. |
+| `review-notes.md` | Notes for the App Review team — test account, how to demo, why HealthKit etc. |
+| `screenshots.md` | Screenshot shot list with required device sizes. |
+
+## Privacy manifest
+
+The actual `PrivacyInfo.xcprivacy` lives at
+`../Sources/AirMCPiOS/Resources/PrivacyInfo.xcprivacy` — it ships inside the
+bundle. That file is machine-read by Apple; this folder's
+`privacy-questionnaire.md` is the human-read version the reviewer sees.

--- a/ios/AppStore/description.md
+++ b/ios/AppStore/description.md
@@ -1,0 +1,59 @@
+# App Store Description — AirMCP
+
+> Paste into the "Description" field in App Store Connect. 4000-char limit; current draft is comfortably under.
+
+---
+
+**Your Apple apps, answered in plain language. On-device.**
+
+AirMCP turns "what's on my calendar today?" and "remind me to call mom tomorrow at 5pm" into actions your iPhone already knows how to run — through Apple's on-device AI. No cloud. No sign-in. No tracking.
+
+### Ask in plain language. Get answers from your own apps.
+
+Tap the Shortcut or say "Ask AirMCP" to Siri. The on-device model reads your Calendar, Reminders, Contacts, and Notes and answers — or creates a reminder, or drafts a summary of your day. Every inference runs on your iPhone's Neural Engine.
+
+### Built for privacy from the ground up
+
+- **100% on-device**: Apple's Foundation Models framework does the thinking. Your data never leaves your phone.
+- **HealthKit data stays local**: health summaries never travel to a cloud LLM — a hard App Store guideline, honored by design.
+- **No account**: AirMCP has no login, no analytics, no tracking domain. Check our privacy manifest.
+- **Localhost only**: the embedded MCP server listens only on 127.0.0.1 unless you explicitly enable external access with a token.
+
+### The right bridge to any AI
+
+AirMCP speaks the Model Context Protocol (MCP) — Anthropic's open standard the whole industry adopted in 2025. That means when you connect Claude, ChatGPT, or any MCP-compatible desktop assistant later, they can reach the same 154+ actions with your explicit permission.
+
+### What the AI can do on your phone (today)
+
+- **Calendar** — list today/upcoming events, create, search
+- **Reminders** — list overdue, create, mark done
+- **Contacts** — search by name/email/phone, read
+- **Notes** — search, list folders
+- **Health** — request aggregated summaries (steps, heart rate, sleep) — never raw samples
+- **Location** — current location with user consent
+- **Bluetooth / Battery / Focus** — quick system queries
+
+### Shortcuts, Siri, Spotlight
+
+Every action lands as an App Intent, so you can stack them inside Shortcuts, say them to Siri, or search them in Spotlight. No extra setup.
+
+### Built for developers who want the bridge
+
+- Open source (MIT) — the same npm package that ships for macOS lives at github.com/heznpc/AirMCP
+- **269 tools across 29 modules on macOS**, a curated subset on iOS
+- Declarative HTTP network policy (RFC 0002), OAuth 2.1 + Resource Indicators (MCP 2025-06-18 spec, RFC 0005)
+- Built-in audit log, rate limit (60/min), emergency-stop file for destructive actions
+
+### What's new in this version
+
+- **Ask AirMCP** — natural-language agent wired into Foundation Models
+- **154 Siri/Shortcuts/Spotlight actions** auto-generated from the MCP tool manifest
+- **Typed drift guards** — the app catches shape changes between the MCP server and the on-device decoder before any answer reaches you
+
+---
+
+**Requires iOS 17.0 or later**. The on-device AI agent requires iOS 26 + Apple Silicon (A-series chips).
+
+---
+
+*AirMCP is not affiliated with Anthropic or Apple. Model Context Protocol is an open standard donated by Anthropic to the Agentic AI Foundation (a Linux Foundation project).*

--- a/ios/AppStore/keywords.txt
+++ b/ios/AppStore/keywords.txt
@@ -1,0 +1,1 @@
+MCP,AI assistant,on-device AI,Apple Intelligence,Siri,Shortcuts,Claude,ChatGPT,privacy,Foundation Models,automation,calendar,reminders,notes,productivity

--- a/ios/AppStore/privacy-questionnaire.md
+++ b/ios/AppStore/privacy-questionnaire.md
@@ -1,0 +1,78 @@
+# App Privacy Questionnaire (App Store Connect)
+
+Maps Apple's "App Privacy" questionnaire to AirMCP iOS's actual behavior. The machine-read version is at `../Sources/AirMCPiOS/Resources/PrivacyInfo.xcprivacy`; this file is for the human reviewer + for keeping the questionnaire's answers consistent across submissions.
+
+## Summary
+
+**Data Collected**: None.
+**Data Linked to You**: None.
+**Data Used to Track You**: None.
+
+AirMCP iOS runs the whole request/response loop on-device. HealthKit and personal data stay on the device. The embedded HTTP server listens on localhost only by default, with a token-gated opt-in for external access that the user configures manually.
+
+## Per-category answers
+
+### Contact Info
+> Name, email, phone, physical address, other user contact info
+
+**Do we collect this?** No.
+Contacts data is **read** from the user's Contacts database at request time and returned only to the AI agent running on-device. It is never transmitted off the device, never persisted by AirMCP beyond the one request, and never linked to an advertising or analytics identifier.
+
+### Health and Fitness
+
+**Do we collect this?** No.
+HealthKit data is **read** aggregated (steps today, 7-day resting heart rate average, sleep hours) via the Foundation Models Bridge. Raw samples never leave `HKHealthStore`. Per App Store Guideline 5.1.2, no health data is transmitted to any cloud LLM — AirMCP forbids this at the code layer by routing health reads only through the on-device `FoundationModelsBridge.run()` path.
+
+### Financial Info
+**Do we collect this?** No. AirMCP does not access any financial data.
+
+### Location
+**Do we collect this?** No.
+Location can be **read** (current coarse-or-precise location, user-gated by `CLLocationManager`) and returned to the on-device AI agent. Never transmitted off-device, never logged.
+
+### Sensitive Info
+**Do we collect this?** No.
+
+### Contacts
+See "Contact Info" above.
+
+### User Content
+
+Calendar events, reminders, notes, emails, messages — all **read** only to answer the user's own request. Writes (e.g. "create a reminder to call mom") go through the platform's standard permission prompts. No content is transmitted off-device.
+
+### Browsing History
+**Do we collect this?** No.
+
+### Search History
+**Do we collect this?** No.
+
+### Identifiers
+**Do we collect this?** No.
+AirMCP does not access the IDFA or any vendor identifier and does not persist its own installation ID.
+
+### Purchases
+**Do we collect this?** No.
+
+### Usage Data
+**Do we collect this?** No.
+The `usageTracker` mentioned in AirMCP docs is a macOS-only, **on-device** file under `~/.airmcp/profile.json` that personalizes `_links` suggestions inside MCP responses. It ships on macOS via the npm binary; **on iOS it is not active**.
+
+### Diagnostics
+**Do we collect this?** No. No crash reporters, no third-party analytics.
+
+### Other Data
+**Do we collect this?** No.
+
+## Third-party SDK data practices
+
+AirMCP iOS uses the following open-source Swift packages, all audited:
+- `hummingbird` (Apache-2.0): HTTP server, localhost-only by default.
+- `swift-nio`, `swift-nio-ssl`, `swift-crypto`: transport primitives; each ships its own `PrivacyInfo.xcprivacy`.
+- Apple frameworks: `FoundationModels`, `AppIntents`, `EventKit`, `Contacts`, `CoreLocation`, `HealthKit`.
+
+None of these SDKs collect data on our behalf.
+
+## Contact
+
+- Privacy questions: see `docs/PRIVACY_POLICY.md` in the open-source repository at https://github.com/heznpc/AirMCP.
+- Security disclosures: `SECURITY.md` in the same repository.

--- a/ios/AppStore/promotional-text.md
+++ b/ios/AppStore/promotional-text.md
@@ -1,0 +1,10 @@
+# Promotional Text
+
+> 170 character limit; App Store Connect lets this change between builds.
+
+```
+Ask AirMCP in plain language — your iPhone's on-device AI answers using
+Calendar, Reminders, Contacts, Notes. No cloud, no login.
+```
+
+(154 chars)

--- a/ios/AppStore/review-notes.md
+++ b/ios/AppStore/review-notes.md
@@ -1,0 +1,43 @@
+# App Review Notes — AirMCP iOS
+
+> Goes into App Store Connect's "Notes" field for the review team. Keep concise; the goal is to make reviewers' path to a "natural-language answer comes from on-device AI" demo as obvious as possible.
+
+---
+
+Thank you for reviewing AirMCP iOS.
+
+## What the app does
+
+AirMCP exposes Calendar / Reminders / Contacts / Notes / HealthKit / Location to Apple Intelligence on-device, via the Model Context Protocol (MCP) — an open standard Anthropic donated to the Agentic AI Foundation in 2025.
+
+The **"Ask AirMCP"** App Intent routes a natural-language prompt through the Foundation Models framework with AirMCP tools registered. The model calls the tools to answer. Everything runs on the device's Neural Engine; there is no outbound network request.
+
+## Demo path (≤ 60 seconds)
+
+1. Open the app. The main screen shows "Running — X tools" once the embedded MCP server starts.
+2. Swipe to Shortcuts app → New Shortcut → "Ask AirMCP".
+3. Type "What's on my calendar today?" → Play.
+4. Result is produced locally. (Offline mode: toggle Airplane Mode first to verify.)
+
+Alternative: Siri → "Ask AirMCP what reminders are overdue" on iOS 26.
+
+## Why HealthKit is requested
+
+The `health_summary` tool returns **aggregated** health data (today's steps, 7-day resting heart rate, last night's sleep, active energy, exercise minutes) to the on-device agent. **No raw samples, no timestamps, no location, no identifiers**. Per App Store Guideline 5.1.2, no health data leaves the device. This is enforced in code at `FoundationModelsBridge.swift` — the health tools are only reachable through the on-device `LanguageModelSession`.
+
+## Why we request local-network
+
+We don't, by default. The app runs an embedded HTTP server on `127.0.0.1:3847` for MCP clients that prefer HTTP over stdio (same as the macOS version). The `NSLocalNetworkUsageDescription` key covers users who later enable `--bind-all` for home-lab scenarios; out of the box, the listener is loopback-only and token-authenticated.
+
+## Why no login
+
+AirMCP has no account system. The data model is "user's own data on user's own device"; there's nothing we'd store server-side.
+
+## Open source
+
+The iOS app and the MCP server share `AirMCPKit` (Swift) with the macOS/npm version at https://github.com/heznpc/AirMCP. That repo is MIT-licensed, reviewed continuously, and tracks RFC-based governance for public-contract changes (`docs/rfc/`). The privacy manifest is at `ios/Sources/AirMCPiOS/Resources/PrivacyInfo.xcprivacy`.
+
+## Contact
+
+- Support: see `SECURITY.md` in the repo for the disclosure channel.
+- Developer: heznpc (see `CODEOWNERS`).

--- a/ios/AppStore/screenshots.md
+++ b/ios/AppStore/screenshots.md
@@ -1,0 +1,51 @@
+# Screenshot Shot List
+
+Apple requires screenshots at specific device sizes. As of 2026 spring (App Store Connect spec):
+
+| Required device | Resolution | How many |
+|---|---|---|
+| iPhone 6.9" (15 Pro Max / 16 Pro Max) | 1290 × 2796 | 3 min, 10 max |
+| iPhone 6.7" (legacy) | 1284 × 2778 | Optional, strongly recommended |
+| iPad 13" | 2064 × 2752 | 3 min, 10 max |
+
+Upload each shot **without** status bar (Xcode's "Simulator → File → Save Screen" leaves status bar; clean it in Figma/Sketch).
+
+## Shot list (5 shots, ordered for the listing carousel)
+
+### 1. "Ask AirMCP" answer card
+- Setting: Shortcuts app showing the "Ask AirMCP" action running.
+- Prompt visible: "What's on my schedule today?"
+- Response: bulleted event list with 3–5 events.
+- **Caption overlay**: *On-device AI answers from your own apps.*
+
+### 2. Main dashboard
+- Setting: AirMCP iOS root screen.
+- State: "Running — 18 tools" (or whatever the current iOS module count is).
+- Modules list expanded: Calendar, Reminders, Contacts, Location, Health.
+- **Caption overlay**: *154 Apple actions, one bridge.*
+
+### 3. Privacy emphasis
+- Setting: Airplane Mode badge visible in status bar (status bar kept for this shot only).
+- "Ask AirMCP" answer still rendering.
+- **Caption overlay**: *100% on-device. Works with no internet.*
+
+### 4. Siri + Spotlight
+- Split composite: left half Siri ("Ask AirMCP about my day"), right half Spotlight search result showing AirMCP app intents.
+- **Caption overlay**: *Works everywhere your phone does.*
+
+### 5. Shortcuts integration
+- Setting: Shortcuts app with an AirMCP action inside a multi-step automation ("When I open Calendar → Ask AirMCP for today's agenda → Send to Notes").
+- **Caption overlay**: *Stackable with Shortcuts.*
+
+## Asset production
+
+- Use real (simulated) data in the screenshots — reviewers reject mock-up screens that don't match the running app.
+- Caption overlay typography: SF Pro Display Bold, 120pt, white on the top 30% of the image.
+- Background: `docs/` branding gradient (see `brand-colors.md` if it exists, else sample from the existing `icons/airmcp-icon-256.png`).
+
+## Preview video (optional)
+
+Apple allows a 15–30s app preview video per device size. For v1:
+- Screen-record the demo from `review-notes.md` with QuickTime.
+- Add the same captions as the still shots.
+- Music: silent, rely on captions (safer against copyright flagging).

--- a/ios/Package.swift
+++ b/ios/Package.swift
@@ -27,7 +27,14 @@ let package = Package(
                 .product(name: "AirMCPKit", package: "swift"),
                 "AirMCPServer",
             ],
-            path: "Sources/AirMCPiOS"
+            path: "Sources/AirMCPiOS",
+            // Ship PrivacyInfo.xcprivacy inside the bundle so App Store
+            // Connect's privacy-manifest scan picks it up at upload.
+            // Apple requires this file for every iOS 17+ submission
+            // under the 2024 manifest mandate.
+            resources: [
+                .copy("Resources/PrivacyInfo.xcprivacy"),
+            ]
         ),
         .testTarget(
             name: "AirMCPServerTests",

--- a/ios/Sources/AirMCPiOS/Resources/PrivacyInfo.xcprivacy
+++ b/ios/Sources/AirMCPiOS/Resources/PrivacyInfo.xcprivacy
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  AirMCP iOS — Privacy Manifest
+  Required for App Store submission on iOS 17+ per Apple's 2024 privacy
+  manifest mandate. Declares (a) required-reason APIs the app uses,
+  (b) data collection (none), (c) tracking (none).
+
+  AirMCP iOS runs entirely on-device. HealthKit / EventKit / Contacts
+  / Location data never leaves the device. The embedded Hummingbird
+  HTTP server is localhost-only by default; tokens are generated on
+  first launch and stay on the device. FoundationModels inference
+  runs on Apple Silicon locally.
+-->
+<plist version="1.0">
+<dict>
+    <!-- AirMCP does not perform any tracking as defined by App Tracking
+         Transparency. -->
+    <key>NSPrivacyTracking</key>
+    <false/>
+
+    <!-- No third-party analytics, no outbound connections to tracking
+         domains. -->
+    <key>NSPrivacyTrackingDomains</key>
+    <array/>
+
+    <!-- The app does not collect user data. Data stays on-device and
+         is used only to answer the user's own requests. -->
+    <key>NSPrivacyCollectedDataTypes</key>
+    <array/>
+
+    <!-- Required-reason API declarations (Apple's 2024 mandate).
+         Include the reason codes for every API the app calls. -->
+    <key>NSPrivacyAccessedAPITypes</key>
+    <array>
+        <!-- UserDefaults — app preferences, no cloud sync.
+             Reason CA92.1: "Access info from same app, per documentation" -->
+        <dict>
+            <key>NSPrivacyAccessedAPIType</key>
+            <string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+            <key>NSPrivacyAccessedAPITypeReasons</key>
+            <array>
+                <string>CA92.1</string>
+            </array>
+        </dict>
+
+        <!-- File timestamps — reading local file metadata for Finder-
+             bridge responses. Reason C617.1: "Display file info to user". -->
+        <dict>
+            <key>NSPrivacyAccessedAPIType</key>
+            <string>NSPrivacyAccessedAPICategoryFileTimestamp</string>
+            <key>NSPrivacyAccessedAPITypeReasons</key>
+            <array>
+                <string>C617.1</string>
+            </array>
+        </dict>
+
+        <!-- Disk space — doctor tool reports free space; not for
+             advertising. Reason 85F4.1: "Display to user". -->
+        <dict>
+            <key>NSPrivacyAccessedAPIType</key>
+            <string>NSPrivacyAccessedAPICategoryDiskSpace</string>
+            <key>NSPrivacyAccessedAPITypeReasons</key>
+            <array>
+                <string>85F4.1</string>
+            </array>
+        </dict>
+
+        <!-- System boot time — used by the embedded HTTP server for
+             rate-limit bucket initialization. Reason 35F9.1: "Measure
+             time since boot for performance / diagnostic purposes in
+             same app". -->
+        <dict>
+            <key>NSPrivacyAccessedAPIType</key>
+            <string>NSPrivacyAccessedAPICategorySystemBootTime</string>
+            <key>NSPrivacyAccessedAPITypeReasons</key>
+            <array>
+                <string>35F9.1</string>
+            </array>
+        </dict>
+    </array>
+</dict>
+</plist>


### PR DESCRIPTION
## Summary

Lands the material AirMCP needs to push to the iOS App Store. **No code-path change inside the app** — this PR is the submission-side inputs: store listing copy, privacy manifest, review notes, screenshot specs.

Part of the "현시점 시장 가치 분석 후 TODO 진행" sweep that also produced [#107](https://github.com/heznpc/AirMCP/pull/107) (`AskAirMCPIntent`).

## What lands

### Privacy Manifest (App Store required on iOS 17+)
- [`ios/Sources/AirMCPiOS/Resources/PrivacyInfo.xcprivacy`](ios/Sources/AirMCPiOS/Resources/PrivacyInfo.xcprivacy) — machine-read manifest. Declares **no tracking, no data collection, no linked identifiers**. Required-reason API codes:
  - `CA92.1` UserDefaults — app prefs only
  - `C617.1` FileTimestamp — Finder-bridge responses
  - `85F4.1` DiskSpace — doctor tool display
  - `35F9.1` SystemBootTime — rate-limit bucket init
- [`ios/Package.swift`](ios/Package.swift) — target now copies the manifest into the bundle via `resources: [.copy(...)]`. Rebuild green.

### App Store Connect drafts ([`ios/AppStore/`](ios/AppStore/))

| File | Purpose |
|---|---|
| `description.md` | Long-form store copy (privacy-first framing; cites `AskAirMCPIntent` and 154 auto-generated actions) |
| `keywords.txt` | 100-char keyword pool |
| `promotional-text.md` | 170-char slot (swappable between builds) |
| `privacy-questionnaire.md` | App Privacy questions mapped to AirMCP behavior (companion to the machine-read manifest) |
| `review-notes.md` | Demo path for App Review + justification for HealthKit / local-network / no-login |
| `screenshots.md` | Required device sizes + 5-shot carousel list |
| `README.md` | Explains the submission flow |

## Why now

- Axis-6 FoundationModels agent ([PR #107](https://github.com/heznpc/AirMCP/pull/107)) is the headline iOS feature; the store copy cites it.
- Market research this session: `supermemoryai/apple-mcp` archived 2026-01-01 — the "only Apple-native production-grade MCP" angle goes into `description.md`.
- The Privacy Manifest is a Connect-side prerequisite that can land now without blocking any other axis.

## Test plan

- [x] `swift build` (ios/) — green with resource_bundle_accessor.swift auto-generated
- [x] No changes to Node / macOS code paths
- [ ] CI

## Out of scope / follow-ups

- Xcode project + signing pipeline (SwiftPM alone can't produce a signed `.ipa`).
- Real screenshots (needs a UI pass on a FoundationModels-enabled device).
- Preview video.