### PR TITLE
docs: market positioning + registry submission plan (2026-04-23 sweep)

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ npx airmcp init
 ```
 
 This will:
+
 - Let you choose which Apple apps to connect (Notes, Calendar, Reminders, etc.)
 - Automatically configure your MCP client
 - Save your preferences to `~/.config/airmcp/config.json`
@@ -70,32 +71,38 @@ Checks Node.js version, config files, MCP client setup, macOS permissions, and m
 Once connected, just ask your AI in natural language. Here are some things you can try:
 
 **Everyday**
+
 - "Read my latest notes and summarize them"
 - "What's on my calendar today?"
 - "Show me overdue reminders and reschedule them to tomorrow"
 - "Play some jazz on Apple Music"
 
 **Productivity**
+
 - "Draft a meeting agenda in Notes, then create calendar events for each topic"
 - "Find all emails from Alex about the project and create reminders for action items"
 - "Search my contacts for everyone at Acme Corp"
 
 **System Control**
+
 - "Turn on dark mode, set volume to 50%, and lower brightness"
 - "Take a screenshot and save it to my Desktop"
 - "What apps are running right now? Quit anything I'm not using"
 
 **Research & Web**
+
 - "Open the Apple developer docs in Safari and summarize the page"
 - "Search my Safari tabs for that article I was reading about Swift"
 
 **Power User**
+
 - "Scan nearby Bluetooth devices"
 - "Get my current GPS coordinates and show the weather here"
 - "Record my screen for 10 seconds"
 - "Run my 'Morning Routine' shortcut"
 
 **Cross-App Workflows**
+
 - "Check today's meetings, find related notes, and create a prep checklist in Reminders"
 - "Search my files for the Q1 report, read it, and draft a summary email to the team"
 
@@ -105,19 +112,25 @@ These are just starting points — with 262 tools across 29 Apple apps, the comb
 
 ## Why AirMCP?
 
-| | Direct AppleScript | Siri Shortcuts | apple-mcp | **AirMCP** |
-|---|---|---|---|---|
-| Tools | Manual scripts | Limited actions | 15 | **270+** |
-| Modules | — | — | 5 | **28** |
-| MCP protocol | ❌ | ❌ | ✅ | ✅ |
-| Input validation | ❌ | N/A | ❌ | **Zod + `outputSchema` on ~35% of read tools** |
-| Security | None | Sandboxed | Basic | **HITL + audit log (queryable) + rate limit + emergency stop** |
-| Automations | Hand-wired AppleScripts | `.shortcut` files | ❌ | **14 YAML skills with `parallel`/`loop`/`on_error`/`retry`/inputs + 9 event triggers** |
-| Multi-client | ❌ | ❌ | ✅ | **Claude Desktop/Code/Cowork, Cursor, Windsurf, Copilot** |
-| Swift bridge | ❌ | ❌ | ❌ | **EventKit, PhotoKit, HealthKit, Vision, Foundation Models** |
-| HTTP transport | — | — | ❌ | **Streamable HTTP + declarative `allowNetwork` policy (RFC 0002)** |
-| i18n | ❌ | ❌ | ❌ | **9 languages** |
-| Maintained | — | Apple | ❌ Archived | **Active (v2.10)** |
+After [`supermemoryai/apple-mcp` was archived 2026-01-01](https://github.com/supermemoryai/apple-mcp) (3.1k stars, no more updates), AirMCP is the **only production-grade Apple-native MCP server** still shipping. Apple has not released an official iCloud MCP; Google, Dropbox, and Microsoft have. That gap is AirMCP's.
+
+|                                   | Direct AppleScript      | Siri Shortcuts    | apple-mcp (archived)       | **AirMCP**                                                                                        |
+| --------------------------------- | ----------------------- | ----------------- | -------------------------- | ------------------------------------------------------------------------------------------------- |
+| Tools                             | Manual scripts          | Limited actions   | 15                         | **270+**                                                                                          |
+| Modules                           | —                       | —                 | 5                          | **29**                                                                                            |
+| MCP protocol                      | ❌                      | ❌                | ✅                         | ✅ (2025-06-18 spec + OAuth 2.1 + Resource Indicators, RFC 0005)                                  |
+| Input validation                  | ❌                      | N/A               | ❌                         | **Zod + `outputSchema` on ~35% of read tools + script↔schema contract tests**                     |
+| Security                          | None                    | Sandboxed         | Basic                      | **HITL + audit log (queryable) + rate limit + emergency stop + `allowNetwork` policy (RFC 0002)** |
+| Automations                       | Hand-wired AppleScripts | `.shortcut` files | ❌                         | **14 YAML skills with `parallel`/`loop`/`on_error`/`retry`/inputs + 9 event triggers**            |
+| Multi-client                      | ❌                      | ❌                | ✅                         | **Claude Desktop/Code/Cowork, Cursor, Windsurf, Copilot, VS Code, ChatGPT (MCP Apps)**            |
+| Swift bridge                      | ❌                      | ❌                | ❌                         | **EventKit, PhotoKit, HealthKit, Vision, Foundation Models**                                      |
+| **iOS: Siri/Shortcuts/Spotlight** | ❌                      | Native            | ❌                         | **154 auto-generated AppIntents + AppShortcutsProvider (RFC 0007)**                               |
+| **iOS: on-device agent**          | —                       | —                 | —                          | **`AskAirMCPIntent` → Foundation Models tool calling (iOS 26+)**                                  |
+| HTTP transport                    | —                       | —                 | ❌                         | **Streamable HTTP + declarative `allowNetwork` policy (RFC 0002)**                                |
+| i18n                              | ❌                      | ❌                | ❌                         | **9 languages**                                                                                   |
+| Maintained                        | —                       | Apple             | ❌ **Archived 2026-01-01** | **Active (v2.10+, daily commits)**                                                                |
+
+**The Apple-native MCP reference slot is open.** [Research from Apr 2026](https://www.local-mcp.com/guides/best-mcp-server-mac) notes: _"Outside the archived apple-mcp, no implementation exceeds 5 stars. Most have single-digit commits and single contributors."_
 
 ---
 
@@ -131,9 +144,9 @@ title: Sender → Tasks
 expose_as: tool
 
 inputs:
-  query:    { type: string,  default: newsletter }
-  mailbox:  { type: string,  default: INBOX }
-  limit:    { type: number,  default: 10 }
+  query: { type: string, default: newsletter }
+  mailbox: { type: string, default: INBOX }
+  limit: { type: number, default: 10 }
 
 steps:
   - id: hits
@@ -146,11 +159,12 @@ steps:
     tool: create_reminder
     only_if: "{{hits}} != null"
     loop: "{{hits}}"
-    on_error: continue      # per-iteration: a HITL denial on one item
-                            # doesn't abort the rest of the batch
+    on_error:
+      continue # per-iteration: a HITL denial on one item
+      # doesn't abort the rest of the batch
     args:
       title: "Follow up: {{_item.subject}}"
-      body:  "From {{_item.sender}} (query: {{query}})"
+      body: "From {{_item.sender}} (query: {{query}})"
 ```
 
 **Built-in skills** (14): `morning-briefing`, `calendar-alert`, `inbox-triage`, `meeting-action-items`, `focus-guardian`, `skills-weekly-review`, `project-digest`, `weekly-digest-note`, `focus-block-planner`, `clipboard-url-to-reading`, `favorites-digest`, `sender-to-tasks`, `evening-winddown`, `daily-journal`.
@@ -302,11 +316,11 @@ npx airmcp --http --bind-all --port 3847
 
 **2 · In the browser extension's MCP settings, add:**
 
-| Field | Value |
-|---|---|
-| Server URL | `http://<your-mac>:3847/mcp` (or `https://…` behind a TLS-terminating proxy) |
-| Auth header | `Authorization: Bearer <AIRMCP_HTTP_TOKEN>` |
-| Transport | Streamable HTTP (SSE) |
+| Field       | Value                                                                        |
+| ----------- | ---------------------------------------------------------------------------- |
+| Server URL  | `http://<your-mac>:3847/mcp` (or `https://…` behind a TLS-terminating proxy) |
+| Auth header | `Authorization: Bearer <AIRMCP_HTTP_TOKEN>`                                  |
+| Transport   | Streamable HTTP (SSE)                                                        |
 
 **3 · Verify wiring:**
 
@@ -329,375 +343,376 @@ Running AirMCP on a laptop that suspends? Put the menubar app on your Mac Mini /
 
 ### Notes (12 tools)
 
-| Tool | Description | Type |
-|------|-------------|------|
-| `list_notes` | List all notes with title, folder, dates | read |
-| `search_notes` | Search by keyword in title and body | read |
-| `read_note` | Read full content by ID | read |
-| `create_note` | Create a note with HTML body | write |
-| `update_note` | Replace entire body | destructive |
-| `delete_note` | Delete (moved to Recently Deleted) | destructive |
-| `move_note` | Move to another folder | destructive |
-| `list_folders` | List folders with note counts | read |
-| `create_folder` | Create a new folder | write |
-| `scan_notes` | Bulk scan with metadata and preview | read |
-| `compare_notes` | Compare 2-5 notes side by side | read |
-| `bulk_move_notes` | Move multiple notes at once | destructive |
+| Tool              | Description                              | Type        |
+| ----------------- | ---------------------------------------- | ----------- |
+| `list_notes`      | List all notes with title, folder, dates | read        |
+| `search_notes`    | Search by keyword in title and body      | read        |
+| `read_note`       | Read full content by ID                  | read        |
+| `create_note`     | Create a note with HTML body             | write       |
+| `update_note`     | Replace entire body                      | destructive |
+| `delete_note`     | Delete (moved to Recently Deleted)       | destructive |
+| `move_note`       | Move to another folder                   | destructive |
+| `list_folders`    | List folders with note counts            | read        |
+| `create_folder`   | Create a new folder                      | write       |
+| `scan_notes`      | Bulk scan with metadata and preview      | read        |
+| `compare_notes`   | Compare 2-5 notes side by side           | read        |
+| `bulk_move_notes` | Move multiple notes at once              | destructive |
 
 ### Reminders (11 tools)
 
-| Tool | Description | Type |
-|------|-------------|------|
-| `list_reminder_lists` | List all lists with counts | read |
-| `list_reminders` | Filter by list/completed | read |
-| `read_reminder` | Full details by ID | read |
-| `create_reminder` | Create with due date/priority | write |
-| `update_reminder` | Update properties | destructive |
-| `complete_reminder` | Mark complete/incomplete | write |
-| `delete_reminder` | Delete permanently | destructive |
-| `search_reminders` | Search by keyword in name/body | read |
-| `create_reminder_list` | Create a new reminder list | write |
-| `delete_reminder_list` | Delete a reminder list | destructive |
-| `create_recurring_reminder` | Create with recurrence rule (Swift/EventKit) | write |
+| Tool                        | Description                                  | Type        |
+| --------------------------- | -------------------------------------------- | ----------- |
+| `list_reminder_lists`       | List all lists with counts                   | read        |
+| `list_reminders`            | Filter by list/completed                     | read        |
+| `read_reminder`             | Full details by ID                           | read        |
+| `create_reminder`           | Create with due date/priority                | write       |
+| `update_reminder`           | Update properties                            | destructive |
+| `complete_reminder`         | Mark complete/incomplete                     | write       |
+| `delete_reminder`           | Delete permanently                           | destructive |
+| `search_reminders`          | Search by keyword in name/body               | read        |
+| `create_reminder_list`      | Create a new reminder list                   | write       |
+| `delete_reminder_list`      | Delete a reminder list                       | destructive |
+| `create_recurring_reminder` | Create with recurrence rule (Swift/EventKit) | write       |
 
 ### Calendar (10 tools)
 
-| Tool | Description | Type |
-|------|-------------|------|
-| `list_calendars` | List calendars with name/color | read |
-| `list_events` | Events in date range with pagination | read |
-| `read_event` | Full details with attendees | read |
-| `create_event` | Create with location/description | write |
-| `update_event` | Update properties | destructive |
-| `delete_event` | Delete permanently | destructive |
-| `search_events` | Keyword search in date range | read |
-| `get_upcoming_events` | Next N events from now | read |
-| `today_events` | All events for today | read |
-| `create_recurring_event` | Create with recurrence rule (Swift/EventKit) | write |
+| Tool                     | Description                                  | Type        |
+| ------------------------ | -------------------------------------------- | ----------- |
+| `list_calendars`         | List calendars with name/color               | read        |
+| `list_events`            | Events in date range with pagination         | read        |
+| `read_event`             | Full details with attendees                  | read        |
+| `create_event`           | Create with location/description             | write       |
+| `update_event`           | Update properties                            | destructive |
+| `delete_event`           | Delete permanently                           | destructive |
+| `search_events`          | Keyword search in date range                 | read        |
+| `get_upcoming_events`    | Next N events from now                       | read        |
+| `today_events`           | All events for today                         | read        |
+| `create_recurring_event` | Create with recurrence rule (Swift/EventKit) | write       |
 
 ### Contacts (10 tools)
 
-| Tool | Description | Type |
-|------|-------------|------|
-| `list_contacts` | List with email/phone, pagination | read |
-| `search_contacts` | Search by name, email, phone, or org | read |
-| `read_contact` | Full details (emails, phones, addresses) | read |
-| `create_contact` | Create with email/phone/org | write |
-| `update_contact` | Update properties | destructive |
-| `delete_contact` | Delete permanently | destructive |
-| `list_groups` | List contact groups | read |
-| `add_contact_email` | Add email to existing contact | write |
-| `add_contact_phone` | Add phone to existing contact | write |
-| `list_group_members` | List contacts in a group | read |
+| Tool                 | Description                              | Type        |
+| -------------------- | ---------------------------------------- | ----------- |
+| `list_contacts`      | List with email/phone, pagination        | read        |
+| `search_contacts`    | Search by name, email, phone, or org     | read        |
+| `read_contact`       | Full details (emails, phones, addresses) | read        |
+| `create_contact`     | Create with email/phone/org              | write       |
+| `update_contact`     | Update properties                        | destructive |
+| `delete_contact`     | Delete permanently                       | destructive |
+| `list_groups`        | List contact groups                      | read        |
+| `add_contact_email`  | Add email to existing contact            | write       |
+| `add_contact_phone`  | Add phone to existing contact            | write       |
+| `list_group_members` | List contacts in a group                 | read        |
 
 ### Mail (11 tools)
 
-| Tool | Description | Type |
-|------|-------------|------|
-| `list_mailboxes` | List mailboxes with unread counts | read |
-| `list_messages` | Recent messages in a mailbox | read |
-| `read_message` | Full message content | read |
-| `search_messages` | Search by subject/sender | read |
-| `mark_message_read` | Mark read/unread | write |
-| `flag_message` | Flag/unflag a message | write |
-| `get_unread_count` | Total unread across all mailboxes | read |
-| `move_message` | Move message to another mailbox | destructive |
-| `list_accounts` | List all mail accounts | read |
-| `send_mail` | Compose and send an email | write |
-| `reply_mail` | Reply to an email message | write |
+| Tool                | Description                       | Type        |
+| ------------------- | --------------------------------- | ----------- |
+| `list_mailboxes`    | List mailboxes with unread counts | read        |
+| `list_messages`     | Recent messages in a mailbox      | read        |
+| `read_message`      | Full message content              | read        |
+| `search_messages`   | Search by subject/sender          | read        |
+| `mark_message_read` | Mark read/unread                  | write       |
+| `flag_message`      | Flag/unflag a message             | write       |
+| `get_unread_count`  | Total unread across all mailboxes | read        |
+| `move_message`      | Move message to another mailbox   | destructive |
+| `list_accounts`     | List all mail accounts            | read        |
+| `send_mail`         | Compose and send an email         | write       |
+| `reply_mail`        | Reply to an email message         | write       |
 
 ### Music (17 tools)
 
-| Tool | Description | Type |
-|------|-------------|------|
-| `list_playlists` | List playlists with track counts | read |
-| `list_tracks` | Tracks in a playlist | read |
-| `now_playing` | Current track and playback state | read |
-| `playback_control` | Play, pause, next, previous | write |
-| `search_tracks` | Search by name/artist/album | read |
-| `play_track` | Play a specific track by name | write |
-| `play_playlist` | Start playing a playlist | write |
-| `get_track_info` | Detailed track metadata | read |
-| `set_shuffle` | Set shuffle and repeat mode | write |
-| `create_playlist` | Create a new playlist | write |
-| `add_to_playlist` | Add a track to a playlist | write |
-| `remove_from_playlist` | Remove a track from a playlist | destructive |
-| `delete_playlist` | Delete an existing playlist | destructive |
-| `get_rating` | Get rating, favorited, and disliked status | read |
-| `set_rating` | Set star rating (0-100) for a track | write |
-| `set_favorited` | Mark or unmark a track as favorited | write |
-| `set_disliked` | Mark or unmark a track as disliked | write |
+| Tool                   | Description                                | Type        |
+| ---------------------- | ------------------------------------------ | ----------- |
+| `list_playlists`       | List playlists with track counts           | read        |
+| `list_tracks`          | Tracks in a playlist                       | read        |
+| `now_playing`          | Current track and playback state           | read        |
+| `playback_control`     | Play, pause, next, previous                | write       |
+| `search_tracks`        | Search by name/artist/album                | read        |
+| `play_track`           | Play a specific track by name              | write       |
+| `play_playlist`        | Start playing a playlist                   | write       |
+| `get_track_info`       | Detailed track metadata                    | read        |
+| `set_shuffle`          | Set shuffle and repeat mode                | write       |
+| `create_playlist`      | Create a new playlist                      | write       |
+| `add_to_playlist`      | Add a track to a playlist                  | write       |
+| `remove_from_playlist` | Remove a track from a playlist             | destructive |
+| `delete_playlist`      | Delete an existing playlist                | destructive |
+| `get_rating`           | Get rating, favorited, and disliked status | read        |
+| `set_rating`           | Set star rating (0-100) for a track        | write       |
+| `set_favorited`        | Mark or unmark a track as favorited        | write       |
+| `set_disliked`         | Mark or unmark a track as disliked         | write       |
 
 ### Finder (8 tools)
 
-| Tool | Description | Type |
-|------|-------------|------|
-| `search_files` | Spotlight file search | read |
-| `get_file_info` | File info (size, dates, tags) | read |
-| `set_file_tags` | Set Finder tags | destructive |
-| `recent_files` | Recently modified files | read |
-| `list_directory` | List files in directory | read |
-| `move_file` | Move/rename file | destructive |
-| `trash_file` | Move to Trash | destructive |
-| `create_directory` | Create new directory | write |
+| Tool               | Description                   | Type        |
+| ------------------ | ----------------------------- | ----------- |
+| `search_files`     | Spotlight file search         | read        |
+| `get_file_info`    | File info (size, dates, tags) | read        |
+| `set_file_tags`    | Set Finder tags               | destructive |
+| `recent_files`     | Recently modified files       | read        |
+| `list_directory`   | List files in directory       | read        |
+| `move_file`        | Move/rename file              | destructive |
+| `trash_file`       | Move to Trash                 | destructive |
+| `create_directory` | Create new directory          | write       |
 
 ### Safari (12 tools)
 
-| Tool | Description | Type |
-|------|-------------|------|
-| `list_tabs` | List tabs across all windows | read |
-| `read_page_content` | Read page text content | read |
-| `get_current_tab` | Current active tab URL/title | read |
-| `open_url` | Open URL in Safari | write |
-| `close_tab` | Close a specific tab | destructive |
-| `activate_tab` | Switch to a specific tab | write |
-| `run_javascript` | Execute JavaScript in tab | write |
-| `search_tabs` | Search tabs by title/URL | read |
-| `list_bookmarks` | List all bookmarks across folders | read |
-| `add_bookmark` | Add a bookmark to Safari | write |
-| `list_reading_list` | List Reading List items | read |
-| `add_to_reading_list` | Add URL to Reading List | write |
+| Tool                  | Description                       | Type        |
+| --------------------- | --------------------------------- | ----------- |
+| `list_tabs`           | List tabs across all windows      | read        |
+| `read_page_content`   | Read page text content            | read        |
+| `get_current_tab`     | Current active tab URL/title      | read        |
+| `open_url`            | Open URL in Safari                | write       |
+| `close_tab`           | Close a specific tab              | destructive |
+| `activate_tab`        | Switch to a specific tab          | write       |
+| `run_javascript`      | Execute JavaScript in tab         | write       |
+| `search_tabs`         | Search tabs by title/URL          | read        |
+| `list_bookmarks`      | List all bookmarks across folders | read        |
+| `add_bookmark`        | Add a bookmark to Safari          | write       |
+| `list_reading_list`   | List Reading List items           | read        |
+| `add_to_reading_list` | Add URL to Reading List           | write       |
 
 ### System (27 tools)
 
-| Tool | Description | Type |
-|------|-------------|------|
-| `get_clipboard` | Read clipboard content | read |
-| `set_clipboard` | Write to clipboard | write |
-| `get_volume` | Get system volume | read |
-| `set_volume` | Set system volume | write |
-| `toggle_dark_mode` | Toggle dark/light mode | write |
-| `get_frontmost_app` | Get frontmost application | read |
-| `list_running_apps` | List running applications | read |
-| `get_screen_info` | Display information | read |
-| `show_notification` | Show system notification | write |
-| `capture_screenshot` | Capture screenshot (full/window/selection) | write |
-| `get_wifi_status` | WiFi connection status and signal | read |
-| `toggle_wifi` | Turn WiFi on or off | write |
-| `list_bluetooth_devices` | List paired Bluetooth devices | read |
-| `get_battery_status` | Battery percentage, charging, time remaining | read |
-| `get_brightness` | Get display brightness level | read |
-| `set_brightness` | Set display brightness level | write |
-| `toggle_focus_mode` | Toggle Do Not Disturb on or off | write |
-| `system_sleep` | Put system to sleep | write |
-| `prevent_sleep` | Keep system awake for N seconds | write |
-| `system_power` | Shutdown or restart the system | destructive |
-| `launch_app` | Launch/activate an application | write |
-| `quit_app` | Quit a running application | destructive |
-| `is_app_running` | Check if an application is running | read |
-| `list_all_windows` | List all windows across all apps | read |
-| `move_window` | Move a window to specific coordinates | write |
-| `resize_window` | Resize a window | write |
-| `minimize_window` | Minimize or restore a window | write |
+| Tool                     | Description                                  | Type        |
+| ------------------------ | -------------------------------------------- | ----------- |
+| `get_clipboard`          | Read clipboard content                       | read        |
+| `set_clipboard`          | Write to clipboard                           | write       |
+| `get_volume`             | Get system volume                            | read        |
+| `set_volume`             | Set system volume                            | write       |
+| `toggle_dark_mode`       | Toggle dark/light mode                       | write       |
+| `get_frontmost_app`      | Get frontmost application                    | read        |
+| `list_running_apps`      | List running applications                    | read        |
+| `get_screen_info`        | Display information                          | read        |
+| `show_notification`      | Show system notification                     | write       |
+| `capture_screenshot`     | Capture screenshot (full/window/selection)   | write       |
+| `get_wifi_status`        | WiFi connection status and signal            | read        |
+| `toggle_wifi`            | Turn WiFi on or off                          | write       |
+| `list_bluetooth_devices` | List paired Bluetooth devices                | read        |
+| `get_battery_status`     | Battery percentage, charging, time remaining | read        |
+| `get_brightness`         | Get display brightness level                 | read        |
+| `set_brightness`         | Set display brightness level                 | write       |
+| `toggle_focus_mode`      | Toggle Do Not Disturb on or off              | write       |
+| `system_sleep`           | Put system to sleep                          | write       |
+| `prevent_sleep`          | Keep system awake for N seconds              | write       |
+| `system_power`           | Shutdown or restart the system               | destructive |
+| `launch_app`             | Launch/activate an application               | write       |
+| `quit_app`               | Quit a running application                   | destructive |
+| `is_app_running`         | Check if an application is running           | read        |
+| `list_all_windows`       | List all windows across all apps             | read        |
+| `move_window`            | Move a window to specific coordinates        | write       |
+| `resize_window`          | Resize a window                              | write       |
+| `minimize_window`        | Minimize or restore a window                 | write       |
 
 ### Photos (9 tools)
 
-| Tool | Description | Type |
-|------|-------------|------|
-| `list_albums` | List albums | read |
-| `list_photos` | List photos in album | read |
-| `search_photos` | Search photos by keyword | read |
-| `get_photo_info` | Photo metadata details | read |
-| `list_favorites` | List favorite photos | read |
-| `create_album` | Create new album | write |
-| `add_to_album` | Add photo to album | write |
-| `import_photo` | Import photo from file (Swift/PhotoKit) | write |
-| `delete_photos` | Delete photos by ID (Swift/PhotoKit) | destructive |
+| Tool             | Description                             | Type        |
+| ---------------- | --------------------------------------- | ----------- |
+| `list_albums`    | List albums                             | read        |
+| `list_photos`    | List photos in album                    | read        |
+| `search_photos`  | Search photos by keyword                | read        |
+| `get_photo_info` | Photo metadata details                  | read        |
+| `list_favorites` | List favorite photos                    | read        |
+| `create_album`   | Create new album                        | write       |
+| `add_to_album`   | Add photo to album                      | write       |
+| `import_photo`   | Import photo from file (Swift/PhotoKit) | write       |
+| `delete_photos`  | Delete photos by ID (Swift/PhotoKit)    | destructive |
 
 ### Messages (6 tools)
 
-| Tool | Description | Type |
-|------|-------------|------|
-| `list_chats` | Recent conversations with participants | read |
-| `read_chat` | Chat details (participants, last update) | read |
-| `search_chats` | Search by name/participant/handle | read |
-| `send_message` | Send iMessage/SMS text | write |
-| `send_file` | Send file via iMessage/SMS | write |
-| `list_participants` | List chat participants | read |
+| Tool                | Description                              | Type  |
+| ------------------- | ---------------------------------------- | ----- |
+| `list_chats`        | Recent conversations with participants   | read  |
+| `read_chat`         | Chat details (participants, last update) | read  |
+| `search_chats`      | Search by name/participant/handle        | read  |
+| `send_message`      | Send iMessage/SMS text                   | write |
+| `send_file`         | Send file via iMessage/SMS               | write |
+| `list_participants` | List chat participants                   | read  |
 
 ### Shortcuts (11 tools)
 
-| Tool | Description | Type |
-|------|-------------|------|
-| `list_shortcuts` | List available shortcuts | read |
-| `run_shortcut` | Run shortcut by name | write |
-| `search_shortcuts` | Search shortcuts by name | read |
-| `get_shortcut_detail` | Shortcut details/actions | read |
-| `create_shortcut` | Create a new shortcut via UI automation | write |
-| `delete_shortcut` | Delete shortcut by name (macOS 13+) | destructive |
-| `export_shortcut` | Export shortcut to .shortcut file | write |
-| `import_shortcut` | Import shortcut from .shortcut file | write |
-| `edit_shortcut` | Open shortcut in Shortcuts app for editing | write |
-| `duplicate_shortcut` | Duplicate an existing shortcut | write |
+| Tool                  | Description                                | Type        |
+| --------------------- | ------------------------------------------ | ----------- |
+| `list_shortcuts`      | List available shortcuts                   | read        |
+| `run_shortcut`        | Run shortcut by name                       | write       |
+| `search_shortcuts`    | Search shortcuts by name                   | read        |
+| `get_shortcut_detail` | Shortcut details/actions                   | read        |
+| `create_shortcut`     | Create a new shortcut via UI automation    | write       |
+| `delete_shortcut`     | Delete shortcut by name (macOS 13+)        | destructive |
+| `export_shortcut`     | Export shortcut to .shortcut file          | write       |
+| `import_shortcut`     | Import shortcut from .shortcut file        | write       |
+| `edit_shortcut`       | Open shortcut in Shortcuts app for editing | write       |
+| `duplicate_shortcut`  | Duplicate an existing shortcut             | write       |
 
 ### UI Automation (10 tools)
 
-| Tool | Description | Type |
-|------|-------------|------|
-| `ui_open_app` | Open app and read accessibility summary | read |
-| `ui_click` | Click element by coordinates or text | write |
-| `ui_type` | Type text into focused field | write |
-| `ui_press_key` | Send key combinations | write |
-| `ui_scroll` | Scroll in direction | write |
-| `ui_read` | Read app accessibility tree | read |
-| `ui_accessibility_query` | Query UI elements by role/title/value/identifier | read |
-| `ui_perform_action` | Find element by locator + perform AX action | write |
-| `ui_traverse` | BFS traverse with PID targeting + visible filter | read |
-| `ui_diff` | Compare UI state before/after an action | read |
+| Tool                     | Description                                      | Type  |
+| ------------------------ | ------------------------------------------------ | ----- |
+| `ui_open_app`            | Open app and read accessibility summary          | read  |
+| `ui_click`               | Click element by coordinates or text             | write |
+| `ui_type`                | Type text into focused field                     | write |
+| `ui_press_key`           | Send key combinations                            | write |
+| `ui_scroll`              | Scroll in direction                              | write |
+| `ui_read`                | Read app accessibility tree                      | read  |
+| `ui_accessibility_query` | Query UI elements by role/title/value/identifier | read  |
+| `ui_perform_action`      | Find element by locator + perform AX action      | write |
+| `ui_traverse`            | BFS traverse with PID targeting + visible filter | read  |
+| `ui_diff`                | Compare UI state before/after an action          | read  |
 
 ### Apple Intelligence (13 tools)
 
 Requires macOS 26+ with Apple Silicon.
 
-| Tool | Description | Type |
-|------|-------------|------|
-| `summarize_text` | On-device text summarization | read |
-| `rewrite_text` | Rewrite with specified tone | read |
-| `proofread_text` | Grammar/spelling correction | read |
-| `generate_text` | Generate text with custom instructions via on-device AI | read |
-| `generate_structured` | Generate structured JSON output with schema | read |
-| `tag_content` | Content classification/tagging with confidence | read |
-| `ai_chat` | Named multi-turn on-device AI session | read |
-| `generate_image` | Generate an image on disk via Image Playground | write |
-| `scan_document` | Detect text / tables / forms in an image | read |
-| `generate_plan` | Ask the on-device model for a JSON tool-call plan | read |
-| `ai_plan_metrics` | Run a sampled GOLDEN_PLANS batch and report planner quality | read |
-| `ai_status` | Check Foundation Model availability | read |
-| `ai_agent` | On-device autonomous tool-calling agent | read |
+| Tool                  | Description                                                 | Type  |
+| --------------------- | ----------------------------------------------------------- | ----- |
+| `summarize_text`      | On-device text summarization                                | read  |
+| `rewrite_text`        | Rewrite with specified tone                                 | read  |
+| `proofread_text`      | Grammar/spelling correction                                 | read  |
+| `generate_text`       | Generate text with custom instructions via on-device AI     | read  |
+| `generate_structured` | Generate structured JSON output with schema                 | read  |
+| `tag_content`         | Content classification/tagging with confidence              | read  |
+| `ai_chat`             | Named multi-turn on-device AI session                       | read  |
+| `generate_image`      | Generate an image on disk via Image Playground              | write |
+| `scan_document`       | Detect text / tables / forms in an image                    | read  |
+| `generate_plan`       | Ask the on-device model for a JSON tool-call plan           | read  |
+| `ai_plan_metrics`     | Run a sampled GOLDEN_PLANS batch and report planner quality | read  |
+| `ai_status`           | Check Foundation Model availability                         | read  |
+| `ai_agent`            | On-device autonomous tool-calling agent                     | read  |
 
 ### Context Memory (4 tools)
 
 Durable on-disk store for facts, named entities, and time-anchored episodes. Backed by `~/.cache/airmcp/memory.json`; also exposed as the `memory://recent` MCP resource.
 
-| Tool | Description | Type |
-|------|-------------|------|
-| `memory_put` | Insert or update a fact / entity / episode (idempotent upsert, optional TTL) | write |
-| `memory_query` | Filter by kind / tags / substring, newest-first | read |
-| `memory_forget` | Delete by id / key / tag | destructive |
-| `memory_stats` | Counts by kind + oldest/newest timestamps (sweeps expired as a side-effect) | read |
+| Tool            | Description                                                                  | Type        |
+| --------------- | ---------------------------------------------------------------------------- | ----------- |
+| `memory_put`    | Insert or update a fact / entity / episode (idempotent upsert, optional TTL) | write       |
+| `memory_query`  | Filter by kind / tags / substring, newest-first                              | read        |
+| `memory_forget` | Delete by id / key / tag                                                     | destructive |
+| `memory_stats`  | Counts by kind + oldest/newest timestamps (sweeps expired as a side-effect)  | read        |
 
 ### Audit (2 tools)
 
 Consumable view of the on-device audit log (populated for every tool call).
 
-| Tool | Description | Type |
-|------|-------------|------|
-| `audit_log` | Paginated recent calls, filterable by tool / status / time window | read |
-| `audit_summary` | Total count, error rate, top-N busiest tools over a window | read |
+| Tool            | Description                                                       | Type |
+| --------------- | ----------------------------------------------------------------- | ---- |
+| `audit_log`     | Paginated recent calls, filterable by tool / status / time window | read |
+| `audit_summary` | Total count, error rate, top-N busiest tools over a window        | read |
 
 ### TV (6 tools)
 
-| Tool | Description | Type |
-|------|-------------|------|
-| `tv_list_playlists` | List Apple TV playlists (library) | read |
-| `tv_list_tracks` | List movies/episodes in playlist | read |
-| `tv_now_playing` | Currently playing content | read |
-| `tv_playback_control` | Play/pause/next/previous control | write |
-| `tv_search` | Search movies/TV shows | read |
-| `tv_play` | Play movie/episode by name | write |
+| Tool                  | Description                       | Type  |
+| --------------------- | --------------------------------- | ----- |
+| `tv_list_playlists`   | List Apple TV playlists (library) | read  |
+| `tv_list_tracks`      | List movies/episodes in playlist  | read  |
+| `tv_now_playing`      | Currently playing content         | read  |
+| `tv_playback_control` | Play/pause/next/previous control  | write |
+| `tv_search`           | Search movies/TV shows            | read  |
+| `tv_play`             | Play movie/episode by name        | write |
 
 ### Screen Capture (5 tools)
 
-| Tool | Description | Type |
-|------|-------------|------|
-| `capture_screen` | Capture full screen screenshot (returns PNG image) | read |
-| `capture_window` | Capture a specific app window | read |
-| `capture_area` | Capture a screen region by coordinates | read |
-| `list_windows` | List all visible windows with position/size | read |
-| `record_screen` | Record screen for 1-60 seconds (.mov) | write |
+| Tool             | Description                                        | Type  |
+| ---------------- | -------------------------------------------------- | ----- |
+| `capture_screen` | Capture full screen screenshot (returns PNG image) | read  |
+| `capture_window` | Capture a specific app window                      | read  |
+| `capture_area`   | Capture a screen region by coordinates             | read  |
+| `list_windows`   | List all visible windows with position/size        | read  |
+| `record_screen`  | Record screen for 1-60 seconds (.mov)              | write |
 
 ### Maps (8 tools)
 
-| Tool | Description | Type |
-|------|-------------|------|
-| `search_location` | Search for a place in Apple Maps | write |
-| `get_directions` | Get directions between two locations | write |
-| `drop_pin` | Drop a pin at specific coordinates | write |
-| `open_address` | Open a specific address in Apple Maps | write |
-| `search_nearby` | Search for places near a location | write |
-| `share_location` | Generate a shareable Apple Maps link | read |
-| `geocode` | Convert place name/address to coordinates | read |
-| `reverse_geocode` | Convert coordinates to place name/address | read |
+| Tool              | Description                               | Type  |
+| ----------------- | ----------------------------------------- | ----- |
+| `search_location` | Search for a place in Apple Maps          | write |
+| `get_directions`  | Get directions between two locations      | write |
+| `drop_pin`        | Drop a pin at specific coordinates        | write |
+| `open_address`    | Open a specific address in Apple Maps     | write |
+| `search_nearby`   | Search for places near a location         | write |
+| `share_location`  | Generate a shareable Apple Maps link      | read  |
+| `geocode`         | Convert place name/address to coordinates | read  |
+| `reverse_geocode` | Convert coordinates to place name/address | read  |
 
 ### Podcasts (6 tools)
 
-| Tool | Description | Type |
-|------|-------------|------|
-| `list_podcast_shows` | List subscribed podcast shows | read |
-| `list_podcast_episodes` | List episodes for a show | read |
-| `podcast_now_playing` | Currently playing podcast episode | read |
-| `podcast_playback_control` | Play, pause, next, previous | write |
-| `play_podcast_episode` | Play a specific episode by name | write |
-| `search_podcast_episodes` | Search episodes by keyword | read |
+| Tool                       | Description                       | Type  |
+| -------------------------- | --------------------------------- | ----- |
+| `list_podcast_shows`       | List subscribed podcast shows     | read  |
+| `list_podcast_episodes`    | List episodes for a show          | read  |
+| `podcast_now_playing`      | Currently playing podcast episode | read  |
+| `podcast_playback_control` | Play, pause, next, previous       | write |
+| `play_podcast_episode`     | Play a specific episode by name   | write |
+| `search_podcast_episodes`  | Search episodes by keyword        | read  |
 
 ### Weather (3 tools)
 
-| Tool | Description | Type |
-|------|-------------|------|
-| `get_current_weather` | Get current weather by coordinates | read |
-| `get_daily_forecast` | Get multi-day forecast by coordinates | read |
-| `get_hourly_forecast` | Get hourly forecast by coordinates | read |
+| Tool                  | Description                           | Type |
+| --------------------- | ------------------------------------- | ---- |
+| `get_current_weather` | Get current weather by coordinates    | read |
+| `get_daily_forecast`  | Get multi-day forecast by coordinates | read |
+| `get_hourly_forecast` | Get hourly forecast by coordinates    | read |
 
 ### Location (2 tools)
 
-| Tool | Description | Type |
-|------|-------------|------|
-| `get_current_location` | Get device's current GPS coordinates | read |
+| Tool                      | Description                                  | Type |
+| ------------------------- | -------------------------------------------- | ---- |
+| `get_current_location`    | Get device's current GPS coordinates         | read |
 | `get_location_permission` | Check Location Services authorization status | read |
 
 ### Bluetooth (4 tools)
 
-| Tool | Description | Type |
-|------|-------------|------|
-| `get_bluetooth_state` | Check Bluetooth power state | read |
-| `scan_bluetooth` | Scan for nearby BLE devices | read |
-| `connect_bluetooth` | Connect to a BLE device by UUID | write |
-| `disconnect_bluetooth` | Disconnect a BLE device | write |
+| Tool                   | Description                     | Type  |
+| ---------------------- | ------------------------------- | ----- |
+| `get_bluetooth_state`  | Check Bluetooth power state     | read  |
+| `scan_bluetooth`       | Scan for nearby BLE devices     | read  |
+| `connect_bluetooth`    | Connect to a BLE device by UUID | write |
+| `disconnect_bluetooth` | Disconnect a BLE device         | write |
 
 ### Google Workspace (16 tools)
 
 Requires: `npm install -g @googleworkspace/cli && gws auth setup`
 
-| Tool | Description | Type |
-|------|-------------|------|
-| `gws_status` | Check GWS CLI availability | read |
-| `gws_gmail_list` | List Gmail messages with query | read |
-| `gws_gmail_read` | Read Gmail message by ID | read |
-| `gws_gmail_send` | Send email via Gmail | write |
-| `gws_drive_list` | List Google Drive files | read |
-| `gws_drive_read` | Get Drive file metadata | read |
-| `gws_drive_search` | Full-text search across Drive | read |
-| `gws_sheets_read` | Read Google Sheet values | read |
-| `gws_sheets_write` | Write to Google Sheet | write |
-| `gws_calendar_list` | List Google Calendar events | read |
-| `gws_calendar_create` | Create Google Calendar event | write |
-| `gws_docs_read` | Read Google Doc content | read |
-| `gws_tasks_list` | List Google Tasks | read |
-| `gws_tasks_create` | Create Google Task | write |
-| `gws_people_search` | Search Google Contacts | read |
-| `gws_raw` | Execute any GWS CLI command | write |
+| Tool                  | Description                    | Type  |
+| --------------------- | ------------------------------ | ----- |
+| `gws_status`          | Check GWS CLI availability     | read  |
+| `gws_gmail_list`      | List Gmail messages with query | read  |
+| `gws_gmail_read`      | Read Gmail message by ID       | read  |
+| `gws_gmail_send`      | Send email via Gmail           | write |
+| `gws_drive_list`      | List Google Drive files        | read  |
+| `gws_drive_read`      | Get Drive file metadata        | read  |
+| `gws_drive_search`    | Full-text search across Drive  | read  |
+| `gws_sheets_read`     | Read Google Sheet values       | read  |
+| `gws_sheets_write`    | Write to Google Sheet          | write |
+| `gws_calendar_list`   | List Google Calendar events    | read  |
+| `gws_calendar_create` | Create Google Calendar event   | write |
+| `gws_docs_read`       | Read Google Doc content        | read  |
+| `gws_tasks_list`      | List Google Tasks              | read  |
+| `gws_tasks_create`    | Create Google Task             | write |
+| `gws_people_search`   | Search Google Contacts         | read  |
+| `gws_raw`             | Execute any GWS CLI command    | write |
 
 ## Resources
 
 MCP resources provide live data from Apple apps via URI.
 
-| URI | Description |
-|-----|-------------|
-| `notes://recent` | 10 most recent notes |
-| `notes://recent/{count}` | Recent notes (custom count, max 50) |
-| `calendar://today` | Today's calendar events |
-| `calendar://upcoming` | Next 7 days of calendar events |
-| `reminders://due` | Overdue reminders |
-| `reminders://today` | Today's due reminders (incomplete only) |
-| `music://now-playing` | Currently playing Apple Music track |
-| `system://clipboard` | macOS clipboard content |
-| `mail://unread` | Unread mail count across all mailboxes |
-| `context://snapshot` | Unified context from all active apps |
+| URI                          | Description                                      |
+| ---------------------------- | ------------------------------------------------ |
+| `notes://recent`             | 10 most recent notes                             |
+| `notes://recent/{count}`     | Recent notes (custom count, max 50)              |
+| `calendar://today`           | Today's calendar events                          |
+| `calendar://upcoming`        | Next 7 days of calendar events                   |
+| `reminders://due`            | Overdue reminders                                |
+| `reminders://today`          | Today's due reminders (incomplete only)          |
+| `music://now-playing`        | Currently playing Apple Music track              |
+| `system://clipboard`         | macOS clipboard content                          |
+| `mail://unread`              | Unread mail count across all mailboxes           |
+| `context://snapshot`         | Unified context from all active apps             |
 | `context://snapshot/{depth}` | Configurable depth context (brief/standard/full) |
 
 ## Prompts
 
 ### Per-App
+
 - **organize-notes** — Classify notes by topic, create folders, move
 - **find-duplicates** — Find similar notes, compare, suggest cleanup
 - **weekly-review** — Summarize past week's notes
@@ -707,6 +722,7 @@ MCP resources provide live data from Apple apps via URI.
 - **meeting-prep** — Event details + related notes for meeting prep
 
 ### Cross-Module
+
 - **daily-briefing** — Today's events + due reminders + recent notes
 - **weekly-digest** — Past N days: events + notes + reminders combined
 - **meeting-notes-to-reminders** — Extract action items from meeting notes, create reminders
@@ -716,6 +732,7 @@ MCP resources provide live data from Apple apps via URI.
 - **file-organizer** — Finder file organization + Notes logging
 
 ### Developer Workflows
+
 - **dev-session** — Scan project, check specs, research docs, create session notes
 - **debug-loop** — Capture errors from Safari/clipboard, locate code, log bugs, create fix tasks
 - **screen-capture-flow** — Screenshot → Photos import → annotation notes
@@ -724,6 +741,7 @@ MCP resources provide live data from Apple apps via URI.
 - **build-log** — Analyze build output, log errors or celebrate success
 
 ### Shortcuts
+
 - **shortcut-automation** — Discover and chain Siri Shortcuts for automation
 - **shortcut-discovery** — Find relevant shortcuts for a task
 - **shortcut-troubleshooting** — Debug and fix broken shortcuts
@@ -782,31 +800,31 @@ Or edit `~/.config/airmcp/config.json` directly:
 
 ## CLI Commands
 
-| Command | Description |
-|---------|-------------|
-| `npx airmcp init` | Interactive setup wizard |
-| `npx airmcp doctor` | Diagnose installation issues |
-| `npx airmcp` | Start MCP server (stdio, default) |
-| `npx airmcp --version` | Print version and exit |
-| `npx airmcp --full` | Start with all 27 modules enabled |
-| `npx airmcp --http` | Start as HTTP server (port 3847) |
+| Command                | Description                       |
+| ---------------------- | --------------------------------- |
+| `npx airmcp init`      | Interactive setup wizard          |
+| `npx airmcp doctor`    | Diagnose installation issues      |
+| `npx airmcp`           | Start MCP server (stdio, default) |
+| `npx airmcp --version` | Print version and exit            |
+| `npx airmcp --full`    | Start with all 27 modules enabled |
+| `npx airmcp --http`    | Start as HTTP server (port 3847)  |
 
 ## Configuration
 
 ### Environment Variables
 
-| Variable | Default | Description |
-|----------|---------|-------------|
-| `AIRMCP_INCLUDE_SHARED` | `false` | Include shared notes/folders |
-| `AIRMCP_ALLOW_SEND_MESSAGES` | `false` | Allow sending iMessages (opt-in) |
-| `AIRMCP_ALLOW_SEND_MAIL` | `false` | Allow sending emails (opt-in) |
-| `AIRMCP_FULL` | `false` | Enable all modules (ignores preset) |
-| `AIRMCP_DISABLE_{MODULE}` | — | Disable a specific module (e.g. `AIRMCP_DISABLE_MUSIC=true`) |
-| `GEMINI_API_KEY` | — | Google Gemini API key for cloud embeddings (optional) |
-| `AIRMCP_EMBEDDING_MODEL` | `gemini-embedding-2-preview` | Gemini embedding model name |
-| `AIRMCP_EMBEDDING_DIM` | `3072` | Embedding dimension (256/512/1024/2048/3072) |
-| `AIRMCP_EMBEDDING_PROVIDER` | auto | Force provider: `gemini`, `swift`, `hybrid`, `none` |
-| `AIRMCP_HTTP_TOKEN` | — | Bearer token for HTTP mode authentication |
+| Variable                     | Default                      | Description                                                  |
+| ---------------------------- | ---------------------------- | ------------------------------------------------------------ |
+| `AIRMCP_INCLUDE_SHARED`      | `false`                      | Include shared notes/folders                                 |
+| `AIRMCP_ALLOW_SEND_MESSAGES` | `false`                      | Allow sending iMessages (opt-in)                             |
+| `AIRMCP_ALLOW_SEND_MAIL`     | `false`                      | Allow sending emails (opt-in)                                |
+| `AIRMCP_FULL`                | `false`                      | Enable all modules (ignores preset)                          |
+| `AIRMCP_DISABLE_{MODULE}`    | —                            | Disable a specific module (e.g. `AIRMCP_DISABLE_MUSIC=true`) |
+| `GEMINI_API_KEY`             | —                            | Google Gemini API key for cloud embeddings (optional)        |
+| `AIRMCP_EMBEDDING_MODEL`     | `gemini-embedding-2-preview` | Gemini embedding model name                                  |
+| `AIRMCP_EMBEDDING_DIM`       | `3072`                       | Embedding dimension (256/512/1024/2048/3072)                 |
+| `AIRMCP_EMBEDDING_PROVIDER`  | auto                         | Force provider: `gemini`, `swift`, `hybrid`, `none`          |
+| `AIRMCP_HTTP_TOKEN`          | —                            | Bearer token for HTTP mode authentication                    |
 
 ### Config File
 
@@ -849,6 +867,7 @@ npm run swift-build  # Build the Swift bridge first
 ```
 
 Then use the tools:
+
 1. `semantic_index` — Index data from enabled Apple apps into a local vector store
 2. `semantic_search` — Search by meaning across all indexed data
 3. `find_related` — Find items related to a specific note/event/reminder
@@ -890,47 +909,59 @@ Modules with OS requirements (e.g., Intelligence requires macOS 26+) are automat
 - Bluetooth connect/disconnect operates within the server process lifecycle.
 
 ### Notes
+
 - Move copies and deletes (new ID, reset dates, lost attachments). Update replaces entire body — read first to preserve content.
 - Password-protected notes cannot be read.
 
 ### Reminders / Calendar
+
 - JXA recurrence is read-only — use `create_recurring_event`/`create_recurring_reminder` (Swift/EventKit).
 - Calendar attendees are read-only.
 
 ### Contacts
+
 - Custom fields not accessible.
 
 ### Mail
+
 - Content truncated to 5000 chars by default (`maxLength` parameter adjustable).
 
 ### Messages
+
 - Individual message content (chat history) not accessible via JXA.
 - Send requires recipient to be a registered buddy in Messages.
 
 ### Music
+
 - Smart playlists are read-only.
 - Queue manipulation not available.
 
 ### Finder
+
 - Tags use Spotlight (mdfind), performance varies with index state.
 
 ### Safari
+
 - Reading page content requires "Allow JavaScript from Apple Events" in Safari Developer menu.
 - `run_javascript` rejects `javascript:` and `data:` URLs to prevent injection attacks.
 - **macOS 26+:** Bookmark and Reading List tools (`list_bookmarks`, `list_reading_list`, `add_bookmark`) use `Bookmarks.plist` instead of JXA (Apple removed bookmark scripting). Requires **Full Disk Access** for your terminal in System Settings > Privacy & Security. `add_bookmark` is not supported on macOS 26+.
 
 ### Podcasts
+
 - **macOS 26+:** All Podcasts tools are non-functional. Apple removed the Podcasts scripting dictionary in macOS 26 (Tahoe). The circuit breaker will auto-disable the module after 3 failures.
 
 ### Photos
+
 - JXA: album creation and photo addition only, no import/delete.
 - Swift bridge (macOS 26+): full import/delete via PhotoKit.
 
 ### Pages / Numbers / Keynote
+
 - **macOS 26+:** Apple renamed iWork apps (e.g. "Pages" → "Pages Creator Studio"). AirMCP uses bundle IDs internally so this is handled transparently.
 - Requires the corresponding iWork app to be open for document operations.
 
 ### Apple Intelligence
+
 - Requires macOS 26 (Tahoe) + Apple Silicon.
 - Build bridge binary with `npm run swift-build`.
 

--- a/docs/REGISTRY_SUBMISSIONS.md
+++ b/docs/REGISTRY_SUBMISSIONS.md
@@ -2,16 +2,25 @@
 
 Internal tracking doc for AirMCP's public-registry presence. Update the status column on every change; use the checklist to prepare a resubmission.
 
-## Status (as of 2026-04-20 — v2.10 prep)
+## Status (as of 2026-04-23 — v2.10 shipping + iOS roadmap in flight)
 
-| Registry | Status | Last action | Next step |
-|---|---|---|---|
-| **Anthropic MCP Registry** | Pending (submitted via Google Form, no response) | 2026-03-28 | Resubmit with v2.10 description (`server.json`) — registry schema now validates on the fly |
-| **Smithery.ai** | Listed (`airmcp`) | Manifest auto-tracked via `smithery.yaml` | Request featured placement once v2.10 lands on npm |
-| **Glama** | Listed (`AirMCP`) | `glama.json` present | Verify icon + category render on the live detail page |
-| **MCP Market (mcpmarket.com)** | Not submitted | — | Submit after v2.10 with the README's "Beyond Siri" card set as the screenshot pitch |
-| **Cline MCP Marketplace** | Not submitted | — | Low priority — distribution overlap with the above three |
-| **PulseMCP** | Auto-indexed (GitHub crawl) | Passive | No action needed; listing follows the README metadata |
+| Registry                       | Status                                           | Last action                               | Next step                                                                                                                           |
+| ------------------------------ | ------------------------------------------------ | ----------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
+| **Anthropic MCP Registry**     | Pending (submitted via Google Form, no response) | 2026-03-28                                | **Resubmit this week** with the v2.10 description below + cite `supermemoryai/apple-mcp` archival as the reference-slot opportunity |
+| **Smithery.ai**                | Listed (`airmcp`)                                | Manifest auto-tracked via `smithery.yaml` | Request featured placement — npm now has v2.10, the "only Apple-native production-grade MCP" angle is fresh                         |
+| **Glama**                      | Listed (`AirMCP`)                                | `glama.json` present                      | Verify icon + category render on the live detail page; ask for category "Apple / macOS" pin                                         |
+| **MCP Market (mcpmarket.com)** | Not submitted                                    | —                                         | **Submit this week** — see section below for the pitch                                                                              |
+| **Cline MCP Marketplace**      | Not submitted                                    | —                                         | Low priority — distribution overlap with the above three                                                                            |
+| **PulseMCP**                   | Auto-indexed (GitHub crawl)                      | Passive                                   | No action needed; listing follows the README metadata                                                                               |
+
+### 2026-04-23 research recap (use in every submission)
+
+- [Best MCP for Mac, 2026 survey](https://www.local-mcp.com/guides/best-mcp-server-mac): _"Outside the archived apple-mcp, no implementation exceeds 5 stars. Most have single-digit commits and single contributors."_
+- `supermemoryai/apple-mcp` archived 2026-01-01 with 3.1k stars, zero further updates.
+- Apple has **not** released an official iCloud MCP; Google, Dropbox, Microsoft have.
+- MCP ecosystem: 97M monthly SDK installs (Mar 2026), 10,000+ public servers; Gartner expects 75% of API gateway vendors to ship MCP support by end of 2026.
+
+These numbers belong in every submission blurb — they explain _why now_.
 
 ## Manifest files (keep in sync)
 
@@ -56,3 +65,27 @@ Ask after the npm publish lands. Pitch the following concrete wins over the base
 - Only Apple MCP with a documented **HTTP declarative security policy** (RFC 0002 in-tree)
 
 The manifest is auto-synced; they shouldn't need any new asset from our side.
+
+## MCP Market (mcpmarket.com) — first submission
+
+One-paragraph pitch for the submission form:
+
+> AirMCP is the only production-grade Apple-native MCP server still actively shipping after supermemoryai/apple-mcp was archived in January 2026. 269 tools across 29 modules (Notes, Calendar, Reminders, Contacts, Mail, Messages, Music, Finder, Safari, System, Photos, Shortcuts, Apple Intelligence, TV, Screen Capture, Maps, Podcasts, Weather, Pages/Numbers/Keynote, Location, Bluetooth, HealthKit, Context Memory, Audit) with a Skills DSL (parallel/loop/retry/event triggers), HITL approval, queryable audit log, rate limiting, and a declarative HTTP network policy (RFC 0002). Open source (MIT), v2.10 on npm. iOS sibling with 154 auto-generated AppIntents + Foundation Models on-device agent (RFC 0007) in active development.
+
+Screenshots to attach:
+
+- `docs/screenshots/beyond-siri-cards.png` (the landing page's five-card pitch)
+- Terminal with `npx airmcp doctor` showing module status
+
+## Axis tracker (iOS roadmap)
+
+Registry descriptions should cite the iOS work cumulatively as it lands. Update here when each of these merges so the next resubmission inherits the mention:
+
+- [x] RFC 0007 accepted + `AirMCPKit` shared Swift package — macOS/iOS
+- [x] Tool manifest codegen + 154 auto-generated Siri/Shortcuts/Spotlight AppIntents (PR #101–#105)
+- [x] `MCPIntentRouter` runtime on macOS (execFile) + iOS (in-process) — PR #103
+- [x] Codable drift guards (50 typed output structs) — PR #106
+- [x] `AskAirMCPIntent` on-device Foundation Models agent — PR #107
+- [x] App Store submission assets + Privacy Manifest — PR #108 (this sweep)
+- [ ] Interactive Snippets renderer (axis 4)
+- [ ] Destructive-tool HITL via `requestConfirmation` (A.3)


### PR DESCRIPTION
## Summary

Documentation-only PR that lands the written side of this session's market-value research. Pairs with the code PRs [#107](https://github.com/heznpc/AirMCP/pull/107) (AskAirMCPIntent) and [#108](https://github.com/heznpc/AirMCP/pull/108) (App Store assets).

## Research recap (2026-04-23)

- [supermemoryai/apple-mcp archived 2026-01-01](https://github.com/supermemoryai/apple-mcp) (3.1k stars, zero further updates)
- [Best MCP for Mac 2026](https://www.local-mcp.com/guides/best-mcp-server-mac): *"Outside the archived apple-mcp, no implementation exceeds 5 stars. Most have single-digit commits and single contributors."*
- Apple has not released an official iCloud MCP; Google/Dropbox/Microsoft have
- MCP ecosystem: 97M monthly SDK installs (Mar 2026), 10,000+ public servers
- Gartner: 75% of API gateway + 50% of iPaaS vendors expected to ship MCP by end of 2026

**AirMCP is currently the only production-grade Apple-native MCP server still shipping.** Time-limited window before Apple releases an official iCloud MCP or another large vendor fills the gap.

## Changes

### [README.md](README.md)
- "Why AirMCP?" table gains a fact-grounded lede citing the archive + Apple absence + the 2026 survey quote.
- Comparison rows expand: iOS Siri/Shortcuts/Spotlight (154 auto-generated AppIntents), on-device Foundation Models agent (AskAirMCPIntent), MCP 2025-06-18 spec + OAuth 2.1 / Resource Indicators.
- Every new row points at a merged PR or in-tree RFC — no claims the repo can't back.

### [docs/REGISTRY_SUBMISSIONS.md](docs/REGISTRY_SUBMISSIONS.md)
- Status table brought up to 2026-04-23. "Resubmit this week" flags on Anthropic Registry + MCP Market (both actionable now).
- New "research recap" section holds the quote + stats every submission blurb should reuse.
- New "MCP Market — first submission" section with the paragraph ready to paste into the form.
- New "Axis tracker" checklist ties each registry resubmission to PRs #101–#108 so descriptions stay current without a separate tracking spreadsheet.

## Test plan

- [x] `prettier --check` clean
- [x] `npm run stats:check` green (no tool counts touched)
- [ ] CI

## Follow-ups (not in this PR — human actions)

- Actually resubmit the Anthropic Registry Google Form with the v2.10 description.
- Actually submit to mcpmarket.com.
- Request Smithery featured placement.
- Verify Glama's live detail page renders the icon + category correctly.