### PR TITLE
ci: trigger CI on PRs to any base branch, not just main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,12 @@ name: CI
 on:
   push:
     branches: [main]
+  # Trigger on every PR regardless of base branch so stacked PRs
+  # (PR targeting another PR's branch — common with chained RFC work)
+  # get full CI feedback before the chain merges sequentially to main.
+  # Without this, only the stack's bottom PR shows checks, and later
+  # regressions only surface after each rebase onto main.
   pull_request:
-    branches: [main]
   workflow_call:
 
 permissions:


### PR DESCRIPTION
## Summary

Stacked PRs (PRs whose base is another open PR) currently get zero CI feedback because \`pull_request: branches: [main]\` filters them out. With the RFC 0007 chain spanning 10+ PRs stacked off main, only the bottom PR shows checks — regressions in later PRs only surface after each rebase onto main.

## Change

\`\`\`diff
 pull_request:
-  branches: [main]
\`\`\`

Every PR now runs CI regardless of base branch. \`push: branches: [main]\` still guards main-line automation from duplicate runs.

## Why now

The current RFC 0007 stack (#112-#123) demonstrates the exact problem: #112 and #113 (both targeting main) show green CI. #114-#123 (stacked) show "no checks reported" — not failing, just never triggered. This PR lands as a small independent change so the stack picks up CI feedback retroactively on next push.

## Test plan

- [x] YAML valid — no syntax change beyond removing the filter key
- [ ] Merge and observe #114-#123 start reporting checks on their next rebase push