### PR TITLE
test(rfc-0007): extract codegen helpers to lib + unit tests

### DIFF
--- a/scripts/gen-swift-intents.mjs
+++ b/scripts/gen-swift-intents.mjs
@@ -38,6 +38,29 @@
 import { readFileSync, writeFileSync, mkdirSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
+import {
+  swiftIdent,
+  toPascalCase,
+  intentStructName,
+  swiftLit,
+  humanizeKey,
+  enumCaseName as _enumCaseName,
+  enumCaseDisplayLabel,
+  enumTypeName,
+  intentActionNameFor,
+} from "./lib/codegen-helpers.mjs";
+
+// CLI wrapper: the lib throws on invalid enum value so tests can
+// assert the specific error, but the CLI wants the historic process.exit(2)
+// contract (caller expects "codegen failed, stop").
+function enumCaseName(value) {
+  try {
+    return _enumCaseName(value);
+  } catch (e) {
+    console.error(`[gen-intents] ${e.message}`);
+    process.exit(2);
+  }
+}
 
 const ROOT = fileURLToPath(new URL("..", import.meta.url));
 const MANIFEST_PATH = process.env.AIRMCP_INTENTS_MANIFEST ?? join(ROOT, "docs", "tool-manifest.json");
@@ -147,48 +170,11 @@ for (const name of APP_SHORTCUTS_TOP) {
 // strings wrap awkwardly.
 const MAX_TITLE_LEN = 80;
 
-function toPascalCase(snake) {
-  // Skills may arrive with dashes (e.g. `skill_focus-guardian`); Swift
-  // identifiers require alphanumeric only, so split on any non-word char.
-  return snake
-    .split(/[^a-zA-Z0-9]+/)
-    .filter(Boolean)
-    .map((part) => part.charAt(0).toUpperCase() + part.slice(1).toLowerCase())
-    .join("");
-}
-
-function intentStructName(toolName) {
-  // audit_log → AuditLogIntent; avoids collision with hand-written
-  // intents that live in app/Sources/AirMCPApp (different Swift module).
-  return `${toPascalCase(toolName)}Intent`;
-}
-
-/**
- * Pick a `ConfirmationActionName` literal for a destructive tool. Apple
- * only exposes `.go` and `.send` on this type as of iOS 26 (checked with
- * `swiftc -typecheck` — `.delete`/`.save` don't compile, and
- * `ConfirmationActionName` has no public initializers), so we map:
- *   send/reply/post → `.send` (renders as "Send")
- *   everything else → `.go`  (generic verb)
- *
- * The destructive semantic is carried by the dialog text ("This action
- * is destructive and cannot be undone"), not the button label. When
- * Apple widens the ConfirmationActionName case list this mapping can be
- * refined — nothing else in the codegen has to change.
- */
-function intentActionNameFor(toolName) {
-  if (/^(send|reply|post)_/.test(toolName)) return ".send";
-  return ".go";
-}
-
-/**
- * Swift-safe string literal for a LocalizedStringResource / description.
- * Escapes backslashes and double-quotes. Strips newlines to avoid breaking
- * the single-line literal form AppIntent accepts.
- */
-function swiftLit(s) {
-  return (s ?? "").replace(/\\/g, "\\\\").replace(/"/g, '\\"').replace(/\r?\n/g, " ").trim();
-}
+// toPascalCase, intentStructName, intentActionNameFor, swiftLit,
+// humanizeKey, enumCaseDisplayLabel, enumTypeName, swiftIdent,
+// SWIFT_RESERVED are imported from scripts/lib/codegen-helpers.mjs.
+// `enumCaseName` is the top-of-file CLI wrapper that converts the
+// library's thrown error into process.exit(2).
 
 /**
  * Pick the Swift type for a JSON-Schema property.
@@ -211,35 +197,8 @@ function swiftTypeFor(propSchema) {
   return null;
 }
 
-/**
- * Swift identifier for an enum case value. JSON-Schema enum values we
- * currently carry are all pure [A-Za-z_][A-Za-z0-9_]* (verified via the
- * manifest), so this is a passthrough — the validator below hard-exits
- * if a future manifest slips in something like "next-track". Avoiding
- * automatic kebab→camel on the fly keeps the wire contract obvious: the
- * case name equals the JSON value.
- */
-function enumCaseName(value) {
-  if (!/^[a-zA-Z_][a-zA-Z0-9_]*$/.test(value)) {
-    console.error(`[gen-intents] enum value "${value}" is not a safe Swift identifier`);
-    process.exit(2);
-  }
-  // Swift reserved words — unlikely but keep the same escape hatch as swiftIdent.
-  return SWIFT_RESERVED.has(value) ? `${value}_` : value;
-}
-
-/**
- * Human-readable display label for an enum case, shown in the Shortcuts
- * picker. "nextTrack" → "Next Track", "selection" → "Selection".
- */
-function enumCaseDisplayLabel(value) {
-  const spaced = value.replace(/([a-z])([A-Z])/g, "$1 $2");
-  return spaced.charAt(0).toUpperCase() + spaced.slice(1);
-}
-
-function enumTypeName(toolName, paramName) {
-  return `${toPascalCase(toolName)}${toPascalCase(paramName)}Option`;
-}
+// enumCaseName (CLI wrapper at top), enumCaseDisplayLabel, enumTypeName
+// imported from scripts/lib/codegen-helpers.mjs.
 
 /**
  * Scan every picked tool's input schema and collect string enums. Returns
@@ -392,39 +351,7 @@ function buildArgsBlock(decls) {
   return { prelude: lines.map((l) => `        ${l}`).join("\n"), argsExpr: "args" };
 }
 
-/**
- * Swift identifiers can't use `default`, `class`, `init`, etc. Map any
- * collision to a `_`-suffixed name; the JSON-Schema property name stays
- * the wire contract, the Swift variable just dodges the keyword.
- */
-const SWIFT_RESERVED = new Set([
-  "default",
-  "class",
-  "struct",
-  "init",
-  "public",
-  "private",
-  "extension",
-  "import",
-  "static",
-  "return",
-  "self",
-  "func",
-  "case",
-  "switch",
-  "if",
-  "else",
-  "for",
-  "while",
-  "in",
-  "where",
-  "operator",
-  "protocol",
-  "typealias",
-]);
-function swiftIdent(name) {
-  return SWIFT_RESERVED.has(name) ? `${name}_` : name;
-}
+// SWIFT_RESERVED, swiftIdent imported from scripts/lib/codegen-helpers.mjs.
 
 // ── outputSchema → Swift Codable (A.2b.2) ────────────────────────────
 //
@@ -819,20 +746,7 @@ const FOLLOW_UP_MAP = {
   search_chats: { target: "read_chat", itemField: "id", targetParam: "chatId" },
 };
 
-/**
- * Humanize a camelCase / snake_case property name into a display label.
- * "stepsToday" → "Steps Today", "sleep_hours" → "Sleep Hours".
- */
-function humanizeKey(key) {
-  const spaced = key
-    .replace(/([a-z])([A-Z])/g, "$1 $2")
-    .replace(/[_-]+/g, " ")
-    .trim();
-  return spaced
-    .split(/\s+/)
-    .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
-    .join(" ");
-}
+// humanizeKey imported from scripts/lib/codegen-helpers.mjs.
 
 /**
  * Render one row of the scalar snippet view VStack. Value rendering is

--- a/scripts/lib/codegen-helpers.mjs
+++ b/scripts/lib/codegen-helpers.mjs
@@ -1,0 +1,121 @@
+// RFC 0007 Swift codegen — pure helper functions.
+//
+// Extracted from scripts/gen-swift-intents.mjs so they can be
+// exercised by unit tests (see tests/codegen-helpers.test.js)
+// without spinning up the full manifest → codegen pipeline. Every
+// function here is input → output with no I/O, no process.env read,
+// no filesystem access.
+//
+// Keeping these in a shared module also prepares the ground for a
+// future split of gen-swift-intents.mjs into focused files — that
+// refactor is deferred until the RFC 0007 stack merges (see the
+// PR chain 112 → 123).
+
+// Swift reserved words — Swift identifiers can't use `default`,
+// `class`, `init`, etc. Map any collision to a `_`-suffixed name;
+// the JSON-Schema property name stays the wire contract, the Swift
+// variable just dodges the keyword.
+export const SWIFT_RESERVED = new Set([
+  "default",
+  "class",
+  "struct",
+  "init",
+  "public",
+  "private",
+  "extension",
+  "import",
+  "static",
+  "return",
+  "self",
+  "func",
+  "case",
+  "switch",
+  "if",
+  "else",
+  "for",
+  "while",
+  "in",
+  "where",
+  "operator",
+  "protocol",
+  "typealias",
+]);
+
+export function swiftIdent(name) {
+  return SWIFT_RESERVED.has(name) ? `${name}_` : name;
+}
+
+// snake_case / kebab-case / mixed → PascalCase. Skills may arrive
+// with dashes (e.g. `skill_focus-guardian`); Swift identifiers
+// require alphanumeric only, so split on any non-word char.
+export function toPascalCase(snake) {
+  return snake
+    .split(/[^a-zA-Z0-9]+/)
+    .filter(Boolean)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1).toLowerCase())
+    .join("");
+}
+
+// audit_log → AuditLogIntent. Avoids collision with hand-written
+// intents that live in app/Sources/AirMCPApp (different Swift module).
+export function intentStructName(toolName) {
+  return `${toPascalCase(toolName)}Intent`;
+}
+
+// Swift-safe string literal for a LocalizedStringResource /
+// description. Escapes backslashes and double-quotes. Strips newlines
+// to avoid breaking the single-line literal form AppIntent accepts.
+export function swiftLit(s) {
+  return (s ?? "").replace(/\\/g, "\\\\").replace(/"/g, '\\"').replace(/\r?\n/g, " ").trim();
+}
+
+// Humanize a camelCase / snake_case property name into a display
+// label. "stepsToday" → "Steps Today", "sleep_hours" → "Sleep Hours".
+export function humanizeKey(key) {
+  const spaced = key
+    .replace(/([a-z])([A-Z])/g, "$1 $2")
+    .replace(/[_-]+/g, " ")
+    .trim();
+  return spaced
+    .split(/\s+/)
+    .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+    .join(" ");
+}
+
+// Swift identifier for an enum case value. JSON-Schema enum values
+// we currently carry are all pure [A-Za-z_][A-Za-z0-9_]* (verified
+// via the manifest). Non-identifier-safe values throw — this forces
+// a future manifest slip to surface at codegen time, not as Swift
+// compile errors.
+export function enumCaseName(value) {
+  if (!/^[a-zA-Z_][a-zA-Z0-9_]*$/.test(value)) {
+    throw new Error(`enum value "${value}" is not a safe Swift identifier`);
+  }
+  return SWIFT_RESERVED.has(value) ? `${value}_` : value;
+}
+
+// Human-readable display label for an enum case, shown in the
+// Shortcuts picker. "nextTrack" → "Next Track", "selection" →
+// "Selection".
+export function enumCaseDisplayLabel(value) {
+  const spaced = value.replace(/([a-z])([A-Z])/g, "$1 $2");
+  return spaced.charAt(0).toUpperCase() + spaced.slice(1);
+}
+
+// Per-tool, per-param AppEnum type name. Using a tool-scoped name
+// avoids cross-tool collision when two tools define the same param
+// name with different enum value sets.
+export function enumTypeName(toolName, paramName) {
+  return `${toPascalCase(toolName)}${toPascalCase(paramName)}Option`;
+}
+
+// Pick a `ConfirmationActionName` literal for a destructive tool.
+// Apple only exposes `.go` and `.send` on this type as of iOS 26
+// (checked with `swiftc -typecheck` — `.delete`/`.save` don't compile,
+// and `ConfirmationActionName` has no public initializers), so we map:
+//   send/reply/post → `.send` (renders as "Send")
+//   everything else → `.go`  (generic verb)
+export function intentActionNameFor(toolName) {
+  if (/^(send|reply|post)_/.test(toolName)) return ".send";
+  return ".go";
+}

--- a/tests/codegen-helpers.test.js
+++ b/tests/codegen-helpers.test.js
@@ -1,0 +1,199 @@
+// scripts/lib/codegen-helpers.mjs — unit tests.
+//
+// The helpers here drive every AppIntent struct name, parameter
+// label, enum case name, and Shortcuts display string the Swift
+// codegen emits. Output drift is already caught by gen:intents:check
+// in CI, but a pure-function test at this layer fails faster + gives
+// a specific error message when someone tweaks a helper without
+// realising it also changes the wire-facing struct name for all 229
+// intents.
+
+import { describe, test, expect } from "@jest/globals";
+import {
+  SWIFT_RESERVED,
+  swiftIdent,
+  toPascalCase,
+  intentStructName,
+  swiftLit,
+  humanizeKey,
+  enumCaseName,
+  enumCaseDisplayLabel,
+  enumTypeName,
+  intentActionNameFor,
+} from "../scripts/lib/codegen-helpers.mjs";
+
+describe("toPascalCase", () => {
+  test("snake_case joins without underscore", () => {
+    expect(toPascalCase("audit_log")).toBe("AuditLog");
+    expect(toPascalCase("list_events")).toBe("ListEvents");
+    expect(toPascalCase("today_events")).toBe("TodayEvents");
+  });
+
+  test("single-word stays title-cased", () => {
+    expect(toPascalCase("doctor")).toBe("Doctor");
+    expect(toPascalCase("SCREAMING")).toBe("Screaming");
+  });
+
+  test("non-word separators split (skill_focus-guardian → SkillFocusGuardian)", () => {
+    expect(toPascalCase("skill_focus-guardian")).toBe("SkillFocusGuardian");
+    expect(toPascalCase("gws.calendar.create")).toBe("GwsCalendarCreate");
+  });
+
+  test("digits preserved", () => {
+    expect(toPascalCase("rfc_0007_intent")).toBe("Rfc0007Intent");
+  });
+
+  test("empty string → empty string", () => {
+    expect(toPascalCase("")).toBe("");
+  });
+});
+
+describe("intentStructName", () => {
+  test("wraps toPascalCase with Intent suffix", () => {
+    expect(intentStructName("list_events")).toBe("ListEventsIntent");
+    expect(intentStructName("read_note")).toBe("ReadNoteIntent");
+    expect(intentStructName("playback_control")).toBe("PlaybackControlIntent");
+  });
+});
+
+describe("swiftIdent", () => {
+  test("passes non-reserved names through", () => {
+    expect(swiftIdent("id")).toBe("id");
+    expect(swiftIdent("chatId")).toBe("chatId");
+    expect(swiftIdent("startDate")).toBe("startDate");
+  });
+
+  test("suffixes reserved words with _", () => {
+    expect(swiftIdent("default")).toBe("default_");
+    expect(swiftIdent("class")).toBe("class_");
+    expect(swiftIdent("case")).toBe("case_");
+    expect(swiftIdent("switch")).toBe("switch_");
+    expect(swiftIdent("in")).toBe("in_");
+  });
+
+  test("SWIFT_RESERVED contains expected core keywords", () => {
+    // Spot-check the set — if any of these disappear a wire-contract
+    // change slipped in.
+    expect(SWIFT_RESERVED.has("default")).toBe(true);
+    expect(SWIFT_RESERVED.has("case")).toBe(true);
+    expect(SWIFT_RESERVED.has("func")).toBe(true);
+    expect(SWIFT_RESERVED.has("typealias")).toBe(true);
+  });
+});
+
+describe("swiftLit", () => {
+  test("escapes backslashes and double-quotes", () => {
+    expect(swiftLit('say "hi"')).toBe('say \\"hi\\"');
+    expect(swiftLit("path\\with\\backslash")).toBe("path\\\\with\\\\backslash");
+  });
+
+  test("strips newlines (single-line literal form)", () => {
+    expect(swiftLit("line 1\nline 2")).toBe("line 1 line 2");
+    expect(swiftLit("line 1\r\nline 2")).toBe("line 1 line 2");
+  });
+
+  test("trims surrounding whitespace", () => {
+    expect(swiftLit("  padded  ")).toBe("padded");
+  });
+
+  test("handles null / undefined without throwing", () => {
+    expect(swiftLit(null)).toBe("");
+    expect(swiftLit(undefined)).toBe("");
+  });
+});
+
+describe("humanizeKey", () => {
+  test("camelCase → spaced title case", () => {
+    expect(humanizeKey("stepsToday")).toBe("Steps Today");
+    expect(humanizeKey("sleepHoursLastNight")).toBe("Sleep Hours Last Night");
+    expect(humanizeKey("id")).toBe("Id");
+  });
+
+  test("snake_case → spaced title case", () => {
+    expect(humanizeKey("sleep_hours")).toBe("Sleep Hours");
+    expect(humanizeKey("heart_rate_avg_7d")).toBe("Heart Rate Avg 7d");
+  });
+
+  test("kebab-case → spaced title case", () => {
+    expect(humanizeKey("next-track")).toBe("Next Track");
+  });
+
+  test("single words stay title-cased", () => {
+    expect(humanizeKey("temperature")).toBe("Temperature");
+  });
+});
+
+describe("enumCaseName", () => {
+  test("passes identifier-safe values through", () => {
+    expect(enumCaseName("play")).toBe("play");
+    expect(enumCaseName("nextTrack")).toBe("nextTrack");
+    expect(enumCaseName("ok")).toBe("ok");
+    expect(enumCaseName("AXConfirm")).toBe("AXConfirm");
+  });
+
+  test("reserved words get _ suffix", () => {
+    expect(enumCaseName("default")).toBe("default_");
+  });
+
+  test("throws on identifier-unsafe values", () => {
+    expect(() => enumCaseName("next-track")).toThrow(/not a safe Swift identifier/);
+    expect(() => enumCaseName("2fast")).toThrow(/not a safe Swift identifier/);
+    expect(() => enumCaseName("with space")).toThrow(/not a safe Swift identifier/);
+    expect(() => enumCaseName("")).toThrow(/not a safe Swift identifier/);
+  });
+});
+
+describe("enumCaseDisplayLabel", () => {
+  test("camelCase → title-cased with spaces", () => {
+    expect(enumCaseDisplayLabel("nextTrack")).toBe("Next Track");
+    expect(enumCaseDisplayLabel("previousTrack")).toBe("Previous Track");
+  });
+
+  test("single-word values get first letter capitalised", () => {
+    expect(enumCaseDisplayLabel("play")).toBe("Play");
+    expect(enumCaseDisplayLabel("selection")).toBe("Selection");
+    expect(enumCaseDisplayLabel("ok")).toBe("Ok");
+  });
+
+  test("preserves acronym boundaries (AXConfirm stays readable)", () => {
+    // Only splits on lowercase-uppercase boundary. AXConfirm has no
+    // such boundary at the start, so it stays as "AXConfirm" with
+    // first letter already uppercase.
+    expect(enumCaseDisplayLabel("AXConfirm")).toBe("AXConfirm");
+  });
+});
+
+describe("enumTypeName", () => {
+  test("tool + param combined into scoped name", () => {
+    expect(enumTypeName("playback_control", "action")).toBe("PlaybackControlActionOption");
+    expect(enumTypeName("memory_query", "kind")).toBe("MemoryQueryKindOption");
+  });
+
+  test("avoids collision when two tools share a param name", () => {
+    expect(enumTypeName("memory_put", "kind")).toBe("MemoryPutKindOption");
+    expect(enumTypeName("memory_query", "kind")).toBe("MemoryQueryKindOption");
+    expect(enumTypeName("memory_put", "kind")).not.toBe(enumTypeName("memory_query", "kind"));
+  });
+});
+
+describe("intentActionNameFor", () => {
+  test("send_* / reply_* / post_* → .send", () => {
+    expect(intentActionNameFor("send_mail")).toBe(".send");
+    expect(intentActionNameFor("send_message")).toBe(".send");
+    expect(intentActionNameFor("reply_mail")).toBe(".send");
+    expect(intentActionNameFor("post_status")).toBe(".send");
+  });
+
+  test("everything else → .go (ConfirmationActionName limitation)", () => {
+    expect(intentActionNameFor("delete_event")).toBe(".go");
+    expect(intentActionNameFor("trash_file")).toBe(".go");
+    expect(intentActionNameFor("update_reminder")).toBe(".go");
+    expect(intentActionNameFor("system_power")).toBe(".go");
+    expect(intentActionNameFor("quit_app")).toBe(".go");
+  });
+
+  test("non-destructive names also map (function is only called on destructive, but mapping is pure)", () => {
+    expect(intentActionNameFor("list_events")).toBe(".go");
+    expect(intentActionNameFor("read_note")).toBe(".go");
+  });
+});


### PR DESCRIPTION
## Summary

The pure helpers that drive every AppIntent struct name, parameter label, enum case, and Shortcuts display string in the generated Swift file move to [\`scripts/lib/codegen-helpers.mjs\`](scripts/lib/codegen-helpers.mjs) so they can be unit-tested in Node without the full manifest → codegen pipeline.

Stacked on [#125](https://github.com/heznpc/heznpc/AirMCP/pull/125) (docs refresh).

## Extracted helpers

All pure, no I/O:

| Helper | Drives |
|---|---|
| \`toPascalCase\` | Every struct/type name (\`ListEventsIntent\`, \`ListEventsActionOption\`) |
| \`intentStructName\` | \`Read<Foo>Intent\` wire name |
| \`swiftIdent\` + \`SWIFT_RESERVED\` | \`@Parameter\` variable names that dodge Swift keywords |
| \`swiftLit\` | Escaping for every \`LocalizedStringResource\` + \`IntentDescription\` |
| \`humanizeKey\` | Scalar snippet view labels ("stepsToday" → "Steps Today") |
| \`enumCaseName\` / \`enumCaseDisplayLabel\` / \`enumTypeName\` | AppEnum codegen (17 enums across 16 tools) |
| \`intentActionNameFor\` | Destructive tool \`requestConfirmation(actionName:)\` verb |

[gen-swift-intents.mjs](scripts/gen-swift-intents.mjs) imports them instead of defining locally.

## CLI bridge for \`enumCaseName\`

The library version throws on invalid identifiers so tests can assert the exact error, but the CLI wants the historic \`process.exit(2)\` contract. A 10-line top-of-file wrapper bridges the two:

\`\`\`js
function enumCaseName(value) {
  try {
    return _enumCaseName(value);
  } catch (e) {
    console.error(\`[gen-intents] \${e.message}\`);
    process.exit(2);
  }
}
\`\`\`

## Test coverage (28 cases)

- \`toPascalCase\` across snake_case / kebab / digits / empty
- \`intentStructName\` composition
- \`swiftIdent\` reserved-word suffix rule + \`SWIFT_RESERVED\` spot-checks
- \`swiftLit\` quote / backslash / newline handling + \`null\` safety
- \`humanizeKey\` across camel / snake / kebab boundaries
- \`enumCaseName\` throws on \`"next-track"\`, \`"2fast"\`, \`"with space"\`, \`""\`
- \`enumCaseDisplayLabel\` for camelCase + single-word + AX-prefix acronyms
- \`enumTypeName\` collision avoidance between tools sharing a param name
- \`intentActionNameFor\` send/reply/post → \`.send\`, rest → \`.go\`

## Why

Output drift is already caught by \`gen:intents:check\` in CI. This layer fails faster with a specific helper-level error message when someone tweaks a helper without realising it also shifts the wire-facing name for all 229 intents.

Also a first, small step toward the deferred gen-swift-intents.mjs split — the pure helpers now live in a dedicated file so the larger refactor PR after the stack merges has less to move.

## Test plan

- [x] \`npm test -- tests/codegen-helpers.test.js\` → 28 passed
- [x] \`npm run gen:intents:check\` — output byte-stable after refactor (229 intents)
- [x] \`swift build\` passes