### PR TITLE
feat(rfc-0007): axis 4.3 interactive snippet follow-up taps

### DIFF
--- a/scripts/gen-swift-intents.mjs
+++ b/scripts/gen-swift-intents.mjs
@@ -658,26 +658,45 @@ ${toolEntries.join("\n")}
 }`;
 }
 
-// ── outputSchema → Interactive Snippet SwiftUI view (A.4.1) ──────────
+// ── outputSchema → Interactive Snippet SwiftUI view (A.4.1 + A.4.3) ──
 //
 // RFC 0007 §3.7 renderer. Produces a small SwiftUI view per codable-safe
 // tool so Interactive Snippets (iOS 26+ / macOS 26+) can display the
 // tool's result inline in Shortcuts / Spotlight / Siri.
 //
-// A.4.1 scope: view struct only. Wiring the view into each AppIntent's
-// `perform()` result (the `.result(value:, view:)` overload) lands in
-// A.4.2 so this PR can't regress the iOS 17-compatible baseline.
-//
 // Shape detection
 //   list-object: outputSchema has exactly one `type: array` property
 //     whose items are `type: object`. Rendered as a ForEach over the
-//     array, each row showing the first string-typed field of the item.
+//     array. If the tool is in FOLLOW_UP_MAP (A.4.3), each row is wrapped
+//     in `Button(intent: ReadFooIntent(id: row.id))` so tapping a list
+//     entry dispatches the follow-up read intent without opening the app
+//     — the Interactive Snippet chain promised in RFC §3.7. Otherwise
+//     the row stays as a plain Text (A.4.1 baseline).
 //   list-string: same but items are `type: string`. Rendered ForEach
 //     with the raw string.
 //   scalar: everything else. Rendered as a VStack of key-value rows.
 //
 // All views gated on `canImport(SwiftUI) && canImport(AppIntents) &&
 // compiler(>=6.3)` + `@available(macOS 26, iOS 26, *)`.
+
+// A.4.3: list → read follow-up map. Tools in this map render each row
+// as `Button(intent: Read<Target>Intent(id: row.id))` so taps dispatch
+// the follow-up AppIntent in-place. Entries validated at load time
+// against the manifest (tool/target must exist; target's @Parameter
+// must be named exactly "id"; list items must carry a matching `id`
+// field). Extending the map is adding one line + re-running codegen.
+const FOLLOW_UP_MAP = {
+  list_events: { target: "read_event", idField: "id" },
+  today_events: { target: "read_event", idField: "id" },
+  get_upcoming_events: { target: "read_event", idField: "id" },
+  search_events: { target: "read_event", idField: "id" },
+  list_notes: { target: "read_note", idField: "id" },
+  search_notes: { target: "read_note", idField: "id" },
+  list_reminders: { target: "read_reminder", idField: "id" },
+  search_reminders: { target: "read_reminder", idField: "id" },
+  list_contacts: { target: "read_contact", idField: "id" },
+  search_contacts: { target: "read_contact", idField: "id" },
+};
 
 function detectSnippetShape(schema) {
   const props = schema.properties ?? {};
@@ -687,8 +706,15 @@ function detectSnippetShape(schema) {
     const arrayKey = arrayKeys[0];
     const items = props[arrayKey].items ?? {};
     if (items.type === "object") {
-      const firstString = Object.keys(items.properties ?? {}).find((k) => items.properties[k].type === "string");
-      return { shape: "list-object", arrayField: arrayKey, primaryField: firstString ?? null };
+      const itemProps = items.properties ?? {};
+      // Prefer a non-id string field for display so list rows show the
+      // human label (summary / name / title) rather than the raw UID.
+      // Fall back to `id` if nothing else is stringly typed — the row
+      // still renders, just less prettily.
+      const stringKeys = Object.keys(itemProps).filter((k) => itemProps[k].type === "string");
+      const primaryField = stringKeys.find((k) => k !== "id") ?? stringKeys[0] ?? null;
+      const hasId = itemProps.id?.type === "string";
+      return { shape: "list-object", arrayField: arrayKey, primaryField, hasId };
     }
     if (items.type === "string") {
       return { shape: "list-string", arrayField: arrayKey };
@@ -696,6 +722,44 @@ function detectSnippetShape(schema) {
   }
   return { shape: "scalar" };
 }
+
+// Validate FOLLOW_UP_MAP against the manifest so a typo or removed tool
+// surfaces at codegen time rather than as a SwiftUI compile error. Also
+// ensures the list's items carry the expected id field and the target's
+// @Parameter shape matches.
+function resolveFollowUpMap() {
+  const resolved = {};
+  for (const [listName, entry] of Object.entries(FOLLOW_UP_MAP)) {
+    const listTool = byName.get(listName);
+    const target = byName.get(entry.target);
+    if (!listTool) {
+      console.error(`[gen-intents] FOLLOW_UP_MAP: list tool missing: ${listName}`);
+      process.exit(2);
+    }
+    if (!target) {
+      console.error(`[gen-intents] FOLLOW_UP_MAP: target tool missing: ${entry.target}`);
+      process.exit(2);
+    }
+    const info = detectSnippetShape(listTool.outputSchema ?? {});
+    if (info.shape !== "list-object" || !info.hasId) {
+      console.error(
+        `[gen-intents] FOLLOW_UP_MAP: ${listName} has no list-object items with \`id\` field (shape=${info.shape}, hasId=${info.hasId})`,
+      );
+      process.exit(2);
+    }
+    const targetParams = Object.keys(target.inputSchema?.properties ?? {});
+    if (!targetParams.includes(entry.idField)) {
+      console.error(
+        `[gen-intents] FOLLOW_UP_MAP: target ${entry.target} has no @Parameter named "${entry.idField}" (params: ${targetParams.join(", ")})`,
+      );
+      process.exit(2);
+    }
+    resolved[listName] = { ...entry, targetIntentName: intentStructName(entry.target) };
+  }
+  return resolved;
+}
+const followUpMap = resolveFollowUpMap();
+const followUpTargets = Array.from(new Set(Object.values(followUpMap).map((e) => e.targetIntentName)));
 
 function snippetViewNameFor(tool) {
   return `MCP${toPascalCase(tool.name)}SnippetView`;
@@ -709,7 +773,25 @@ function renderSnippetView(tool) {
   let body;
   if (info.shape === "list-object") {
     const primaryAccess = info.primaryField ? `row.${swiftIdent(info.primaryField)}` : `"(row)"`;
-    body = `        VStack(alignment: .leading, spacing: 4) {
+    const followUp = followUpMap[tool.name];
+    // A.4.3: wrap the row in Button(intent:) when the tool has a list→read
+    // pairing AND the list items have an `id` field. Uses `id: \.id` for
+    // the ForEach key so SwiftUI diffs correctly across follow-up taps
+    // (the old `id: \.offset` was safe only for static-display rows).
+    if (followUp && info.hasId) {
+      body = `        VStack(alignment: .leading, spacing: 4) {
+            ForEach(data.${swiftIdent(info.arrayField)}, id: \\.id) { row in
+                Button(intent: _mk${followUp.targetIntentName}(id: row.id)) {
+                    Text(${primaryAccess})
+                        .font(.body)
+                        .lineLimit(1)
+                }
+                .buttonStyle(.plain)
+            }
+        }
+        .padding()`;
+    } else {
+      body = `        VStack(alignment: .leading, spacing: 4) {
             ForEach(Array(data.${swiftIdent(info.arrayField)}.enumerated()), id: \\.offset) { _, row in
                 Text(${primaryAccess})
                     .font(.body)
@@ -717,6 +799,7 @@ function renderSnippetView(tool) {
             }
         }
         .padding()`;
+    }
   } else if (info.shape === "list-string") {
     body = `        VStack(alignment: .leading, spacing: 4) {
             ForEach(Array(data.${swiftIdent(info.arrayField)}.enumerated()), id: \\.offset) { _, row in
@@ -759,6 +842,20 @@ const outputStructs = typedTools.map((tool) => {
 });
 const snippetViews = typedTools.map((tool) => renderSnippetView(tool));
 
+// A.4.3: one factory per unique follow-up target so the snippet view
+// can construct a parameterized intent instance (AppIntent requires a
+// no-arg init + property set — a plain `Read<Foo>Intent(id:)` call
+// site doesn't compile). File-private keeps the helpers out of the
+// public surface.
+const followUpFactories = followUpTargets.map(
+  (intentName) => `@available(macOS 26, iOS 26, *)
+fileprivate func _mk${intentName}(id: String) -> ${intentName} {
+    var intent = ${intentName}()
+    intent.id = id
+    return intent
+}`,
+);
+
 const header = `// GENERATED — do not edit.
 //
 // Source: docs/tool-manifest.json
@@ -793,7 +890,7 @@ const snippetsHeader = `
 
 #endif
 
-// MARK: - Interactive Snippet views (RFC 0007 §3.7, A.4.1)
+// MARK: - Interactive Snippet views (RFC 0007 §3.7, A.4.1 + A.4.3)
 
 #if canImport(SwiftUI) && canImport(AppIntents) && compiler(>=6.3)
 import SwiftUI
@@ -816,6 +913,7 @@ const source =
   shortcutsHeader +
   appShortcuts +
   snippetsHeader +
+  (followUpFactories.length > 0 ? followUpFactories.join("\n\n") + "\n\n" : "") +
   snippetViews.join("\n\n") +
   footer;
 

--- a/swift/Sources/AirMCPKit/Generated/MCPIntents.swift
+++ b/swift/Sources/AirMCPKit/Generated/MCPIntents.swift
@@ -8110,10 +8110,38 @@ public struct AirMCPGeneratedShortcuts: AppShortcutsProvider {
 
 #endif
 
-// MARK: - Interactive Snippet views (RFC 0007 §3.7, A.4.1)
+// MARK: - Interactive Snippet views (RFC 0007 §3.7, A.4.1 + A.4.3)
 
 #if canImport(SwiftUI) && canImport(AppIntents) && compiler(>=6.3)
 import SwiftUI
+
+@available(macOS 26, iOS 26, *)
+fileprivate func _mkReadEventIntent(id: String) -> ReadEventIntent {
+    var intent = ReadEventIntent()
+    intent.id = id
+    return intent
+}
+
+@available(macOS 26, iOS 26, *)
+fileprivate func _mkReadNoteIntent(id: String) -> ReadNoteIntent {
+    var intent = ReadNoteIntent()
+    intent.id = id
+    return intent
+}
+
+@available(macOS 26, iOS 26, *)
+fileprivate func _mkReadReminderIntent(id: String) -> ReadReminderIntent {
+    var intent = ReadReminderIntent()
+    intent.id = id
+    return intent
+}
+
+@available(macOS 26, iOS 26, *)
+fileprivate func _mkReadContactIntent(id: String) -> ReadContactIntent {
+    var intent = ReadContactIntent()
+    intent.id = id
+    return intent
+}
 
 // Snippet view for: ai_plan_metrics  (shape: list-object)
 @available(macOS 26, iOS 26, *)
@@ -8287,10 +8315,13 @@ public struct MCPGetUpcomingEventsSnippetView: View {
     public init(data: MCPGetUpcomingEventsOutput) { self.data = data }
     public var body: some View {
         VStack(alignment: .leading, spacing: 4) {
-            ForEach(Array(data.events.enumerated()), id: \.offset) { _, row in
-                Text(row.id)
-                    .font(.body)
-                    .lineLimit(1)
+            ForEach(data.events, id: \.id) { row in
+                Button(intent: _mkReadEventIntent(id: row.id)) {
+                    Text(row.summary)
+                        .font(.body)
+                        .lineLimit(1)
+                }
+                .buttonStyle(.plain)
             }
         }
         .padding()
@@ -8354,7 +8385,7 @@ public struct MCPListCalendarsSnippetView: View {
     public var body: some View {
         VStack(alignment: .leading, spacing: 4) {
             ForEach(Array(data.calendars.enumerated()), id: \.offset) { _, row in
-                Text(row.id)
+                Text(row.name)
                     .font(.body)
                     .lineLimit(1)
             }
@@ -8387,10 +8418,13 @@ public struct MCPListContactsSnippetView: View {
     public init(data: MCPListContactsOutput) { self.data = data }
     public var body: some View {
         VStack(alignment: .leading, spacing: 4) {
-            ForEach(Array(data.contacts.enumerated()), id: \.offset) { _, row in
-                Text(row.id)
-                    .font(.body)
-                    .lineLimit(1)
+            ForEach(data.contacts, id: \.id) { row in
+                Button(intent: _mkReadContactIntent(id: row.id)) {
+                    Text(row.name)
+                        .font(.body)
+                        .lineLimit(1)
+                }
+                .buttonStyle(.plain)
             }
         }
         .padding()
@@ -8421,10 +8455,13 @@ public struct MCPListEventsSnippetView: View {
     public init(data: MCPListEventsOutput) { self.data = data }
     public var body: some View {
         VStack(alignment: .leading, spacing: 4) {
-            ForEach(Array(data.events.enumerated()), id: \.offset) { _, row in
-                Text(row.id)
-                    .font(.body)
-                    .lineLimit(1)
+            ForEach(data.events, id: \.id) { row in
+                Button(intent: _mkReadEventIntent(id: row.id)) {
+                    Text(row.summary)
+                        .font(.body)
+                        .lineLimit(1)
+                }
+                .buttonStyle(.plain)
             }
         }
         .padding()
@@ -8439,7 +8476,7 @@ public struct MCPListFoldersSnippetView: View {
     public var body: some View {
         VStack(alignment: .leading, spacing: 4) {
             ForEach(Array(data.folders.enumerated()), id: \.offset) { _, row in
-                Text(row.id)
+                Text(row.name)
                     .font(.body)
                     .lineLimit(1)
             }
@@ -8456,7 +8493,7 @@ public struct MCPListGroupMembersSnippetView: View {
     public var body: some View {
         VStack(alignment: .leading, spacing: 4) {
             ForEach(Array(data.contacts.enumerated()), id: \.offset) { _, row in
-                Text(row.id)
+                Text(row.name)
                     .font(.body)
                     .lineLimit(1)
             }
@@ -8473,7 +8510,7 @@ public struct MCPListGroupsSnippetView: View {
     public var body: some View {
         VStack(alignment: .leading, spacing: 4) {
             ForEach(Array(data.groups.enumerated()), id: \.offset) { _, row in
-                Text(row.id)
+                Text(row.name)
                     .font(.body)
                     .lineLimit(1)
             }
@@ -8507,7 +8544,7 @@ public struct MCPListMessagesSnippetView: View {
     public var body: some View {
         VStack(alignment: .leading, spacing: 4) {
             ForEach(Array(data.messages.enumerated()), id: \.offset) { _, row in
-                Text(row.id)
+                Text(row.subject)
                     .font(.body)
                     .lineLimit(1)
             }
@@ -8523,10 +8560,13 @@ public struct MCPListNotesSnippetView: View {
     public init(data: MCPListNotesOutput) { self.data = data }
     public var body: some View {
         VStack(alignment: .leading, spacing: 4) {
-            ForEach(Array(data.notes.enumerated()), id: \.offset) { _, row in
-                Text(row.id)
-                    .font(.body)
-                    .lineLimit(1)
+            ForEach(data.notes, id: \.id) { row in
+                Button(intent: _mkReadNoteIntent(id: row.id)) {
+                    Text(row.name)
+                        .font(.body)
+                        .lineLimit(1)
+                }
+                .buttonStyle(.plain)
             }
         }
         .padding()
@@ -8558,7 +8598,7 @@ public struct MCPListPlaylistsSnippetView: View {
     public var body: some View {
         VStack(alignment: .leading, spacing: 4) {
             ForEach(Array(data.playlists.enumerated()), id: \.offset) { _, row in
-                Text(row.id)
+                Text(row.name)
                     .font(.body)
                     .lineLimit(1)
             }
@@ -8592,7 +8632,7 @@ public struct MCPListReminderListsSnippetView: View {
     public var body: some View {
         VStack(alignment: .leading, spacing: 4) {
             ForEach(Array(data.lists.enumerated()), id: \.offset) { _, row in
-                Text(row.id)
+                Text(row.name)
                     .font(.body)
                     .lineLimit(1)
             }
@@ -8608,10 +8648,13 @@ public struct MCPListRemindersSnippetView: View {
     public init(data: MCPListRemindersOutput) { self.data = data }
     public var body: some View {
         VStack(alignment: .leading, spacing: 4) {
-            ForEach(Array(data.reminders.enumerated()), id: \.offset) { _, row in
-                Text(row.id)
-                    .font(.body)
-                    .lineLimit(1)
+            ForEach(data.reminders, id: \.id) { row in
+                Button(intent: _mkReadReminderIntent(id: row.id)) {
+                    Text(row.name)
+                        .font(.body)
+                        .lineLimit(1)
+                }
+                .buttonStyle(.plain)
             }
         }
         .padding()
@@ -8660,7 +8703,7 @@ public struct MCPListTracksSnippetView: View {
     public var body: some View {
         VStack(alignment: .leading, spacing: 4) {
             ForEach(Array(data.tracks.enumerated()), id: \.offset) { _, row in
-                Text(row.id)
+                Text(row.name)
                     .font(.body)
                     .lineLimit(1)
             }
@@ -8707,7 +8750,7 @@ public struct MCPMemoryQuerySnippetView: View {
     public var body: some View {
         VStack(alignment: .leading, spacing: 4) {
             ForEach(Array(data.entries.enumerated()), id: \.offset) { _, row in
-                Text(row.id)
+                Text(row.kind)
                     .font(.body)
                     .lineLimit(1)
             }
@@ -8888,10 +8931,13 @@ public struct MCPSearchContactsSnippetView: View {
     public init(data: MCPSearchContactsOutput) { self.data = data }
     public var body: some View {
         VStack(alignment: .leading, spacing: 4) {
-            ForEach(Array(data.contacts.enumerated()), id: \.offset) { _, row in
-                Text(row.id)
-                    .font(.body)
-                    .lineLimit(1)
+            ForEach(data.contacts, id: \.id) { row in
+                Button(intent: _mkReadContactIntent(id: row.id)) {
+                    Text(row.name)
+                        .font(.body)
+                        .lineLimit(1)
+                }
+                .buttonStyle(.plain)
             }
         }
         .padding()
@@ -8905,10 +8951,13 @@ public struct MCPSearchEventsSnippetView: View {
     public init(data: MCPSearchEventsOutput) { self.data = data }
     public var body: some View {
         VStack(alignment: .leading, spacing: 4) {
-            ForEach(Array(data.events.enumerated()), id: \.offset) { _, row in
-                Text(row.id)
-                    .font(.body)
-                    .lineLimit(1)
+            ForEach(data.events, id: \.id) { row in
+                Button(intent: _mkReadEventIntent(id: row.id)) {
+                    Text(row.summary)
+                        .font(.body)
+                        .lineLimit(1)
+                }
+                .buttonStyle(.plain)
             }
         }
         .padding()
@@ -8922,10 +8971,13 @@ public struct MCPSearchNotesSnippetView: View {
     public init(data: MCPSearchNotesOutput) { self.data = data }
     public var body: some View {
         VStack(alignment: .leading, spacing: 4) {
-            ForEach(Array(data.notes.enumerated()), id: \.offset) { _, row in
-                Text(row.id)
-                    .font(.body)
-                    .lineLimit(1)
+            ForEach(data.notes, id: \.id) { row in
+                Button(intent: _mkReadNoteIntent(id: row.id)) {
+                    Text(row.name)
+                        .font(.body)
+                        .lineLimit(1)
+                }
+                .buttonStyle(.plain)
             }
         }
         .padding()
@@ -8939,10 +8991,13 @@ public struct MCPSearchRemindersSnippetView: View {
     public init(data: MCPSearchRemindersOutput) { self.data = data }
     public var body: some View {
         VStack(alignment: .leading, spacing: 4) {
-            ForEach(Array(data.reminders.enumerated()), id: \.offset) { _, row in
-                Text(row.id)
-                    .font(.body)
-                    .lineLimit(1)
+            ForEach(data.reminders, id: \.id) { row in
+                Button(intent: _mkReadReminderIntent(id: row.id)) {
+                    Text(row.name)
+                        .font(.body)
+                        .lineLimit(1)
+                }
+                .buttonStyle(.plain)
             }
         }
         .padding()
@@ -9018,10 +9073,13 @@ public struct MCPTodayEventsSnippetView: View {
     public init(data: MCPTodayEventsOutput) { self.data = data }
     public var body: some View {
         VStack(alignment: .leading, spacing: 4) {
-            ForEach(Array(data.events.enumerated()), id: \.offset) { _, row in
-                Text(row.id)
-                    .font(.body)
-                    .lineLimit(1)
+            ForEach(data.events, id: \.id) { row in
+                Button(intent: _mkReadEventIntent(id: row.id)) {
+                    Text(row.summary)
+                        .font(.body)
+                        .lineLimit(1)
+                }
+                .buttonStyle(.plain)
             }
         }
         .padding()


### PR DESCRIPTION
## Summary

Delivers the Interactive Snippet chain promised in [RFC 0007 §3.7](docs/rfc/0007-app-intent-bridge.md#37-interactive-snippets-renderer-confirmed-ios-26-api) — tapping a row in a list-view snippet dispatches a follow-up AppIntent (e.g. \`list_events\` → tap → \`read_event\`) so users can drill into a specific item inline in Shortcuts / Spotlight / Siri without returning to AirMCP.

Stacked on [#114](https://github.com/heznpc/AirMCP/pull/114) (axis 3 destructive HITL) — base flips to \`main\` once the chain lands.

## Scope

10 list → read pairs validated at codegen time:

| list tool | follow-up target |
|---|---|
| \`list_events\`, \`today_events\`, \`get_upcoming_events\`, \`search_events\` | \`read_event\` |
| \`list_notes\`, \`search_notes\` | \`read_note\` |
| \`list_reminders\`, \`search_reminders\` | \`read_reminder\` |
| \`list_contacts\`, \`search_contacts\` | \`read_contact\` |

Extending the map is a one-line change in [FOLLOW_UP_MAP](scripts/gen-swift-intents.mjs). The \`resolveFollowUpMap\` validator hard-exits codegen if:
- list tool or target tool is missing from the manifest
- list items have no \`id: string\` field (Button dispatch needs an id)
- target tool has no \`@Parameter\` matching the configured \`idField\`

## Generated Swift

Row wrapping switches from plain Text to \`Button(intent: _mkRead…Intent(id:))\`:

\`\`\`swift
// Snippet view for: list_events  (shape: list-object)
@available(macOS 26, iOS 26, *)
public struct MCPListEventsSnippetView: View {
    public let data: MCPListEventsOutput
    public var body: some View {
        VStack(alignment: .leading, spacing: 4) {
            ForEach(data.events, id: \.id) { row in
                Button(intent: _mkReadEventIntent(id: row.id)) {
                    Text(row.summary)
                        .font(.body)
                        .lineLimit(1)
                }
                .buttonStyle(.plain)
            }
        }
        .padding()
    }
}
\`\`\`

## Design choices

- **File-private factory per target** (\`_mkReadEventIntent(id:)\`) — AppIntent requires a no-arg init + property set, so a direct \`ReadEventIntent(id:)\` call site doesn't compile. Keeping the helpers file-private keeps them out of the public API surface.
- **\`ForEach(id: \\.id)\` replaces \`id: \\.offset\`** — the old offset-based key was fine for static display but breaks SwiftUI diffing when a follow-up tap re-enters the snippet with a reordered/updated list.
- **\`primaryField\` now skips \`id\`** — rows previously rendered the raw UID for lists where \`id\` came first in the schema. Now we prefer the first non-\`id\` string (summary / name / title); fall back to \`id\` only when nothing else is available.
- **Non-mapped list-object snippets stay on the A.4.1 baseline** (display-only Text, \`id: \\.offset\`). Adding Button(intent:) indiscriminately would require every list tool to have a matching read target, which isn't true today.

## Test plan

- [x] \`npm run gen:intents\` — 277 intents, 10 follow-up wrapped snippets
- [x] \`swift build\` passes (7.8s)
- [x] Verified: \`list_events\` snippet renders \`Text(row.summary)\` (not \`row.id\`), \`Button(intent: _mkReadEventIntent(id: row.id))\`
- [x] Validator probe: added a bogus \`FOLLOW_UP_MAP\` entry locally, confirmed codegen exits 2 with a specific error before writing output
- [ ] CI drift + iOS/swift builds
- [ ] Manual iOS 26: tap a list row in Shortcuts snippet → read intent fires (follow-up after device pipeline)