### PR TITLE
chore(rfc-0007): manifest ineligibility diagnostics

### DIFF
--- a/docs/tool-manifest.json
+++ b/docs/tool-manifest.json
@@ -3,6 +3,13 @@
   "protocolVersion": "2025-06-18",
   "toolCount": 282,
   "eligibleCount": 277,
+  "ineligibleCount": 5,
+  "ineligibleByReason": {
+    "object-param:recurrence": 2,
+    "object-param:schema": 1,
+    "object-param:args": 1,
+    "object-param:params": 1
+  },
   "tools": [
     {
       "name": "activate_tab",
@@ -36,7 +43,8 @@
         "idempotentHint": true,
         "openWorldHint": false
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "add_contact_email",
@@ -76,7 +84,8 @@
         "idempotentHint": false,
         "openWorldHint": false
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "add_contact_phone",
@@ -117,7 +126,8 @@
         "idempotentHint": false,
         "openWorldHint": false
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "add_to_album",
@@ -156,7 +166,8 @@
         "idempotentHint": false,
         "openWorldHint": false
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "add_to_playlist",
@@ -190,7 +201,8 @@
         "idempotentHint": false,
         "openWorldHint": false
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "add_to_reading_list",
@@ -223,7 +235,8 @@
         "idempotentHint": false,
         "openWorldHint": false
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "ai_agent",
@@ -257,7 +270,8 @@
         "idempotentHint": false,
         "openWorldHint": false
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "ai_chat",
@@ -296,7 +310,8 @@
         "idempotentHint": false,
         "openWorldHint": false
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "ai_plan_metrics",
@@ -400,7 +415,8 @@
         "idempotentHint": false,
         "openWorldHint": false
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "ai_status",
@@ -418,7 +434,8 @@
         "idempotentHint": true,
         "openWorldHint": false
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "audit_log",
@@ -518,7 +535,8 @@
         "idempotentHint": true,
         "openWorldHint": false
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "audit_summary",
@@ -602,7 +620,8 @@
         "idempotentHint": true,
         "openWorldHint": false
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "bulk_move_notes",
@@ -641,7 +660,8 @@
         "idempotentHint": false,
         "openWorldHint": false
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "calendar_week_view",
@@ -666,7 +686,8 @@
         "idempotentHint": true,
         "openWorldHint": false
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "capture_area",
@@ -710,7 +731,8 @@
         "idempotentHint": true,
         "openWorldHint": true
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "capture_screen",
@@ -735,7 +757,8 @@
         "idempotentHint": true,
         "openWorldHint": true
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "capture_screenshot",
@@ -774,7 +797,8 @@
         "idempotentHint": false,
         "openWorldHint": false
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "capture_window",
@@ -799,7 +823,8 @@
         "idempotentHint": true,
         "openWorldHint": true
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "classify_image",
@@ -835,7 +860,8 @@
         "idempotentHint": true,
         "openWorldHint": false
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "close_tab",
@@ -869,7 +895,8 @@
         "idempotentHint": true,
         "openWorldHint": false
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "cloud_sync_status",
@@ -887,7 +914,8 @@
         "idempotentHint": true,
         "openWorldHint": false
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "compare_notes",
@@ -919,7 +947,8 @@
         "idempotentHint": true,
         "openWorldHint": false
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "complete_reminder",
@@ -952,7 +981,8 @@
         "idempotentHint": true,
         "openWorldHint": false
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "connect_bluetooth",
@@ -980,7 +1010,8 @@
         "idempotentHint": true,
         "openWorldHint": false
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "create_album",
@@ -1008,7 +1039,8 @@
         "idempotentHint": false,
         "openWorldHint": false
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "create_contact",
@@ -1067,7 +1099,8 @@
         "idempotentHint": false,
         "openWorldHint": false
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "create_directory",
@@ -1096,7 +1129,8 @@
         "idempotentHint": true,
         "openWorldHint": false
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "create_event",
@@ -1156,7 +1190,8 @@
         "idempotentHint": false,
         "openWorldHint": false
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "create_folder",
@@ -1189,7 +1224,8 @@
         "idempotentHint": true,
         "openWorldHint": false
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "create_note",
@@ -1222,7 +1258,8 @@
         "idempotentHint": false,
         "openWorldHint": false
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "create_playlist",
@@ -1250,7 +1287,8 @@
         "idempotentHint": false,
         "openWorldHint": false
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "create_recurring_event",
@@ -1352,7 +1390,8 @@
         "idempotentHint": false,
         "openWorldHint": false
       },
-      "appIntentEligible": false
+      "appIntentEligible": false,
+      "ineligibleReason": "object-param:recurrence"
     },
     {
       "name": "create_recurring_reminder",
@@ -1447,7 +1486,8 @@
         "idempotentHint": false,
         "openWorldHint": false
       },
-      "appIntentEligible": false
+      "appIntentEligible": false,
+      "ineligibleReason": "object-param:recurrence"
     },
     {
       "name": "create_reminder",
@@ -1496,7 +1536,8 @@
         "idempotentHint": false,
         "openWorldHint": false
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "create_reminder_list",
@@ -1524,7 +1565,8 @@
         "idempotentHint": false,
         "openWorldHint": false
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "create_shortcut",
@@ -1552,7 +1594,8 @@
         "idempotentHint": false,
         "openWorldHint": true
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "delete_contact",
@@ -1580,7 +1623,8 @@
         "idempotentHint": true,
         "openWorldHint": false
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "delete_event",
@@ -1608,7 +1652,8 @@
         "idempotentHint": true,
         "openWorldHint": false
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "delete_note",
@@ -1636,7 +1681,8 @@
         "idempotentHint": true,
         "openWorldHint": false
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "delete_photos",
@@ -1666,7 +1712,8 @@
         "idempotentHint": false,
         "openWorldHint": false
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "delete_playlist",
@@ -1694,7 +1741,8 @@
         "idempotentHint": false,
         "openWorldHint": false
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "delete_reminder",
@@ -1722,7 +1770,8 @@
         "idempotentHint": true,
         "openWorldHint": false
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "delete_reminder_list",
@@ -1750,7 +1799,8 @@
         "idempotentHint": true,
         "openWorldHint": false
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "delete_shortcut",
@@ -1778,7 +1828,8 @@
         "idempotentHint": false,
         "openWorldHint": false
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "disconnect_bluetooth",
@@ -1806,7 +1857,8 @@
         "idempotentHint": true,
         "openWorldHint": false
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "discover_tools",
@@ -1884,7 +1936,8 @@
         "idempotentHint": true,
         "openWorldHint": false
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "drop_pin",
@@ -1921,7 +1974,8 @@
         "idempotentHint": true,
         "openWorldHint": false
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "duplicate_shortcut",
@@ -1955,7 +2009,8 @@
         "idempotentHint": false,
         "openWorldHint": false
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "edit_shortcut",
@@ -1983,7 +2038,8 @@
         "idempotentHint": false,
         "openWorldHint": true
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "event_status",
@@ -2001,7 +2057,8 @@
         "idempotentHint": true,
         "openWorldHint": false
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "event_subscribe",
@@ -2019,7 +2076,8 @@
         "idempotentHint": false,
         "openWorldHint": false
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "export_shortcut",
@@ -2054,7 +2112,8 @@
         "idempotentHint": true,
         "openWorldHint": false
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "find_related",
@@ -2094,7 +2153,8 @@
         "idempotentHint": true,
         "openWorldHint": false
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "flag_message",
@@ -2128,7 +2188,8 @@
         "idempotentHint": true,
         "openWorldHint": false
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "generate_image",
@@ -2163,7 +2224,8 @@
         "idempotentHint": false,
         "openWorldHint": false
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "generate_plan",
@@ -2203,7 +2265,8 @@
         "idempotentHint": false,
         "openWorldHint": false
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "generate_structured",
@@ -2259,7 +2322,8 @@
         "idempotentHint": false,
         "openWorldHint": false
       },
-      "appIntentEligible": false
+      "appIntentEligible": false,
+      "ineligibleReason": "object-param:schema"
     },
     {
       "name": "generate_text",
@@ -2298,7 +2362,8 @@
         "idempotentHint": false,
         "openWorldHint": false
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "geocode",
@@ -2327,7 +2392,8 @@
         "idempotentHint": true,
         "openWorldHint": true
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "get_battery_status",
@@ -2345,7 +2411,8 @@
         "idempotentHint": true,
         "openWorldHint": false
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "get_bluetooth_state",
@@ -2363,7 +2430,8 @@
         "idempotentHint": true,
         "openWorldHint": false
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "get_brightness",
@@ -2381,7 +2449,8 @@
         "idempotentHint": true,
         "openWorldHint": false
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "get_clipboard",
@@ -2419,7 +2488,8 @@
         "idempotentHint": true,
         "openWorldHint": false
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "get_current_location",
@@ -2437,7 +2507,8 @@
         "idempotentHint": false,
         "openWorldHint": false
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "get_current_tab",
@@ -2471,7 +2542,8 @@
         "idempotentHint": true,
         "openWorldHint": false
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "get_current_weather",
@@ -2583,7 +2655,8 @@
         "idempotentHint": true,
         "openWorldHint": true
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "get_daily_forecast",
@@ -2626,7 +2699,8 @@
         "idempotentHint": true,
         "openWorldHint": true
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "get_directions",
@@ -2670,7 +2744,8 @@
         "idempotentHint": true,
         "openWorldHint": true
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "get_file_info",
@@ -2738,7 +2813,8 @@
         "idempotentHint": true,
         "openWorldHint": false
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "get_frontmost_app",
@@ -2776,7 +2852,8 @@
         "idempotentHint": true,
         "openWorldHint": false
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "get_hourly_forecast",
@@ -2819,7 +2896,8 @@
         "idempotentHint": true,
         "openWorldHint": true
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "get_location_permission",
@@ -2837,7 +2915,8 @@
         "idempotentHint": true,
         "openWorldHint": false
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "get_photo_info",
@@ -2865,7 +2944,8 @@
         "idempotentHint": true,
         "openWorldHint": false
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "get_rating",
@@ -2893,7 +2973,8 @@
         "idempotentHint": true,
         "openWorldHint": false
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "get_screen_info",
@@ -2911,7 +2992,8 @@
         "idempotentHint": true,
         "openWorldHint": false
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "get_shortcut_detail",
@@ -2955,7 +3037,8 @@
         "idempotentHint": true,
         "openWorldHint": false
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "get_track_info",
@@ -2983,7 +3066,8 @@
         "idempotentHint": true,
         "openWorldHint": false
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "get_unread_count",
@@ -3037,7 +3121,8 @@
         "idempotentHint": true,
         "openWorldHint": false
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "get_upcoming_events",
@@ -3120,7 +3205,8 @@
         "idempotentHint": true,
         "openWorldHint": false
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "get_volume",
@@ -3158,7 +3244,8 @@
         "idempotentHint": true,
         "openWorldHint": false
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "get_wifi_status",
@@ -3176,7 +3263,8 @@
         "idempotentHint": true,
         "openWorldHint": false
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "get_workflow",
@@ -3212,7 +3300,8 @@
         "idempotentHint": true,
         "openWorldHint": false
       },
-      "appIntentEligible": false
+      "appIntentEligible": false,
+      "ineligibleReason": "object-param:args"
     },
     {
       "name": "gws_calendar_create",
@@ -3265,7 +3354,8 @@
         "idempotentHint": false,
         "openWorldHint": true
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "gws_calendar_list",
@@ -3306,7 +3396,8 @@
         "idempotentHint": true,
         "openWorldHint": true
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "gws_docs_read",
@@ -3335,7 +3426,8 @@
         "idempotentHint": true,
         "openWorldHint": true
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "gws_drive_list",
@@ -3371,7 +3463,8 @@
         "idempotentHint": true,
         "openWorldHint": true
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "gws_drive_read",
@@ -3400,7 +3493,8 @@
         "idempotentHint": true,
         "openWorldHint": true
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "gws_drive_search",
@@ -3435,7 +3529,8 @@
         "idempotentHint": true,
         "openWorldHint": true
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "gws_gmail_list",
@@ -3467,7 +3562,8 @@
         "idempotentHint": true,
         "openWorldHint": true
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "gws_gmail_read",
@@ -3506,7 +3602,8 @@
         "idempotentHint": true,
         "openWorldHint": true
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "gws_gmail_send",
@@ -3552,7 +3649,8 @@
         "idempotentHint": false,
         "openWorldHint": true
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "gws_people_search",
@@ -3587,7 +3685,8 @@
         "idempotentHint": true,
         "openWorldHint": true
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "gws_raw",
@@ -3640,7 +3739,8 @@
         "idempotentHint": false,
         "openWorldHint": true
       },
-      "appIntentEligible": false
+      "appIntentEligible": false,
+      "ineligibleReason": "object-param:params"
     },
     {
       "name": "gws_sheets_read",
@@ -3675,7 +3775,8 @@
         "idempotentHint": true,
         "openWorldHint": true
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "gws_sheets_write",
@@ -3723,7 +3824,8 @@
         "idempotentHint": false,
         "openWorldHint": true
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "gws_status",
@@ -3741,7 +3843,8 @@
         "idempotentHint": true,
         "openWorldHint": false
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "gws_tasks_create",
@@ -3780,7 +3883,8 @@
         "idempotentHint": false,
         "openWorldHint": true
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "gws_tasks_list",
@@ -3811,7 +3915,8 @@
         "idempotentHint": true,
         "openWorldHint": true
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "import_photo",
@@ -3845,7 +3950,8 @@
         "idempotentHint": false,
         "openWorldHint": false
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "import_shortcut",
@@ -3874,7 +3980,8 @@
         "idempotentHint": false,
         "openWorldHint": false
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "is_app_running",
@@ -3903,7 +4010,8 @@
         "idempotentHint": true,
         "openWorldHint": false
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "keynote_add_slide",
@@ -3931,7 +4039,8 @@
         "idempotentHint": false,
         "openWorldHint": false
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "keynote_close_document",
@@ -3964,7 +4073,8 @@
         "idempotentHint": false,
         "openWorldHint": false
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "keynote_create_document",
@@ -3982,7 +4092,8 @@
         "idempotentHint": false,
         "openWorldHint": false
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "keynote_export_pdf",
@@ -4017,7 +4128,8 @@
         "idempotentHint": false,
         "openWorldHint": true
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "keynote_get_slide",
@@ -4051,7 +4163,8 @@
         "idempotentHint": true,
         "openWorldHint": false
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "keynote_list_documents",
@@ -4069,7 +4182,8 @@
         "idempotentHint": true,
         "openWorldHint": false
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "keynote_list_slides",
@@ -4097,7 +4211,8 @@
         "idempotentHint": true,
         "openWorldHint": false
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "keynote_set_presenter_notes",
@@ -4137,7 +4252,8 @@
         "idempotentHint": true,
         "openWorldHint": false
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "keynote_start_slideshow",
@@ -4171,7 +4287,8 @@
         "idempotentHint": false,
         "openWorldHint": false
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "launch_app",
@@ -4200,7 +4317,8 @@
         "idempotentHint": true,
         "openWorldHint": true
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "list_accounts",
@@ -4256,7 +4374,8 @@
         "idempotentHint": true,
         "openWorldHint": false
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "list_albums",
@@ -4274,7 +4393,8 @@
         "idempotentHint": true,
         "openWorldHint": false
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "list_all_windows",
@@ -4292,7 +4412,8 @@
         "idempotentHint": true,
         "openWorldHint": false
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "list_bluetooth_devices",
@@ -4310,7 +4431,8 @@
         "idempotentHint": true,
         "openWorldHint": false
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "list_bookmarks",
@@ -4364,7 +4486,8 @@
         "idempotentHint": true,
         "openWorldHint": false
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "list_calendars",
@@ -4421,7 +4544,8 @@
         "idempotentHint": true,
         "openWorldHint": false
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "list_chats",
@@ -4520,7 +4644,8 @@
         "idempotentHint": true,
         "openWorldHint": false
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "list_contacts",
@@ -4607,7 +4732,8 @@
         "idempotentHint": true,
         "openWorldHint": false
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "list_directory",
@@ -4685,7 +4811,8 @@
         "idempotentHint": true,
         "openWorldHint": false
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "list_events",
@@ -4793,7 +4920,8 @@
         "idempotentHint": true,
         "openWorldHint": false
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "list_favorites",
@@ -4820,7 +4948,8 @@
         "idempotentHint": true,
         "openWorldHint": false
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "list_folders",
@@ -4878,7 +5007,8 @@
         "idempotentHint": true,
         "openWorldHint": false
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "list_group_members",
@@ -4967,7 +5097,8 @@
         "idempotentHint": true,
         "openWorldHint": false
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "list_groups",
@@ -5013,7 +5144,8 @@
         "idempotentHint": true,
         "openWorldHint": false
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "list_mailboxes",
@@ -5063,7 +5195,8 @@
         "idempotentHint": true,
         "openWorldHint": false
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "list_messages",
@@ -5168,7 +5301,8 @@
         "idempotentHint": true,
         "openWorldHint": false
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "list_notes",
@@ -5262,7 +5396,8 @@
         "idempotentHint": true,
         "openWorldHint": false
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "list_participants",
@@ -5335,7 +5470,8 @@
         "idempotentHint": true,
         "openWorldHint": false
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "list_photos",
@@ -5376,7 +5512,8 @@
         "idempotentHint": true,
         "openWorldHint": false
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "list_playlists",
@@ -5430,7 +5567,8 @@
         "idempotentHint": true,
         "openWorldHint": false
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "list_podcast_episodes",
@@ -5465,7 +5603,8 @@
         "idempotentHint": true,
         "openWorldHint": false
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "list_podcast_shows",
@@ -5483,7 +5622,8 @@
         "idempotentHint": true,
         "openWorldHint": false
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "list_reading_list",
@@ -5533,7 +5673,8 @@
         "idempotentHint": true,
         "openWorldHint": false
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "list_reminder_lists",
@@ -5583,7 +5724,8 @@
         "idempotentHint": true,
         "openWorldHint": false
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "list_reminders",
@@ -5688,7 +5830,8 @@
         "idempotentHint": true,
         "openWorldHint": false
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "list_running_apps",
@@ -5706,7 +5849,8 @@
         "idempotentHint": true,
         "openWorldHint": false
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "list_shortcuts",
@@ -5743,7 +5887,8 @@
         "idempotentHint": true,
         "openWorldHint": false
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "list_tabs",
@@ -5797,7 +5942,8 @@
         "idempotentHint": true,
         "openWorldHint": false
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "list_tracks",
@@ -5910,7 +6056,8 @@
         "idempotentHint": true,
         "openWorldHint": false
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "list_triggers",
@@ -5928,7 +6075,8 @@
         "idempotentHint": true,
         "openWorldHint": false
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "list_windows",
@@ -5946,7 +6094,8 @@
         "idempotentHint": true,
         "openWorldHint": true
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "local_llm_generate",
@@ -5985,7 +6134,8 @@
         "idempotentHint": false,
         "openWorldHint": true
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "local_llm_status",
@@ -6003,7 +6153,8 @@
         "idempotentHint": true,
         "openWorldHint": true
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "mark_message_read",
@@ -6037,7 +6188,8 @@
         "idempotentHint": true,
         "openWorldHint": false
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "memory_forget",
@@ -6097,7 +6249,8 @@
         "idempotentHint": true,
         "openWorldHint": false
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "memory_put",
@@ -6219,7 +6372,8 @@
         "idempotentHint": true,
         "openWorldHint": false
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "memory_query",
@@ -6339,7 +6493,8 @@
         "idempotentHint": true,
         "openWorldHint": false
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "memory_stats",
@@ -6404,7 +6559,8 @@
         "idempotentHint": true,
         "openWorldHint": false
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "minimize_window",
@@ -6443,7 +6599,8 @@
         "idempotentHint": true,
         "openWorldHint": false
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "move_file",
@@ -6477,7 +6634,8 @@
         "idempotentHint": false,
         "openWorldHint": false
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "move_message",
@@ -6517,7 +6675,8 @@
         "idempotentHint": false,
         "openWorldHint": false
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "move_note",
@@ -6551,7 +6710,8 @@
         "idempotentHint": false,
         "openWorldHint": false
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "move_window",
@@ -6595,7 +6755,8 @@
         "idempotentHint": true,
         "openWorldHint": false
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "music_player",
@@ -6613,7 +6774,8 @@
         "idempotentHint": true,
         "openWorldHint": false
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "now_playing",
@@ -6679,7 +6841,8 @@
         "idempotentHint": true,
         "openWorldHint": false
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "numbers_add_sheet",
@@ -6713,7 +6876,8 @@
         "idempotentHint": false,
         "openWorldHint": false
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "numbers_close_document",
@@ -6746,7 +6910,8 @@
         "idempotentHint": false,
         "openWorldHint": false
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "numbers_create_document",
@@ -6764,7 +6929,8 @@
         "idempotentHint": false,
         "openWorldHint": false
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "numbers_export_pdf",
@@ -6799,7 +6965,8 @@
         "idempotentHint": false,
         "openWorldHint": true
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "numbers_get_cell",
@@ -6839,7 +7006,8 @@
         "idempotentHint": true,
         "openWorldHint": false
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "numbers_list_documents",
@@ -6857,7 +7025,8 @@
         "idempotentHint": true,
         "openWorldHint": false
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "numbers_list_sheets",
@@ -6885,7 +7054,8 @@
         "idempotentHint": true,
         "openWorldHint": false
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "numbers_read_cells",
@@ -6943,7 +7113,8 @@
         "idempotentHint": true,
         "openWorldHint": false
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "numbers_set_cell",
@@ -6989,7 +7160,8 @@
         "idempotentHint": true,
         "openWorldHint": false
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "open_address",
@@ -7017,7 +7189,8 @@
         "idempotentHint": true,
         "openWorldHint": true
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "open_url",
@@ -7045,7 +7218,8 @@
         "idempotentHint": true,
         "openWorldHint": true
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "pages_close_document",
@@ -7078,7 +7252,8 @@
         "idempotentHint": false,
         "openWorldHint": false
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "pages_create_document",
@@ -7096,7 +7271,8 @@
         "idempotentHint": false,
         "openWorldHint": false
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "pages_export_pdf",
@@ -7131,7 +7307,8 @@
         "idempotentHint": false,
         "openWorldHint": true
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "pages_get_body_text",
@@ -7159,7 +7336,8 @@
         "idempotentHint": true,
         "openWorldHint": false
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "pages_list_documents",
@@ -7177,7 +7355,8 @@
         "idempotentHint": true,
         "openWorldHint": false
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "pages_open_document",
@@ -7206,7 +7385,8 @@
         "idempotentHint": false,
         "openWorldHint": false
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "pages_set_body_text",
@@ -7240,7 +7420,8 @@
         "idempotentHint": true,
         "openWorldHint": false
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "play_playlist",
@@ -7272,7 +7453,8 @@
         "idempotentHint": false,
         "openWorldHint": false
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "play_podcast_episode",
@@ -7305,7 +7487,8 @@
         "idempotentHint": false,
         "openWorldHint": false
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "play_track",
@@ -7338,7 +7521,8 @@
         "idempotentHint": false,
         "openWorldHint": false
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "playback_control",
@@ -7371,7 +7555,8 @@
         "idempotentHint": false,
         "openWorldHint": false
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "podcast_now_playing",
@@ -7389,7 +7574,8 @@
         "idempotentHint": true,
         "openWorldHint": false
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "podcast_playback_control",
@@ -7422,7 +7608,8 @@
         "idempotentHint": false,
         "openWorldHint": false
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "prevent_sleep",
@@ -7449,7 +7636,8 @@
         "idempotentHint": false,
         "openWorldHint": false
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "proactive_context",
@@ -7529,7 +7717,8 @@
         "idempotentHint": true,
         "openWorldHint": false
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "proofread_text",
@@ -7557,7 +7746,8 @@
         "idempotentHint": false,
         "openWorldHint": false
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "query_photos",
@@ -7607,7 +7797,8 @@
         "idempotentHint": true,
         "openWorldHint": false
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "quit_app",
@@ -7636,7 +7827,8 @@
         "idempotentHint": true,
         "openWorldHint": false
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "read_chat",
@@ -7716,7 +7908,8 @@
         "idempotentHint": true,
         "openWorldHint": false
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "read_contact",
@@ -7872,7 +8065,8 @@
         "idempotentHint": true,
         "openWorldHint": false
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "read_event",
@@ -7993,7 +8187,8 @@
         "idempotentHint": true,
         "openWorldHint": false
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "read_message",
@@ -8029,7 +8224,8 @@
         "idempotentHint": true,
         "openWorldHint": false
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "read_note",
@@ -8101,7 +8297,8 @@
         "idempotentHint": true,
         "openWorldHint": false
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "read_page_content",
@@ -8140,7 +8337,8 @@
         "idempotentHint": true,
         "openWorldHint": false
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "read_reminder",
@@ -8226,7 +8424,8 @@
         "idempotentHint": true,
         "openWorldHint": false
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "recent_files",
@@ -8267,7 +8466,8 @@
         "idempotentHint": true,
         "openWorldHint": false
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "record_screen",
@@ -8301,7 +8501,8 @@
         "idempotentHint": false,
         "openWorldHint": true
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "remove_from_playlist",
@@ -8335,7 +8536,8 @@
         "idempotentHint": false,
         "openWorldHint": false
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "reply_mail",
@@ -8375,7 +8577,8 @@
         "idempotentHint": false,
         "openWorldHint": true
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "resize_window",
@@ -8421,7 +8624,8 @@
         "idempotentHint": true,
         "openWorldHint": false
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "reverse_geocode",
@@ -8457,7 +8661,8 @@
         "idempotentHint": true,
         "openWorldHint": true
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "rewrite_text",
@@ -8495,7 +8700,8 @@
         "idempotentHint": false,
         "openWorldHint": false
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "run_javascript",
@@ -8535,7 +8741,8 @@
         "idempotentHint": false,
         "openWorldHint": true
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "run_shortcut",
@@ -8568,7 +8775,8 @@
         "idempotentHint": false,
         "openWorldHint": true
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "scan_bluetooth",
@@ -8595,7 +8803,8 @@
         "idempotentHint": false,
         "openWorldHint": false
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "scan_document",
@@ -8624,7 +8833,8 @@
         "idempotentHint": true,
         "openWorldHint": false
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "scan_notes",
@@ -8669,7 +8879,8 @@
         "idempotentHint": true,
         "openWorldHint": false
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "search_chats",
@@ -8776,7 +8987,8 @@
         "idempotentHint": true,
         "openWorldHint": false
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "search_contacts",
@@ -8872,7 +9084,8 @@
         "idempotentHint": true,
         "openWorldHint": false
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "search_events",
@@ -8967,7 +9180,8 @@
         "idempotentHint": true,
         "openWorldHint": false
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "search_files",
@@ -9009,7 +9223,8 @@
         "idempotentHint": true,
         "openWorldHint": false
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "search_location",
@@ -9037,7 +9252,8 @@
         "idempotentHint": true,
         "openWorldHint": true
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "search_messages",
@@ -9078,7 +9294,8 @@
         "idempotentHint": true,
         "openWorldHint": false
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "search_nearby",
@@ -9114,7 +9331,8 @@
         "idempotentHint": true,
         "openWorldHint": true
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "search_notes",
@@ -9212,7 +9430,8 @@
         "idempotentHint": true,
         "openWorldHint": false
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "search_photos",
@@ -9247,7 +9466,8 @@
         "idempotentHint": true,
         "openWorldHint": false
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "search_podcast_episodes",
@@ -9282,7 +9502,8 @@
         "idempotentHint": true,
         "openWorldHint": false
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "search_reminders",
@@ -9372,7 +9593,8 @@
         "idempotentHint": true,
         "openWorldHint": false
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "search_shortcuts",
@@ -9419,7 +9641,8 @@
         "idempotentHint": true,
         "openWorldHint": false
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "search_tabs",
@@ -9447,7 +9670,8 @@
         "idempotentHint": true,
         "openWorldHint": false
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "search_tracks",
@@ -9482,7 +9706,8 @@
         "idempotentHint": true,
         "openWorldHint": false
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "semantic_clear",
@@ -9500,7 +9725,8 @@
         "idempotentHint": true,
         "openWorldHint": false
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "semantic_index",
@@ -9535,7 +9761,8 @@
         "idempotentHint": true,
         "openWorldHint": false
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "semantic_search",
@@ -9588,7 +9815,8 @@
         "idempotentHint": true,
         "openWorldHint": false
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "semantic_status",
@@ -9606,7 +9834,8 @@
         "idempotentHint": true,
         "openWorldHint": false
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "send_file",
@@ -9642,7 +9871,8 @@
         "idempotentHint": false,
         "openWorldHint": true
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "send_mail",
@@ -9710,7 +9940,8 @@
         "idempotentHint": false,
         "openWorldHint": true
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "send_message",
@@ -9745,7 +9976,8 @@
         "idempotentHint": false,
         "openWorldHint": true
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "set_brightness",
@@ -9774,7 +10006,8 @@
         "idempotentHint": true,
         "openWorldHint": false
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "set_clipboard",
@@ -9818,7 +10051,8 @@
         "idempotentHint": true,
         "openWorldHint": false
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "set_disliked",
@@ -9851,7 +10085,8 @@
         "idempotentHint": true,
         "openWorldHint": false
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "set_favorited",
@@ -9884,7 +10119,8 @@
         "idempotentHint": true,
         "openWorldHint": false
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "set_file_tags",
@@ -9921,7 +10157,8 @@
         "idempotentHint": true,
         "openWorldHint": false
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "set_rating",
@@ -9956,7 +10193,8 @@
         "idempotentHint": true,
         "openWorldHint": false
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "set_shuffle",
@@ -9989,7 +10227,8 @@
         "idempotentHint": true,
         "openWorldHint": false
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "set_volume",
@@ -10035,7 +10274,8 @@
         "idempotentHint": true,
         "openWorldHint": false
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "setup_permissions",
@@ -10053,7 +10293,8 @@
         "idempotentHint": true,
         "openWorldHint": false
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "share_location",
@@ -10090,7 +10331,8 @@
         "idempotentHint": true,
         "openWorldHint": false
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "show_notification",
@@ -10133,7 +10375,8 @@
         "idempotentHint": false,
         "openWorldHint": false
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "skill_calendar-alert",
@@ -10151,7 +10394,8 @@
         "idempotentHint": true,
         "openWorldHint": false
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "skill_clipboard-url-to-reading",
@@ -10169,7 +10413,8 @@
         "idempotentHint": true,
         "openWorldHint": false
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "skill_daily-journal",
@@ -10194,7 +10439,8 @@
         "idempotentHint": true,
         "openWorldHint": false
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "skill_evening-winddown",
@@ -10212,7 +10458,8 @@
         "idempotentHint": true,
         "openWorldHint": false
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "skill_focus-block-planner",
@@ -10230,7 +10477,8 @@
         "idempotentHint": true,
         "openWorldHint": false
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "skill_focus-guardian",
@@ -10248,7 +10496,8 @@
         "idempotentHint": true,
         "openWorldHint": false
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "skill_inbox-triage",
@@ -10266,7 +10515,8 @@
         "idempotentHint": true,
         "openWorldHint": false
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "skill_project-digest",
@@ -10284,7 +10534,8 @@
         "idempotentHint": true,
         "openWorldHint": false
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "skill_sender-to-tasks",
@@ -10319,7 +10570,8 @@
         "idempotentHint": true,
         "openWorldHint": false
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "smart_clipboard",
@@ -10337,7 +10589,8 @@
         "idempotentHint": true,
         "openWorldHint": false
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "speech_availability",
@@ -10355,7 +10608,8 @@
         "idempotentHint": true,
         "openWorldHint": false
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "spotlight_clear",
@@ -10373,7 +10627,8 @@
         "idempotentHint": true,
         "openWorldHint": false
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "spotlight_sync",
@@ -10391,7 +10646,8 @@
         "idempotentHint": true,
         "openWorldHint": false
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "suggest_next_tools",
@@ -10465,7 +10721,8 @@
         "idempotentHint": true,
         "openWorldHint": false
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "summarize_context",
@@ -10490,7 +10747,8 @@
         "idempotentHint": true,
         "openWorldHint": false
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "summarize_text",
@@ -10518,7 +10776,8 @@
         "idempotentHint": true,
         "openWorldHint": false
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "system_power",
@@ -10549,7 +10808,8 @@
         "idempotentHint": false,
         "openWorldHint": false
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "system_sleep",
@@ -10567,7 +10827,8 @@
         "idempotentHint": false,
         "openWorldHint": false
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "tag_content",
@@ -10606,7 +10867,8 @@
         "idempotentHint": true,
         "openWorldHint": false
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "timeline_today",
@@ -10624,7 +10886,8 @@
         "idempotentHint": true,
         "openWorldHint": false
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "today_events",
@@ -10694,7 +10957,8 @@
         "idempotentHint": true,
         "openWorldHint": false
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "toggle_dark_mode",
@@ -10724,7 +10988,8 @@
         "idempotentHint": true,
         "openWorldHint": false
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "toggle_focus_mode",
@@ -10751,7 +11016,8 @@
         "idempotentHint": true,
         "openWorldHint": false
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "toggle_wifi",
@@ -10778,7 +11044,8 @@
         "idempotentHint": true,
         "openWorldHint": false
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "transcribe_audio",
@@ -10810,7 +11077,8 @@
         "idempotentHint": true,
         "openWorldHint": false
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "trash_file",
@@ -10839,7 +11107,8 @@
         "idempotentHint": true,
         "openWorldHint": false
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "tv_list_playlists",
@@ -10857,7 +11126,8 @@
         "idempotentHint": true,
         "openWorldHint": false
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "tv_list_tracks",
@@ -10892,7 +11162,8 @@
         "idempotentHint": true,
         "openWorldHint": false
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "tv_now_playing",
@@ -10910,7 +11181,8 @@
         "idempotentHint": true,
         "openWorldHint": false
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "tv_play",
@@ -10938,7 +11210,8 @@
         "idempotentHint": false,
         "openWorldHint": false
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "tv_playback_control",
@@ -10971,7 +11244,8 @@
         "idempotentHint": false,
         "openWorldHint": false
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "tv_search",
@@ -11006,7 +11280,8 @@
         "idempotentHint": true,
         "openWorldHint": false
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "ui_accessibility_query",
@@ -11073,7 +11348,8 @@
         "idempotentHint": true,
         "openWorldHint": true
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "ui_click",
@@ -11119,7 +11395,8 @@
         "idempotentHint": false,
         "openWorldHint": true
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "ui_diff",
@@ -11153,7 +11430,8 @@
         "idempotentHint": true,
         "openWorldHint": true
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "ui_open_app",
@@ -11181,7 +11459,8 @@
         "idempotentHint": true,
         "openWorldHint": true
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "ui_perform_action",
@@ -11272,7 +11551,8 @@
         "idempotentHint": false,
         "openWorldHint": true
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "ui_press_key",
@@ -11311,7 +11591,8 @@
         "idempotentHint": false,
         "openWorldHint": true
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "ui_read",
@@ -11350,7 +11631,8 @@
         "idempotentHint": true,
         "openWorldHint": true
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "ui_scroll",
@@ -11394,7 +11676,8 @@
         "idempotentHint": false,
         "openWorldHint": true
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "ui_traverse",
@@ -11442,7 +11725,8 @@
         "idempotentHint": true,
         "openWorldHint": true
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "ui_type",
@@ -11475,7 +11759,8 @@
         "idempotentHint": false,
         "openWorldHint": true
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "update_contact",
@@ -11528,7 +11813,8 @@
         "idempotentHint": true,
         "openWorldHint": false
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "update_event",
@@ -11581,7 +11867,8 @@
         "idempotentHint": true,
         "openWorldHint": false
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "update_note",
@@ -11615,7 +11902,8 @@
         "idempotentHint": true,
         "openWorldHint": false
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     },
     {
       "name": "update_reminder",
@@ -11670,7 +11958,8 @@
         "idempotentHint": true,
         "openWorldHint": false
       },
-      "appIntentEligible": true
+      "appIntentEligible": true,
+      "ineligibleReason": null
     }
   ]
 }

--- a/scripts/dump-tool-manifest.mjs
+++ b/scripts/dump-tool-manifest.mjs
@@ -161,14 +161,28 @@ try {
       // Eligibility gate for Swift AppIntent codegen (RFC 0007 §3.3).
       // Composite inputs (arrays of objects, records) can't map to @Parameter
       // today; we flag them so gen-swift-intents skips without breaking.
-      appIntentEligible: isAppIntentEligible(t.inputSchema, t.annotations),
+      // When ineligible we also record the specific reason so a future
+      // WWDC update (e.g. AppIntent accepting struct params) or manifest
+      // refactor can surface "here's what's missing" without re-deriving
+      // from the schema. `null` when the tool is eligible.
+      ...appIntentEligibility(t.inputSchema),
     }));
+
+  const ineligibleCount = normalized.filter((t) => !t.appIntentEligible).length;
+  const ineligibleByReason = {};
+  for (const t of normalized) {
+    if (t.appIntentEligible) continue;
+    const reason = t.ineligibleReason ?? "unknown";
+    ineligibleByReason[reason] = (ineligibleByReason[reason] ?? 0) + 1;
+  }
 
   const manifest = {
     generatedAt: new Date().toISOString(),
     protocolVersion: "2025-06-18",
     toolCount: normalized.length,
     eligibleCount: normalized.filter((t) => t.appIntentEligible).length,
+    ineligibleCount,
+    ineligibleByReason,
     tools: normalized,
   };
 
@@ -187,13 +201,17 @@ try {
       exitCode = 1;
     } else if (existing) {
       console.error(
-        `[manifest --check] OK — ${manifest.toolCount} tools (${manifest.eligibleCount} AppIntent-eligible)`,
+        `[manifest --check] OK — ${manifest.toolCount} tools (${manifest.eligibleCount} AppIntent-eligible, ${manifest.ineligibleCount} ineligible${
+          manifest.ineligibleCount > 0 ? ": " + Object.entries(manifest.ineligibleByReason).map(([r, n]) => `${r}=${n}`).join(", ") : ""
+        })`,
       );
     }
   } else {
     writeFileSync(OUT_PATH, serialized);
     console.error(
-      `[manifest] wrote ${OUT_PATH} — ${manifest.toolCount} tools (${manifest.eligibleCount} AppIntent-eligible)`,
+      `[manifest] wrote ${OUT_PATH} — ${manifest.toolCount} tools (${manifest.eligibleCount} AppIntent-eligible, ${manifest.ineligibleCount} ineligible${
+        manifest.ineligibleCount > 0 ? ": " + Object.entries(manifest.ineligibleByReason).map(([r, n]) => `${r}=${n}`).join(", ") : ""
+      })`,
     );
   }
 } catch (e) {
@@ -220,27 +238,38 @@ function replacerStripGenerated(key, value) {
 }
 
 /**
- * Return true if the tool's inputSchema is expressible as a flat list of
- * AppIntent `@Parameter` properties. RFC 0007 §3.3 table.
+ * Decide whether the tool's inputSchema is expressible as a flat list of
+ * AppIntent `@Parameter` properties, and if not, record why. RFC 0007
+ * §3.3 table.
  *
- * Ineligible cases:
- *   - any property whose type is "array" AND whose items is "object"
- *     (AppIntent supports [String], [Int], [Double], [Bool] but not arrays
- *     of structs at the @Parameter layer as of iOS 17)
- *   - any property whose type is "object" (composite)
- *   - `additionalProperties: true` / record-like schemas
+ * Returns `{ appIntentEligible: true, ineligibleReason: null }` when
+ * eligible, or `{ appIntentEligible: false, ineligibleReason: "..." }`
+ * with a specific code:
+ *   - "record-input"       additionalProperties: true (keys unknown)
+ *   - "object-param:<key>" a property is `type: object` (composite)
+ *   - "array-of-object:<k>" a property is `array<object>` (composite items)
+ *
+ * The reason code lands in the manifest so diagnostic tools can group
+ * ineligibles by cause and so a future WWDC that lifts one constraint
+ * can target a specific code to rerun codegen against.
  */
-function isAppIntentEligible(inputSchema, _annotations) {
-  if (!inputSchema || typeof inputSchema !== "object") return true;
-  if (inputSchema.additionalProperties === true) return false;
+function appIntentEligibility(inputSchema) {
+  if (!inputSchema || typeof inputSchema !== "object") {
+    return { appIntentEligible: true, ineligibleReason: null };
+  }
+  if (inputSchema.additionalProperties === true) {
+    return { appIntentEligible: false, ineligibleReason: "record-input" };
+  }
   const props = inputSchema.properties ?? {};
   for (const key of Object.keys(props)) {
     const p = props[key];
     if (!p || typeof p !== "object") continue;
-    if (p.type === "object") return false;
+    if (p.type === "object") {
+      return { appIntentEligible: false, ineligibleReason: `object-param:${key}` };
+    }
     if (p.type === "array" && p.items && typeof p.items === "object" && p.items.type === "object") {
-      return false;
+      return { appIntentEligible: false, ineligibleReason: `array-of-object:${key}` };
     }
   }
-  return true;
+  return { appIntentEligible: true, ineligibleReason: null };
 }


### PR DESCRIPTION
## Summary

\`isAppIntentEligible\` → \`appIntentEligibility\` returning \`{ appIntentEligible, ineligibleReason }\` so the manifest records *why* a tool dropped out of AppIntent coverage.

Stacked on [#118](https://github.com/heznpc/AirMCP/pull/118) (A.4 destructive opt-in).

**Description length cap split out** — it was a no-op under current compact-mode manifest (src/shared/tool-filter.ts truncates to 80 chars before codegen sees it), so it belongs after #113 merges and full descriptions land. Will reintroduce as a focused follow-up PR.

## Reason codes

| reason | meaning | current tools |
|---|---|---|
| \`object-param:recurrence\` | \`type: object\` property | create_recurring_event, create_recurring_reminder |
| \`object-param:schema\` | \`type: object\` property | generate_structured |
| \`object-param:args\` | \`type: object\` property | get_workflow |
| \`object-param:params\` | \`type: object\` property | gws_raw |
| \`array-of-object:<k>\` | \`array<object>\` property | (0 today) |
| \`record-input\` | \`additionalProperties: true\` | (0 today) |

## Manifest surface

\`\`\`json
"ineligibleCount": 5,
"ineligibleByReason": {
  "object-param:recurrence": 2,
  "object-param:schema": 1,
  "object-param:args": 1,
  "object-param:params": 1
}
\`\`\`

Dump + check scripts print the histogram in their one-line summary:

\`\`\`
[manifest] wrote docs/tool-manifest.json — 282 tools (277 AppIntent-eligible,
  5 ineligible: object-param:recurrence=2, object-param:schema=1,
  object-param:args=1, object-param:params=1)
\`\`\`

Per-tool \`ineligibleReason\` lands in every ineligible entry so a future WWDC that lifts one constraint can target a specific code to rerun codegen against.

## Test plan

- [x] \`npm run gen:manifest\` — summary shows histogram
- [x] \`npm run gen:manifest:check\` green on checked-in manifest
- [x] \`npm run gen:intents:check\` — 229 intents, no change from base
- [x] \`swift build\` passes (3.6s)