### PR TITLE
chore(rfc-0007): surface AppIntent coverage in count-stats

### DIFF
--- a/scripts/count-stats.mjs
+++ b/scripts/count-stats.mjs
@@ -64,7 +64,52 @@ const modules = moduleBlock
   ? (moduleBlock[1].match(/"/g) || []).length / 2
   : 0;
 
-const stats = { tools, prompts, resources, modules };
+// RFC 0007 — AppIntent coverage, derived from the dumped manifest.
+// Opportunistic: if the manifest file is absent (e.g. fresh checkout
+// before `npm run gen:manifest` ran) we leave these as null instead of
+// failing, so `count-stats --check` stays stable. CI runs gen:manifest
+// before count-stats anyway.
+let appIntentEligible = null;
+let appIntentIneligible = null;
+let appIntentGenerated = null;
+let appIntentIneligibleByReason = null;
+let manifestToolCount = null;
+
+const manifestPath = join(ROOT, "docs", "tool-manifest.json");
+if (existsSync(manifestPath)) {
+  try {
+    const m = JSON.parse(readFileSync(manifestPath, "utf-8"));
+    manifestToolCount = m.toolCount ?? m.tools.length;
+    appIntentEligible = m.eligibleCount ?? m.tools.filter((t) => t.appIntentEligible).length;
+    appIntentIneligible = m.ineligibleCount ?? m.tools.filter((t) => !t.appIntentEligible).length;
+    appIntentIneligibleByReason = m.ineligibleByReason ?? null;
+  } catch {
+    /* leave as null */
+  }
+}
+
+const generatedPath = join(ROOT, "swift", "Sources", "AirMCPKit", "Generated", "MCPIntents.swift");
+if (existsSync(generatedPath)) {
+  try {
+    const gen = readFileSync(generatedPath, "utf-8");
+    // Count top-level `public struct FooIntent: AppIntent` declarations.
+    // Excludes output structs (Codable, Sendable) and AppEnum / AppShortcutsProvider.
+    appIntentGenerated = (gen.match(/^public struct \w+Intent: AppIntent\b/gm) || []).length;
+  } catch {
+    /* leave as null */
+  }
+}
+
+const stats = {
+  tools,
+  prompts,
+  resources,
+  modules,
+  appIntentEligible,
+  appIntentIneligible,
+  appIntentGenerated,
+  appIntentIneligibleByReason,
+};
 
 // ── Print mode ─────────────────────────────────────────────────────
 
@@ -119,6 +164,24 @@ function syncFile(relPath, replacements) {
 console.log(
   `\nStats ${mode}: ${tools} tools, ${prompts} prompts, ${resources} resources, ${modules} modules\n`,
 );
+if (appIntentEligible !== null) {
+  const reasonSummary = appIntentIneligibleByReason
+    ? Object.entries(appIntentIneligibleByReason)
+        .map(([r, n]) => `${r}=${n}`)
+        .join(", ")
+    : "";
+  // Use manifestToolCount as the denominator since it reflects the
+  // runtime-registered set (dynamic registrations via skills / apps
+  // providers that the regex-based `tools` count above misses). The
+  // two numbers won't match when skills/apps modules register tools
+  // that aren't literal `server.registerTool(` call sites in src.
+  console.log(
+    `AppIntent coverage: ${appIntentEligible}/${manifestToolCount} eligible` +
+      (appIntentGenerated !== null ? `, ${appIntentGenerated} emitted (destructive opt-in off by default)` : "") +
+      (appIntentIneligible > 0 ? `, ${appIntentIneligible} ineligible (${reasonSummary})` : "") +
+      "\n",
+  );
+}
 
 // README.md
 syncFile("README.md", [


### PR DESCRIPTION
## Summary

\`count-stats.mjs\` now prints an AppIntent coverage line alongside the existing tool/prompt/resource/module stats, so \`npm run count-stats\` and the CI \`count-stats --check\` step make bridge coverage visible without grep'ing the manifest.

Stacked on [#120](https://github.com/heznpc/AirMCP/pull/120) (scalar snippet formatter). Purely a reporting addition.

## Sample output

\`\`\`
Stats print: 269 tools, 32 prompts, 9 resources, 29 modules

AppIntent coverage: 277/282 eligible, 229 emitted (destructive opt-in off by default),
  5 ineligible (object-param:recurrence=2, object-param:schema=1,
  object-param:args=1, object-param:params=1)
\`\`\`

## Design choices

- **Opportunistic read** of \`docs/tool-manifest.json\` and \`swift/Sources/AirMCPKit/Generated/MCPIntents.swift\`. If either is absent (fresh checkout before the gen steps ran) the coverage line is silently omitted — CI order is manifest → intents → count-stats, so the CI log always has it. Local \`npm run count-stats\` also Just Works since \`dist\` → \`gen:manifest\` → \`gen:intents\` → stats is the standard dev flow.
- **Denominator is \`manifestToolCount\` (282)** rather than the regex-scanned src \`tools\` count (269). The 13 extra come from tools registered dynamically by the skills engine and MCP apps providers — real tools at runtime that \`grep server.registerTool\` misses. Using the manifest count gives an honest ratio.
- **Histogram of ineligibility reasons** (from [#119](https://github.com/heznpc/AirMCP/pull/119)) is included inline so any future regression ("+3 object-param tools appeared") is visible on every CI run.

No sync targets added — this is just a printed diagnostic. If the team later wants AppIntent counts in README.md / docs, the stats object carries the fields ready.

## Test plan

- [x] \`node scripts/count-stats.mjs\` prints coverage line
- [x] \`node scripts/count-stats.mjs --check\` still green (no doc sync changes)
- [x] Deleting \`docs/tool-manifest.json\` → coverage line silently omitted, rest of output normal