### PR TITLE
test(rfc-0007): expand codegen helper coverage to 66 cases

### DIFF
--- a/scripts/gen-swift-intents.mjs
+++ b/scripts/gen-swift-intents.mjs
@@ -48,6 +48,16 @@ import {
   enumCaseDisplayLabel,
   enumTypeName,
   intentActionNameFor,
+  swiftTypeFor,
+  swiftDefaultLiteral,
+  enumDefaultLiteral,
+  wireExpr,
+  isNullableUnion,
+  nonNullType,
+  outputTypeNameFor,
+  snippetViewNameFor,
+  detectSnippetShape,
+  systemImageFor,
 } from "./lib/codegen-helpers.mjs";
 
 // CLI wrapper: the lib throws on invalid enum value so tests can
@@ -176,29 +186,9 @@ const MAX_TITLE_LEN = 80;
 // `enumCaseName` is the top-of-file CLI wrapper that converts the
 // library's thrown error into process.exit(2).
 
-/**
- * Pick the Swift type for a JSON-Schema property.
- * Returns null if the type isn't representable as a single @Parameter.
- *
- * String enums are handled at `generateIntent` time (collectEnums),
- * not here — this function sees the primitive only. If the caller
- * knows a param maps to an `AppEnum`, it overrides `baseType` after
- * calling.
- */
-function swiftTypeFor(propSchema) {
-  if (propSchema.type === "string") {
-    if (propSchema.format === "date-time") return "Date";
-    return "String";
-  }
-  if (propSchema.type === "integer") return "Int";
-  if (propSchema.type === "number") return "Double";
-  if (propSchema.type === "boolean") return "Bool";
-  if (propSchema.type === "array" && propSchema.items?.type === "string") return "[String]";
-  return null;
-}
-
+// swiftTypeFor imported from scripts/lib/codegen-helpers.mjs.
 // enumCaseName (CLI wrapper at top), enumCaseDisplayLabel, enumTypeName
-// imported from scripts/lib/codegen-helpers.mjs.
+// also imported from there.
 
 /**
  * Scan every picked tool's input schema and collect string enums. Returns
@@ -248,18 +238,7 @@ ${caseMap}
 }`;
 }
 
-/**
- * Format a JSON-Schema `default` value as a Swift literal suitable for
- * `@Parameter(default: ...)`. Returns null when the default is absent or
- * doesn't match the target type — caller drops the `default:` clause.
- */
-function swiftDefaultLiteral(value, baseType) {
-  if (value === undefined) return null;
-  if ((baseType === "Int" || baseType === "Double") && typeof value === "number") return String(value);
-  if (baseType === "Bool" && typeof value === "boolean") return String(value);
-  if (baseType === "String" && typeof value === "string") return `"${swiftLit(value)}"`;
-  return null;
-}
+// swiftDefaultLiteral imported from scripts/lib/codegen-helpers.mjs.
 
 /**
  * Map a JSON-Schema property to a Swift `@Parameter` declaration.
@@ -304,21 +283,7 @@ function swiftParamDecl(propName, propSchema, isRequired, enumTypeOverride) {
   return `    @Parameter(${optsParts.join(", ")})\n    public var ${propName}: ${typeName}`;
 }
 
-function enumDefaultLiteral(value, enumValues) {
-  if (typeof value !== "string" || !enumValues?.includes(value)) return null;
-  return `.${enumCaseName(value)}`;
-}
-
-/**
- * Render `varName` as the Swift expression the wire accepts for this
- * param's type (Date → ISO-8601 string, AppEnum → .rawValue, else
- * identity). Keeps the required-path and optional-path of
- * `buildArgsBlock` from duplicating the special-cases.
- */
-function wireExpr(type, varName, isEnum) {
-  if (isEnum) return `${varName}.rawValue`;
-  return type === "Date" ? `ISO8601DateFormatter().string(from: ${varName})` : varName;
-}
+// enumDefaultLiteral, wireExpr imported from scripts/lib/codegen-helpers.mjs.
 
 /**
  * Emit the Swift statements that build the `args` dict for a router call.
@@ -373,14 +338,7 @@ function buildArgsBlock(decls) {
 // Everything else (oneOf, allOf, recursive refs) would require AnyCodable
 // or more elaborate machinery — out of A.2b.2 scope.
 
-function isNullableUnion(schema) {
-  if (!Array.isArray(schema.type)) return false;
-  return schema.type.length === 2 && schema.type.includes("null");
-}
-
-function nonNullType(schema) {
-  return schema.type.find((t) => t !== "null");
-}
+// isNullableUnion, nonNullType imported from scripts/lib/codegen-helpers.mjs.
 
 function isCodableSafe(schema) {
   if (!schema || typeof schema !== "object") return true;
@@ -481,14 +439,7 @@ ${body}
 ${indent.slice(4)}}`;
 }
 
-function outputTypeNameFor(tool) {
-  // Prefix avoids collisions with existing hand-written types in
-  // AirMCPKit (e.g. EventKitService.swift already declares
-  // TodayEventsOutput / SearchEventsOutput / SearchRemindersOutput
-  // as native EventKit-backed shapes). Generated types are a separate
-  // transport layer, not the EventKit-native one.
-  return `MCP${toPascalCase(tool.name)}Output`;
-}
+// outputTypeNameFor imported from scripts/lib/codegen-helpers.mjs.
 
 /**
  * Does this tool ship A.2b.2-level typed output? Requires:
@@ -617,33 +568,14 @@ ${tailBlock}
 }`;
 }
 
+// SYSTEM_IMAGE_BY_PREFIX, systemImageFor imported from scripts/lib/codegen-helpers.mjs.
+
 /**
  * Emit the single AppShortcutsProvider block. Apple caps this at 10.
  * Each phrase uses `\(.applicationName)` so the trigger reads naturally
  * ("list calendars in AirMCP"). systemImage is a stable SF Symbol per
  * tool family — conservative choices that compile against iOS 17+.
  */
-const SYSTEM_IMAGE_BY_PREFIX = [
-  [/^(list|search)_events|today_events|get_upcoming_events/, "calendar"],
-  [/^list_calendars/, "calendar.badge.plus"],
-  [/^(list|search|read)_notes|list_folders/, "note.text"],
-  [/^(list|search|read)_reminders|list_reminder_lists/, "checklist"],
-  [/^(list|search|read)_contacts|list_groups|list_group_members/, "person.crop.circle"],
-  [/^list_accounts|list_messages/, "envelope"],
-  [/^list_chats|list_participants/, "message"],
-  [/^list_shortcuts|search_shortcuts|get_shortcut_detail/, "square.stack.3d.up"],
-  [/^list_bookmarks|list_reading_list|list_tabs/, "safari"],
-  [/^get_current_weather|get_daily_forecast|get_hourly_forecast/, "cloud.sun"],
-  [/^summarize_context|proactive_context/, "sparkles"],
-  [/^recent_files|list_directory|search_files|get_file_info/, "folder"],
-];
-function systemImageFor(toolName) {
-  for (const [re, img] of SYSTEM_IMAGE_BY_PREFIX) {
-    if (re.test(toolName)) return img;
-  }
-  return "app.connected.to.app.below.fill";
-}
-
 function generateAppShortcuts() {
   const toolEntries = appShortcutsPicks.map((tool) => {
     const structName = intentStructName(tool.name);
@@ -798,39 +730,7 @@ function renderScalarRow(key, propSchema) {
             }`;
 }
 
-function detectSnippetShape(schema) {
-  const props = schema.properties ?? {};
-  const keys = Object.keys(props);
-  const arrayKeys = keys.filter((k) => props[k].type === "array");
-  if (arrayKeys.length === 1) {
-    const arrayKey = arrayKeys[0];
-    const items = props[arrayKey].items ?? {};
-    if (items.type === "object") {
-      const itemProps = items.properties ?? {};
-      // Prefer a non-id string field for display so list rows show the
-      // human label (summary / name / title) rather than the raw UID.
-      // Fall back to `id` if nothing else is stringly typed — the row
-      // still renders, just less prettily.
-      //
-      // Schemas may declare `type: ["string", "null"]` for optional
-      // fields; treat those the same as plain strings when picking a
-      // display field. The snippet view handles nil via the Codable
-      // struct's Optional<String> type, so rendering the Optional with
-      // `?? ""` is covered at the SwiftUI layer.
-      const isStringish = (p) =>
-        p != null && (p.type === "string" || (Array.isArray(p.type) && p.type.includes("string")));
-      const stringKeys = Object.keys(itemProps).filter((k) => isStringish(itemProps[k]));
-      const primaryField = stringKeys.find((k) => k !== "id") ?? stringKeys[0] ?? null;
-      const primaryFieldOptional = primaryField ? Array.isArray(itemProps[primaryField].type) : false;
-      const hasId = isStringish(itemProps.id);
-      return { shape: "list-object", arrayField: arrayKey, primaryField, primaryFieldOptional, hasId };
-    }
-    if (items.type === "string") {
-      return { shape: "list-string", arrayField: arrayKey };
-    }
-  }
-  return { shape: "scalar" };
-}
+// detectSnippetShape imported from scripts/lib/codegen-helpers.mjs.
 
 // Validate FOLLOW_UP_MAP against the manifest so a typo or removed tool
 // surfaces at codegen time rather than as a SwiftUI compile error. Also
@@ -890,9 +790,7 @@ const followUpFactorySpecs = Array.from(
   ).values(),
 );
 
-function snippetViewNameFor(tool) {
-  return `MCP${toPascalCase(tool.name)}SnippetView`;
-}
+// snippetViewNameFor imported from scripts/lib/codegen-helpers.mjs.
 
 function renderSnippetView(tool) {
   const viewName = snippetViewNameFor(tool);

--- a/scripts/lib/codegen-helpers.mjs
+++ b/scripts/lib/codegen-helpers.mjs
@@ -119,3 +119,140 @@ export function intentActionNameFor(toolName) {
   if (/^(send|reply|post)_/.test(toolName)) return ".send";
   return ".go";
 }
+
+// ── JSON-Schema type mapping ───────────────────────────────────────────
+
+// Pick the Swift type for a JSON-Schema property. Returns null if the
+// type isn't representable as a single @Parameter (callers silently
+// drop such properties from intent codegen). String enums are handled
+// at generateIntent time via `collectEnums` — this function sees the
+// primitive only.
+export function swiftTypeFor(propSchema) {
+  if (propSchema.type === "string") {
+    if (propSchema.format === "date-time") return "Date";
+    return "String";
+  }
+  if (propSchema.type === "integer") return "Int";
+  if (propSchema.type === "number") return "Double";
+  if (propSchema.type === "boolean") return "Bool";
+  if (propSchema.type === "array" && propSchema.items?.type === "string") return "[String]";
+  return null;
+}
+
+// Format a JSON-Schema `default` value as a Swift literal suitable for
+// `@Parameter(default: ...)`. Returns null when the default is absent
+// or doesn't match the target type — caller drops the `default:` clause.
+export function swiftDefaultLiteral(value, baseType) {
+  if (value === undefined) return null;
+  if ((baseType === "Int" || baseType === "Double") && typeof value === "number") return String(value);
+  if (baseType === "Bool" && typeof value === "boolean") return String(value);
+  if (baseType === "String" && typeof value === "string") return `"${swiftLit(value)}"`;
+  return null;
+}
+
+// Format a JSON-Schema `default` value for an AppEnum-backed param.
+// Returns `.caseName` or null if the value isn't one of the declared
+// enum values (in which case the generator drops the `default:` clause).
+export function enumDefaultLiteral(value, enumValues) {
+  if (typeof value !== "string" || !enumValues?.includes(value)) return null;
+  return `.${enumCaseName(value)}`;
+}
+
+// Render `varName` as the Swift expression the wire accepts for this
+// param's type. Date → ISO 8601 string. AppEnum → `.rawValue`.
+// Everything else → identity.
+export function wireExpr(type, varName, isEnum) {
+  if (isEnum) return `${varName}.rawValue`;
+  return type === "Date" ? `ISO8601DateFormatter().string(from: ${varName})` : varName;
+}
+
+// JSON Schema supports nullable via `type: ["string", "null"]` — we
+// treat anything matching that shape as optional. Alternate null
+// encodings (anyOf, oneOf) need explicit support if they ever appear
+// in the manifest.
+export function isNullableUnion(schema) {
+  if (!schema || !Array.isArray(schema.type)) return false;
+  return schema.type.length === 2 && schema.type.includes("null");
+}
+
+export function nonNullType(schema) {
+  if (!schema || !Array.isArray(schema.type)) return null;
+  return schema.type.find((t) => t !== "null");
+}
+
+// ── Naming helpers for generated Swift types ───────────────────────────
+
+// Codable output struct name: `list_events` → `MCPListEventsOutput`.
+// Prefix avoids collision with hand-written types in AirMCPKit
+// (EventKitService.swift declares `TodayEventsOutput` etc. as separate
+// EventKit-backed shapes).
+export function outputTypeNameFor(tool) {
+  return `MCP${toPascalCase(tool.name)}Output`;
+}
+
+// SwiftUI snippet view name: `list_events` → `MCPListEventsSnippetView`.
+export function snippetViewNameFor(tool) {
+  return `MCP${toPascalCase(tool.name)}SnippetView`;
+}
+
+// ── Snippet shape detection ────────────────────────────────────────────
+
+// Decide how a tool's outputSchema renders as an Interactive Snippet.
+// Three shapes:
+//   • list-object: exactly one `type: array` property whose items are
+//     objects. Row rendering uses the first non-`id` string field for
+//     display; optional primary fields (`type: ["string", "null"]`)
+//     render with `?? ""`.
+//   • list-string: exactly one `type: array` of strings.
+//   • scalar: everything else — key/value row per top-level field.
+export function detectSnippetShape(schema) {
+  const props = schema?.properties ?? {};
+  const arrayKeys = Object.keys(props).filter((k) => props[k].type === "array");
+  if (arrayKeys.length === 1) {
+    const arrayKey = arrayKeys[0];
+    const items = props[arrayKey].items ?? {};
+    if (items.type === "object") {
+      const itemProps = items.properties ?? {};
+      // `type: "string"` and `type: ["string", "null"]` both count.
+      const isStringish = (p) =>
+        p != null && (p.type === "string" || (Array.isArray(p.type) && p.type.includes("string")));
+      const stringKeys = Object.keys(itemProps).filter((k) => isStringish(itemProps[k]));
+      const primaryField = stringKeys.find((k) => k !== "id") ?? stringKeys[0] ?? null;
+      const primaryFieldOptional = primaryField ? Array.isArray(itemProps[primaryField].type) : false;
+      const hasId = isStringish(itemProps.id);
+      return { shape: "list-object", arrayField: arrayKey, primaryField, primaryFieldOptional, hasId };
+    }
+    if (items.type === "string") {
+      return { shape: "list-string", arrayField: arrayKey };
+    }
+  }
+  return { shape: "scalar" };
+}
+
+// ── AppShortcutsProvider SF Symbol mapping ─────────────────────────────
+
+// Regex-prefix → SF Symbol for the AppShortcutsProvider's `systemImageName`.
+// Conservative picks that compile against iOS 17+. Order matters — the
+// first match wins, so specific patterns (list_calendars) come before
+// fuzzier catch-alls.
+export const SYSTEM_IMAGE_BY_PREFIX = [
+  [/^(list|search)_events|today_events|get_upcoming_events/, "calendar"],
+  [/^list_calendars/, "calendar.badge.plus"],
+  [/^(list|search|read)_notes|list_folders/, "note.text"],
+  [/^(list|search|read)_reminders|list_reminder_lists/, "checklist"],
+  [/^(list|search|read)_contacts|list_groups|list_group_members/, "person.crop.circle"],
+  [/^list_accounts|list_messages/, "envelope"],
+  [/^list_chats|list_participants/, "message"],
+  [/^list_shortcuts|search_shortcuts|get_shortcut_detail/, "square.stack.3d.up"],
+  [/^list_bookmarks|list_reading_list|list_tabs/, "safari"],
+  [/^get_current_weather|get_daily_forecast|get_hourly_forecast/, "cloud.sun"],
+  [/^summarize_context|proactive_context/, "sparkles"],
+  [/^recent_files|list_directory|search_files|get_file_info/, "folder"],
+];
+
+export function systemImageFor(toolName) {
+  for (const [re, img] of SYSTEM_IMAGE_BY_PREFIX) {
+    if (re.test(toolName)) return img;
+  }
+  return "app.connected.to.app.below.fill";
+}

--- a/tests/codegen-helpers.test.js
+++ b/tests/codegen-helpers.test.js
@@ -20,6 +20,16 @@ import {
   enumCaseDisplayLabel,
   enumTypeName,
   intentActionNameFor,
+  swiftTypeFor,
+  swiftDefaultLiteral,
+  enumDefaultLiteral,
+  wireExpr,
+  isNullableUnion,
+  nonNullType,
+  outputTypeNameFor,
+  snippetViewNameFor,
+  detectSnippetShape,
+  systemImageFor,
 } from "../scripts/lib/codegen-helpers.mjs";
 
 describe("toPascalCase", () => {
@@ -195,5 +205,291 @@ describe("intentActionNameFor", () => {
   test("non-destructive names also map (function is only called on destructive, but mapping is pure)", () => {
     expect(intentActionNameFor("list_events")).toBe(".go");
     expect(intentActionNameFor("read_note")).toBe(".go");
+  });
+});
+
+describe("swiftTypeFor", () => {
+  test("primitive scalars", () => {
+    expect(swiftTypeFor({ type: "string" })).toBe("String");
+    expect(swiftTypeFor({ type: "integer" })).toBe("Int");
+    expect(swiftTypeFor({ type: "number" })).toBe("Double");
+    expect(swiftTypeFor({ type: "boolean" })).toBe("Bool");
+  });
+
+  test("date-time format → Date", () => {
+    expect(swiftTypeFor({ type: "string", format: "date-time" })).toBe("Date");
+  });
+
+  test("string array → [String]", () => {
+    expect(swiftTypeFor({ type: "array", items: { type: "string" } })).toBe("[String]");
+  });
+
+  test("composite shapes → null (silently dropped by caller)", () => {
+    expect(swiftTypeFor({ type: "object" })).toBeNull();
+    expect(swiftTypeFor({ type: "array", items: { type: "object" } })).toBeNull();
+    expect(swiftTypeFor({ type: "unknown" })).toBeNull();
+  });
+});
+
+describe("swiftDefaultLiteral", () => {
+  test("numeric defaults round-trip as Swift literals", () => {
+    expect(swiftDefaultLiteral(50, "Int")).toBe("50");
+    expect(swiftDefaultLiteral(3.14, "Double")).toBe("3.14");
+  });
+
+  test("bool defaults render as true/false", () => {
+    expect(swiftDefaultLiteral(true, "Bool")).toBe("true");
+    expect(swiftDefaultLiteral(false, "Bool")).toBe("false");
+  });
+
+  test("string default gets quoted + escaped via swiftLit", () => {
+    expect(swiftDefaultLiteral("hello", "String")).toBe('"hello"');
+    expect(swiftDefaultLiteral('say "hi"', "String")).toBe('"say \\"hi\\""');
+  });
+
+  test("undefined default → null (caller drops default: clause)", () => {
+    expect(swiftDefaultLiteral(undefined, "Int")).toBeNull();
+  });
+
+  test("type mismatch → null (e.g. number default on a Bool field)", () => {
+    expect(swiftDefaultLiteral(1, "Bool")).toBeNull();
+    expect(swiftDefaultLiteral("text", "Int")).toBeNull();
+  });
+});
+
+describe("enumDefaultLiteral", () => {
+  test("returns .caseName when value is in enumValues", () => {
+    expect(enumDefaultLiteral("play", ["play", "pause"])).toBe(".play");
+    expect(enumDefaultLiteral("nextTrack", ["play", "nextTrack"])).toBe(".nextTrack");
+  });
+
+  test("value outside enum → null", () => {
+    expect(enumDefaultLiteral("stop", ["play", "pause"])).toBeNull();
+  });
+
+  test("missing enumValues → null", () => {
+    expect(enumDefaultLiteral("play", undefined)).toBeNull();
+    expect(enumDefaultLiteral("play", null)).toBeNull();
+  });
+
+  test("non-string default → null", () => {
+    expect(enumDefaultLiteral(0, ["play"])).toBeNull();
+  });
+});
+
+describe("wireExpr", () => {
+  test("passthrough for plain types", () => {
+    expect(wireExpr("String", "name", false)).toBe("name");
+    expect(wireExpr("Int", "limit", false)).toBe("limit");
+  });
+
+  test("Date → ISO8601 format call", () => {
+    expect(wireExpr("Date", "startDate", false)).toBe(
+      "ISO8601DateFormatter().string(from: startDate)",
+    );
+  });
+
+  test("enum → .rawValue regardless of underlying type name", () => {
+    expect(wireExpr("PlaybackControlActionOption", "action", true)).toBe("action.rawValue");
+    // isEnum takes precedence over the Date branch (won't happen in practice,
+    // but locks the priority)
+    expect(wireExpr("Date", "v", true)).toBe("v.rawValue");
+  });
+});
+
+describe("isNullableUnion / nonNullType", () => {
+  test("detects type: [X, null] union", () => {
+    expect(isNullableUnion({ type: ["string", "null"] })).toBe(true);
+    expect(isNullableUnion({ type: ["null", "string"] })).toBe(true);
+    expect(isNullableUnion({ type: ["integer", "null"] })).toBe(true);
+  });
+
+  test("plain types are not unions", () => {
+    expect(isNullableUnion({ type: "string" })).toBe(false);
+    expect(isNullableUnion({ type: "integer" })).toBe(false);
+  });
+
+  test("3-way or non-null unions don't count (out of scope)", () => {
+    expect(isNullableUnion({ type: ["string", "integer"] })).toBe(false);
+    expect(isNullableUnion({ type: ["string", "null", "integer"] })).toBe(false);
+  });
+
+  test("nonNullType extracts the non-null member", () => {
+    expect(nonNullType({ type: ["string", "null"] })).toBe("string");
+    expect(nonNullType({ type: ["null", "integer"] })).toBe("integer");
+  });
+
+  test("nonNullType on non-union returns null", () => {
+    expect(nonNullType({ type: "string" })).toBeNull();
+    expect(nonNullType({})).toBeNull();
+  });
+});
+
+describe("outputTypeNameFor / snippetViewNameFor", () => {
+  test("output struct uses MCP prefix + Output suffix", () => {
+    expect(outputTypeNameFor({ name: "list_events" })).toBe("MCPListEventsOutput");
+    expect(outputTypeNameFor({ name: "get_current_weather" })).toBe("MCPGetCurrentWeatherOutput");
+  });
+
+  test("snippet view uses MCP prefix + SnippetView suffix", () => {
+    expect(snippetViewNameFor({ name: "list_events" })).toBe("MCPListEventsSnippetView");
+    expect(snippetViewNameFor({ name: "audit_summary" })).toBe("MCPAuditSummarySnippetView");
+  });
+
+  test("prefixes avoid EventKit collisions (the motivating case)", () => {
+    // AirMCPKit's EventKitService.swift declares plain TodayEventsOutput.
+    // Generated type must not collide.
+    expect(outputTypeNameFor({ name: "today_events" })).toBe("MCPTodayEventsOutput");
+    expect(outputTypeNameFor({ name: "today_events" })).not.toBe("TodayEventsOutput");
+  });
+});
+
+describe("detectSnippetShape", () => {
+  test("list-object when single array property has object items with id", () => {
+    const shape = detectSnippetShape({
+      properties: {
+        events: {
+          type: "array",
+          items: {
+            type: "object",
+            properties: {
+              id: { type: "string" },
+              summary: { type: "string" },
+              startDate: { type: "string" },
+            },
+          },
+        },
+      },
+    });
+    expect(shape.shape).toBe("list-object");
+    expect(shape.arrayField).toBe("events");
+    expect(shape.primaryField).toBe("summary"); // first non-id string
+    expect(shape.hasId).toBe(true);
+    expect(shape.primaryFieldOptional).toBe(false);
+  });
+
+  test("primaryField prefers non-id even when id is first", () => {
+    const shape = detectSnippetShape({
+      properties: {
+        items: {
+          type: "array",
+          items: {
+            type: "object",
+            properties: { id: { type: "string" }, name: { type: "string" } },
+          },
+        },
+      },
+    });
+    expect(shape.primaryField).toBe("name");
+  });
+
+  test("nullable-union string fields are valid primaryField candidates", () => {
+    const shape = detectSnippetShape({
+      properties: {
+        chats: {
+          type: "array",
+          items: {
+            type: "object",
+            properties: {
+              id: { type: "string" },
+              name: { type: ["string", "null"] },
+            },
+          },
+        },
+      },
+    });
+    expect(shape.primaryField).toBe("name");
+    expect(shape.primaryFieldOptional).toBe(true);
+  });
+
+  test("list-string when single array of strings", () => {
+    const shape = detectSnippetShape({
+      properties: { tags: { type: "array", items: { type: "string" } } },
+    });
+    expect(shape.shape).toBe("list-string");
+    expect(shape.arrayField).toBe("tags");
+  });
+
+  test("scalar when multiple top-level fields", () => {
+    const shape = detectSnippetShape({
+      properties: {
+        temperature: { type: "number" },
+        humidity: { type: "number" },
+      },
+    });
+    expect(shape.shape).toBe("scalar");
+  });
+
+  test("scalar when no array properties", () => {
+    const shape = detectSnippetShape({
+      properties: { value: { type: "string" } },
+    });
+    expect(shape.shape).toBe("scalar");
+  });
+
+  test("scalar when two array properties (multi-array fallthrough)", () => {
+    const shape = detectSnippetShape({
+      properties: {
+        events: { type: "array", items: { type: "object", properties: {} } },
+        reminders: { type: "array", items: { type: "object", properties: {} } },
+      },
+    });
+    expect(shape.shape).toBe("scalar");
+  });
+
+  test("list-object without id field still lands on list-object but hasId false", () => {
+    const shape = detectSnippetShape({
+      properties: {
+        rows: {
+          type: "array",
+          items: { type: "object", properties: { label: { type: "string" } } },
+        },
+      },
+    });
+    expect(shape.shape).toBe("list-object");
+    expect(shape.hasId).toBe(false);
+    expect(shape.primaryField).toBe("label");
+  });
+
+  test("undefined schema → scalar (defensive)", () => {
+    expect(detectSnippetShape(undefined).shape).toBe("scalar");
+    expect(detectSnippetShape(null).shape).toBe("scalar");
+    expect(detectSnippetShape({}).shape).toBe("scalar");
+  });
+});
+
+describe("systemImageFor", () => {
+  test("calendar tools → calendar symbol", () => {
+    expect(systemImageFor("list_events")).toBe("calendar");
+    expect(systemImageFor("today_events")).toBe("calendar");
+    expect(systemImageFor("search_events")).toBe("calendar");
+    expect(systemImageFor("get_upcoming_events")).toBe("calendar");
+  });
+
+  test("list_calendars gets the plus variant (specific before fuzzy)", () => {
+    expect(systemImageFor("list_calendars")).toBe("calendar.badge.plus");
+  });
+
+  test("notes / reminders / contacts mappings", () => {
+    expect(systemImageFor("read_notes")).toBe("note.text");
+    expect(systemImageFor("list_folders")).toBe("note.text");
+    expect(systemImageFor("list_reminders")).toBe("checklist");
+    expect(systemImageFor("list_reminder_lists")).toBe("checklist");
+    expect(systemImageFor("search_contacts")).toBe("person.crop.circle");
+  });
+
+  test("messages / chats / shortcuts / safari / weather / files", () => {
+    expect(systemImageFor("list_messages")).toBe("envelope");
+    expect(systemImageFor("list_chats")).toBe("message");
+    expect(systemImageFor("list_shortcuts")).toBe("square.stack.3d.up");
+    expect(systemImageFor("list_bookmarks")).toBe("safari");
+    expect(systemImageFor("get_current_weather")).toBe("cloud.sun");
+    expect(systemImageFor("recent_files")).toBe("folder");
+    expect(systemImageFor("summarize_context")).toBe("sparkles");
+  });
+
+  test("unknown tool → default catch-all SF Symbol", () => {
+    expect(systemImageFor("unknown_tool_name")).toBe("app.connected.to.app.below.fill");
+    expect(systemImageFor("")).toBe("app.connected.to.app.below.fill");
   });
 });


### PR DESCRIPTION
## Summary

Continues the codegen helper extraction + test effort from [#126](https://github.com/heznpc/AirMCP/pull/126). Adds 38 new test cases covering the remaining pure helpers — total now **66 tests** covering the full pure-function surface of \`gen-swift-intents.mjs\`.

Stacked on [#126](https://github.com/heznpc/AirMCP/pull/126).

## Newly extracted helpers

All pure (no I/O, no global state dep):

| Helper | Drives |
|---|---|
| \`swiftTypeFor\` | JSON-Schema primitive → Swift type mapping (String, Int, Double, Bool, [String], Date) |
| \`swiftDefaultLiteral\` | \`@Parameter(default: …)\` literal synthesis |
| \`enumDefaultLiteral\` | AppEnum default resolution (\`"play"\` → \`.play\`) |
| \`wireExpr\` | Router args expression (Date ISO format, enum \`.rawValue\`, or identity) |
| \`isNullableUnion\` / \`nonNullType\` | JSON-Schema \`type: [X, null]\` detection |
| \`outputTypeNameFor\` / \`snippetViewNameFor\` | Generated Swift type names |
| \`detectSnippetShape\` | **Key function** — drives follow-up tap eligibility, primary-field selection, and nullable handling |
| \`SYSTEM_IMAGE_BY_PREFIX\` / \`systemImageFor\` | SF Symbol mapping for AppShortcutsProvider (12 regex categories) |

## Test coverage additions (38 new)

- **\`swiftTypeFor\`** — every primitive path + date-time format + string-array + composite → null
- **\`swiftDefaultLiteral\`** — type-match rules + type-mismatch null + escape via swiftLit
- **\`enumDefaultLiteral\`** — value-in-enum, value-not-in-enum, missing enumValues, non-string default
- **\`wireExpr\`** — priority (enum > date > identity), each format
- **\`isNullableUnion\` / \`nonNullType\`** — 2-way / 3-way unions, plain types, defensive null
- **Name collision** — \`MCPTodayEventsOutput\` vs hand-written \`TodayEventsOutput\` in EventKitService.swift (the motivating case for the prefix)
- **\`detectSnippetShape\`** — all three shapes + nullable primary field + multi-array fallthrough + defensive null/undefined
- **\`systemImageFor\`** — all 12 regex categories + fallback

## Test plan

- [x] \`npm test -- tests/codegen-helpers.test.js\` → 66 passed
- [x] \`npm run gen:intents:check\` — output byte-stable (229 intents)
- [x] \`swift build\` passes (8.3s)
- [x] \`gen-swift-intents.mjs\` shrunk from 1219 → ~1050 LOC (pure helpers now live in the shared lib)