### PR TITLE
feat(rfc-0007): follow-up taps for chats and messages, rename-aware

### DIFF
--- a/scripts/gen-swift-intents.mjs
+++ b/scripts/gen-swift-intents.mjs
@@ -786,22 +786,37 @@ ${toolEntries.join("\n")}
 // compiler(>=6.3)` + `@available(macOS 26, iOS 26, *)`.
 
 // A.4.3: list → read follow-up map. Tools in this map render each row
-// as `Button(intent: Read<Target>Intent(id: row.id))` so taps dispatch
-// the follow-up AppIntent in-place. Entries validated at load time
-// against the manifest (tool/target must exist; target's @Parameter
-// must be named exactly "id"; list items must carry a matching `id`
-// field). Extending the map is adding one line + re-running codegen.
+// as `Button(intent: _mkRead<Target>Intent(<targetParam>: row.<itemField>))`
+// so taps dispatch the follow-up AppIntent in-place. The
+// itemField/targetParam split handles the common case where the list
+// result's `id` needs to be plumbed into a target tool whose @Parameter
+// has a different name (e.g. list_chats.id → read_chat.chatId).
+//
+// Validation at load time:
+//   • list tool exists in manifest
+//   • target tool exists in manifest
+//   • list output items have a string field named `itemField`
+//   • target input has a @Parameter named `targetParam`
+//
+// Extending the map is adding one line + re-running codegen.
 const FOLLOW_UP_MAP = {
-  list_events: { target: "read_event", idField: "id" },
-  today_events: { target: "read_event", idField: "id" },
-  get_upcoming_events: { target: "read_event", idField: "id" },
-  search_events: { target: "read_event", idField: "id" },
-  list_notes: { target: "read_note", idField: "id" },
-  search_notes: { target: "read_note", idField: "id" },
-  list_reminders: { target: "read_reminder", idField: "id" },
-  search_reminders: { target: "read_reminder", idField: "id" },
-  list_contacts: { target: "read_contact", idField: "id" },
-  search_contacts: { target: "read_contact", idField: "id" },
+  list_events: { target: "read_event", itemField: "id", targetParam: "id" },
+  today_events: { target: "read_event", itemField: "id", targetParam: "id" },
+  get_upcoming_events: { target: "read_event", itemField: "id", targetParam: "id" },
+  search_events: { target: "read_event", itemField: "id", targetParam: "id" },
+  list_notes: { target: "read_note", itemField: "id", targetParam: "id" },
+  search_notes: { target: "read_note", itemField: "id", targetParam: "id" },
+  list_reminders: { target: "read_reminder", itemField: "id", targetParam: "id" },
+  search_reminders: { target: "read_reminder", itemField: "id", targetParam: "id" },
+  list_contacts: { target: "read_contact", itemField: "id", targetParam: "id" },
+  search_contacts: { target: "read_contact", itemField: "id", targetParam: "id" },
+  // Messages: list_messages.id → read_message.id (clean match).
+  list_messages: { target: "read_message", itemField: "id", targetParam: "id" },
+  // Chats: list output uses `id`, read expects `chatId`. The mapping
+  // here lets the codegen plumb row.id → chatId: without changing the
+  // wire contract.
+  list_chats: { target: "read_chat", itemField: "id", targetParam: "chatId" },
+  search_chats: { target: "read_chat", itemField: "id", targetParam: "chatId" },
 };
 
 /**
@@ -882,10 +897,19 @@ function detectSnippetShape(schema) {
       // human label (summary / name / title) rather than the raw UID.
       // Fall back to `id` if nothing else is stringly typed — the row
       // still renders, just less prettily.
-      const stringKeys = Object.keys(itemProps).filter((k) => itemProps[k].type === "string");
+      //
+      // Schemas may declare `type: ["string", "null"]` for optional
+      // fields; treat those the same as plain strings when picking a
+      // display field. The snippet view handles nil via the Codable
+      // struct's Optional<String> type, so rendering the Optional with
+      // `?? ""` is covered at the SwiftUI layer.
+      const isStringish = (p) =>
+        p != null && (p.type === "string" || (Array.isArray(p.type) && p.type.includes("string")));
+      const stringKeys = Object.keys(itemProps).filter((k) => isStringish(itemProps[k]));
       const primaryField = stringKeys.find((k) => k !== "id") ?? stringKeys[0] ?? null;
-      const hasId = itemProps.id?.type === "string";
-      return { shape: "list-object", arrayField: arrayKey, primaryField, hasId };
+      const primaryFieldOptional = primaryField ? Array.isArray(itemProps[primaryField].type) : false;
+      const hasId = isStringish(itemProps.id);
+      return { shape: "list-object", arrayField: arrayKey, primaryField, primaryFieldOptional, hasId };
     }
     if (items.type === "string") {
       return { shape: "list-string", arrayField: arrayKey };
@@ -912,25 +936,45 @@ function resolveFollowUpMap() {
       process.exit(2);
     }
     const info = detectSnippetShape(listTool.outputSchema ?? {});
-    if (info.shape !== "list-object" || !info.hasId) {
+    if (info.shape !== "list-object") {
       console.error(
-        `[gen-intents] FOLLOW_UP_MAP: ${listName} has no list-object items with \`id\` field (shape=${info.shape}, hasId=${info.hasId})`,
+        `[gen-intents] FOLLOW_UP_MAP: ${listName} is not a list-object shape (got ${info.shape})`,
+      );
+      process.exit(2);
+    }
+    const itemProps = listTool.outputSchema?.properties?.[info.arrayField]?.items?.properties ?? {};
+    if (itemProps[entry.itemField]?.type !== "string") {
+      console.error(
+        `[gen-intents] FOLLOW_UP_MAP: ${listName} items have no string field "${entry.itemField}" (fields: ${Object.keys(itemProps).join(", ")})`,
       );
       process.exit(2);
     }
     const targetParams = Object.keys(target.inputSchema?.properties ?? {});
-    if (!targetParams.includes(entry.idField)) {
+    if (!targetParams.includes(entry.targetParam)) {
       console.error(
-        `[gen-intents] FOLLOW_UP_MAP: target ${entry.target} has no @Parameter named "${entry.idField}" (params: ${targetParams.join(", ")})`,
+        `[gen-intents] FOLLOW_UP_MAP: target ${entry.target} has no @Parameter named "${entry.targetParam}" (params: ${targetParams.join(", ")})`,
       );
       process.exit(2);
     }
-    resolved[listName] = { ...entry, targetIntentName: intentStructName(entry.target) };
+    resolved[listName] = {
+      ...entry,
+      targetIntentName: intentStructName(entry.target),
+      // Factory key by (target, targetParam). Two list tools pointing at
+      // the same read target with the same param share one factory; two
+      // list tools pointing at the same target via different params
+      // (unlikely but possible) each get their own.
+      factoryKey: `${intentStructName(entry.target)}_${entry.targetParam}`,
+    };
   }
   return resolved;
 }
 const followUpMap = resolveFollowUpMap();
-const followUpTargets = Array.from(new Set(Object.values(followUpMap).map((e) => e.targetIntentName)));
+// Deduplicate factories by (targetIntentName, targetParam).
+const followUpFactorySpecs = Array.from(
+  new Map(
+    Object.values(followUpMap).map((e) => [e.factoryKey, { targetIntentName: e.targetIntentName, targetParam: e.targetParam }]),
+  ).values(),
+);
 
 function snippetViewNameFor(tool) {
   return `MCP${toPascalCase(tool.name)}SnippetView`;
@@ -943,16 +987,27 @@ function renderSnippetView(tool) {
 
   let body;
   if (info.shape === "list-object") {
-    const primaryAccess = info.primaryField ? `row.${swiftIdent(info.primaryField)}` : `"(row)"`;
+    // Optional string fields decode to `String?`; render with `?? ""`
+    // so SwiftUI sees a non-optional for Text().
+    const primaryAccess = info.primaryField
+      ? info.primaryFieldOptional
+        ? `(row.${swiftIdent(info.primaryField)} ?? "")`
+        : `row.${swiftIdent(info.primaryField)}`
+      : `"(row)"`;
     const followUp = followUpMap[tool.name];
     // A.4.3: wrap the row in Button(intent:) when the tool has a list→read
-    // pairing AND the list items have an `id` field. Uses `id: \.id` for
-    // the ForEach key so SwiftUI diffs correctly across follow-up taps
-    // (the old `id: \.offset` was safe only for static-display rows).
+    // pairing AND the list items carry the expected itemField. Uses
+    // `id: \.id` for the ForEach key (items with string `id` always exist
+    // when a follow-up is configured) so SwiftUI diffs correctly across
+    // follow-up taps — the old `id: \.offset` was safe only for
+    // static-display rows. The factory argument label is the follow-up
+    // target's @Parameter name (may differ from itemField, e.g.
+    // list_chats.id → read_chat.chatId).
     if (followUp && info.hasId) {
+      const factory = `_mk${followUp.factoryKey}`;
       body = `        VStack(alignment: .leading, spacing: 4) {
             ForEach(data.${swiftIdent(info.arrayField)}, id: \\.id) { row in
-                Button(intent: _mk${followUp.targetIntentName}(id: row.id)) {
+                Button(intent: ${factory}(${swiftIdent(followUp.targetParam)}: row.${swiftIdent(followUp.itemField)})) {
                     Text(${primaryAccess})
                         .font(.body)
                         .lineLimit(1)
@@ -1028,18 +1083,23 @@ const outputStructs = typedTools.map((tool) => {
 });
 const snippetViews = typedTools.map((tool) => renderSnippetView(tool));
 
-// A.4.3: one factory per unique follow-up target so the snippet view
-// can construct a parameterized intent instance (AppIntent requires a
-// no-arg init + property set — a plain `Read<Foo>Intent(id:)` call
-// site doesn't compile). File-private keeps the helpers out of the
-// public surface.
-const followUpFactories = followUpTargets.map(
-  (intentName) => `@available(macOS 26, iOS 26, *)
-fileprivate func _mk${intentName}(id: String) -> ${intentName} {
-    var intent = ${intentName}()
-    intent.id = id
+// A.4.3: one factory per (target intent, target param) pair so the
+// snippet view can construct a parameterized intent instance (AppIntent
+// requires a no-arg init + property set — a plain `Read<Foo>Intent(
+// id:)` call site doesn't compile). File-private keeps the helpers out
+// of the public surface. Factory name = `_mk<Intent>_<param>` so
+// list_chats (→ read_chat.chatId) and list_events (→ read_event.id)
+// each get their own helper even when they share a target intent.
+const followUpFactories = followUpFactorySpecs.map(
+  ({ targetIntentName, targetParam }) => {
+    const paramIdent = swiftIdent(targetParam);
+    return `@available(macOS 26, iOS 26, *)
+fileprivate func _mk${targetIntentName}_${targetParam}(${paramIdent}: String) -> ${targetIntentName} {
+    var intent = ${targetIntentName}()
+    intent.${paramIdent} = ${paramIdent}
     return intent
-}`,
+}`;
+  },
 );
 
 const header = `// GENERATED — do not edit.

--- a/swift/Sources/AirMCPKit/Generated/MCPIntents.swift
+++ b/swift/Sources/AirMCPKit/Generated/MCPIntents.swift
@@ -6781,30 +6781,44 @@ public struct AirMCPGeneratedShortcuts: AppShortcutsProvider {
 import SwiftUI
 
 @available(macOS 26, iOS 26, *)
-fileprivate func _mkReadEventIntent(id: String) -> ReadEventIntent {
+fileprivate func _mkReadEventIntent_id(id: String) -> ReadEventIntent {
     var intent = ReadEventIntent()
     intent.id = id
     return intent
 }
 
 @available(macOS 26, iOS 26, *)
-fileprivate func _mkReadNoteIntent(id: String) -> ReadNoteIntent {
+fileprivate func _mkReadNoteIntent_id(id: String) -> ReadNoteIntent {
     var intent = ReadNoteIntent()
     intent.id = id
     return intent
 }
 
 @available(macOS 26, iOS 26, *)
-fileprivate func _mkReadReminderIntent(id: String) -> ReadReminderIntent {
+fileprivate func _mkReadReminderIntent_id(id: String) -> ReadReminderIntent {
     var intent = ReadReminderIntent()
     intent.id = id
     return intent
 }
 
 @available(macOS 26, iOS 26, *)
-fileprivate func _mkReadContactIntent(id: String) -> ReadContactIntent {
+fileprivate func _mkReadContactIntent_id(id: String) -> ReadContactIntent {
     var intent = ReadContactIntent()
     intent.id = id
+    return intent
+}
+
+@available(macOS 26, iOS 26, *)
+fileprivate func _mkReadMessageIntent_id(id: String) -> ReadMessageIntent {
+    var intent = ReadMessageIntent()
+    intent.id = id
+    return intent
+}
+
+@available(macOS 26, iOS 26, *)
+fileprivate func _mkReadChatIntent_chatId(chatId: String) -> ReadChatIntent {
+    var intent = ReadChatIntent()
+    intent.chatId = chatId
     return intent
 }
 
@@ -7101,7 +7115,7 @@ public struct MCPGetUpcomingEventsSnippetView: View {
     public var body: some View {
         VStack(alignment: .leading, spacing: 4) {
             ForEach(data.events, id: \.id) { row in
-                Button(intent: _mkReadEventIntent(id: row.id)) {
+                Button(intent: _mkReadEventIntent_id(id: row.id)) {
                     Text(row.summary)
                         .font(.body)
                         .lineLimit(1)
@@ -7204,10 +7218,13 @@ public struct MCPListChatsSnippetView: View {
     public init(data: MCPListChatsOutput) { self.data = data }
     public var body: some View {
         VStack(alignment: .leading, spacing: 4) {
-            ForEach(Array(data.chats.enumerated()), id: \.offset) { _, row in
-                Text(row.id)
-                    .font(.body)
-                    .lineLimit(1)
+            ForEach(data.chats, id: \.id) { row in
+                Button(intent: _mkReadChatIntent_chatId(chatId: row.id)) {
+                    Text((row.name ?? ""))
+                        .font(.body)
+                        .lineLimit(1)
+                }
+                .buttonStyle(.plain)
             }
         }
         .padding()
@@ -7222,7 +7239,7 @@ public struct MCPListContactsSnippetView: View {
     public var body: some View {
         VStack(alignment: .leading, spacing: 4) {
             ForEach(data.contacts, id: \.id) { row in
-                Button(intent: _mkReadContactIntent(id: row.id)) {
+                Button(intent: _mkReadContactIntent_id(id: row.id)) {
                     Text(row.name)
                         .font(.body)
                         .lineLimit(1)
@@ -7259,7 +7276,7 @@ public struct MCPListEventsSnippetView: View {
     public var body: some View {
         VStack(alignment: .leading, spacing: 4) {
             ForEach(data.events, id: \.id) { row in
-                Button(intent: _mkReadEventIntent(id: row.id)) {
+                Button(intent: _mkReadEventIntent_id(id: row.id)) {
                     Text(row.summary)
                         .font(.body)
                         .lineLimit(1)
@@ -7346,10 +7363,13 @@ public struct MCPListMessagesSnippetView: View {
     public init(data: MCPListMessagesOutput) { self.data = data }
     public var body: some View {
         VStack(alignment: .leading, spacing: 4) {
-            ForEach(Array(data.messages.enumerated()), id: \.offset) { _, row in
-                Text(row.subject)
-                    .font(.body)
-                    .lineLimit(1)
+            ForEach(data.messages, id: \.id) { row in
+                Button(intent: _mkReadMessageIntent_id(id: row.id)) {
+                    Text(row.subject)
+                        .font(.body)
+                        .lineLimit(1)
+                }
+                .buttonStyle(.plain)
             }
         }
         .padding()
@@ -7364,7 +7384,7 @@ public struct MCPListNotesSnippetView: View {
     public var body: some View {
         VStack(alignment: .leading, spacing: 4) {
             ForEach(data.notes, id: \.id) { row in
-                Button(intent: _mkReadNoteIntent(id: row.id)) {
+                Button(intent: _mkReadNoteIntent_id(id: row.id)) {
                     Text(row.name)
                         .font(.body)
                         .lineLimit(1)
@@ -7384,7 +7404,7 @@ public struct MCPListParticipantsSnippetView: View {
     public var body: some View {
         VStack(alignment: .leading, spacing: 4) {
             ForEach(Array(data.participants.enumerated()), id: \.offset) { _, row in
-                Text("(row)")
+                Text((row.name ?? ""))
                     .font(.body)
                     .lineLimit(1)
             }
@@ -7452,7 +7472,7 @@ public struct MCPListRemindersSnippetView: View {
     public var body: some View {
         VStack(alignment: .leading, spacing: 4) {
             ForEach(data.reminders, id: \.id) { row in
-                Button(intent: _mkReadReminderIntent(id: row.id)) {
+                Button(intent: _mkReadReminderIntent_id(id: row.id)) {
                     Text(row.name)
                         .font(.body)
                         .lineLimit(1)
@@ -7672,7 +7692,7 @@ public struct MCPReadChatSnippetView: View {
     public var body: some View {
         VStack(alignment: .leading, spacing: 4) {
             ForEach(Array(data.participants.enumerated()), id: \.offset) { _, row in
-                Text("(row)")
+                Text((row.name ?? ""))
                     .font(.body)
                     .lineLimit(1)
             }
@@ -7778,7 +7798,7 @@ public struct MCPReadEventSnippetView: View {
     public var body: some View {
         VStack(alignment: .leading, spacing: 4) {
             ForEach(Array(data.attendees.enumerated()), id: \.offset) { _, row in
-                Text("(row)")
+                Text((row.name ?? ""))
                     .font(.body)
                     .lineLimit(1)
             }
@@ -7958,10 +7978,13 @@ public struct MCPSearchChatsSnippetView: View {
     public init(data: MCPSearchChatsOutput) { self.data = data }
     public var body: some View {
         VStack(alignment: .leading, spacing: 4) {
-            ForEach(Array(data.chats.enumerated()), id: \.offset) { _, row in
-                Text(row.id)
-                    .font(.body)
-                    .lineLimit(1)
+            ForEach(data.chats, id: \.id) { row in
+                Button(intent: _mkReadChatIntent_chatId(chatId: row.id)) {
+                    Text((row.name ?? ""))
+                        .font(.body)
+                        .lineLimit(1)
+                }
+                .buttonStyle(.plain)
             }
         }
         .padding()
@@ -7976,7 +7999,7 @@ public struct MCPSearchContactsSnippetView: View {
     public var body: some View {
         VStack(alignment: .leading, spacing: 4) {
             ForEach(data.contacts, id: \.id) { row in
-                Button(intent: _mkReadContactIntent(id: row.id)) {
+                Button(intent: _mkReadContactIntent_id(id: row.id)) {
                     Text(row.name)
                         .font(.body)
                         .lineLimit(1)
@@ -7996,7 +8019,7 @@ public struct MCPSearchEventsSnippetView: View {
     public var body: some View {
         VStack(alignment: .leading, spacing: 4) {
             ForEach(data.events, id: \.id) { row in
-                Button(intent: _mkReadEventIntent(id: row.id)) {
+                Button(intent: _mkReadEventIntent_id(id: row.id)) {
                     Text(row.summary)
                         .font(.body)
                         .lineLimit(1)
@@ -8016,7 +8039,7 @@ public struct MCPSearchNotesSnippetView: View {
     public var body: some View {
         VStack(alignment: .leading, spacing: 4) {
             ForEach(data.notes, id: \.id) { row in
-                Button(intent: _mkReadNoteIntent(id: row.id)) {
+                Button(intent: _mkReadNoteIntent_id(id: row.id)) {
                     Text(row.name)
                         .font(.body)
                         .lineLimit(1)
@@ -8036,7 +8059,7 @@ public struct MCPSearchRemindersSnippetView: View {
     public var body: some View {
         VStack(alignment: .leading, spacing: 4) {
             ForEach(data.reminders, id: \.id) { row in
-                Button(intent: _mkReadReminderIntent(id: row.id)) {
+                Button(intent: _mkReadReminderIntent_id(id: row.id)) {
                     Text(row.name)
                         .font(.body)
                         .lineLimit(1)
@@ -8142,7 +8165,7 @@ public struct MCPTodayEventsSnippetView: View {
     public var body: some View {
         VStack(alignment: .leading, spacing: 4) {
             ForEach(data.events, id: \.id) { row in
-                Button(intent: _mkReadEventIntent(id: row.id)) {
+                Button(intent: _mkReadEventIntent_id(id: row.id)) {
                     Text(row.summary)
                         .font(.body)
                         .lineLimit(1)


### PR DESCRIPTION
## Summary

Extends A.4.3 follow-up tap coverage from 10 → 13 list tools. Adds \`list_messages\`, \`list_chats\`, \`search_chats\` as tappable snippet surfaces. Stacked on [#121](https://github.com/heznpc/AirMCP/pull/121).

| list tool | → follow-up | itemField | targetParam | notes |
|---|---|---|---|---|
| \`list_messages\` | \`read_message\` | \`id\` | \`id\` | clean match |
| \`list_chats\` | \`read_chat\` | \`id\` | **\`chatId\`** | param rename |
| \`search_chats\` | \`read_chat\` | \`id\` | **\`chatId\`** | param rename |

## Generalization

The list_chats pairing required FOLLOW_UP_MAP to separate the list-output field from the target-tool @Parameter name:

\`\`\`js
// Before (A.4.3 initial)
list_events: { target: "read_event", idField: "id" },

// After
list_events: { target: "read_event", itemField: "id", targetParam: "id" },
list_chats:  { target: "read_chat",  itemField: "id", targetParam: "chatId" },
\`\`\`

Factory helpers keyed by \`(targetIntent, targetParam)\` so two list tools hitting the same target via different params each get their own helper:

\`\`\`swift
fileprivate func _mkReadEventIntent_id(id: String) -> ReadEventIntent { ... }
fileprivate func _mkReadChatIntent_chatId(chatId: String) -> ReadChatIntent { ... }
\`\`\`

## Side fixes

- **Nullable-union string schemas**: \`list_chats.name\` was declared \`type: ["string", "null"]\` — my primaryField picker missed it, so snippet rows rendered the raw UID instead of the chat name. Fixed by detecting both \`type: "string"\` and \`type: ["string", "null"]\`; optional primary fields emit with \`?? ""\` at the Text() call site.
- **\`isStringish\` undefined guard** — defensive after the above change.

## Sample output

\`\`\`swift
// Snippet view for: list_chats  (shape: list-object)
ForEach(data.chats, id: \.id) { row in
    Button(intent: _mkReadChatIntent_chatId(chatId: row.id)) {
        Text((row.name ?? ""))
            .font(.body).lineLimit(1)
    }.buttonStyle(.plain)
}
\`\`\`

## Test plan

- [x] \`npm run gen:intents\` — 229 intents, 13 follow-up wrapped snippets
- [x] \`swift build\` passes (3.5s)
- [x] \`gen:intents:check\` + golden-sample CI both green
- [x] Verified: chats renders \`row.name\` (not \`row.id\`), messages renders \`row.subject\`, events unchanged
- [x] Validator probe: FOLLOW_UP_MAP entry pointing at wrong targetParam → exits 2 with "target X has no @Parameter named Y"