### PR TITLE
test(rfc-0007): extract collectEnums + renderAppEnum to lib

### DIFF
--- a/scripts/gen-swift-intents.mjs
+++ b/scripts/gen-swift-intents.mjs
@@ -58,9 +58,11 @@ import {
   snippetViewNameFor,
   detectSnippetShape,
   systemImageFor,
+  collectEnums,
+  renderAppEnum as _renderAppEnum,
 } from "./lib/codegen-helpers.mjs";
 
-// CLI wrapper: the lib throws on invalid enum value so tests can
+// CLI wrappers: the lib throws on invalid enum value so tests can
 // assert the specific error, but the CLI wants the historic process.exit(2)
 // contract (caller expects "codegen failed, stop").
 function enumCaseName(value) {
@@ -68,6 +70,14 @@ function enumCaseName(value) {
     return _enumCaseName(value);
   } catch (e) {
     console.error(`[gen-intents] ${e.message}`);
+    process.exit(2);
+  }
+}
+function renderAppEnum(entry) {
+  try {
+    return _renderAppEnum(entry);
+  } catch (e) {
+    console.error(`[gen-intents] rendering ${entry?.typeName}: ${e.message}`);
     process.exit(2);
   }
 }
@@ -196,47 +206,8 @@ const MAX_TITLE_LEN = 80;
  * this to override @Parameter types inside generateIntent and to emit the
  * AppEnum struct block.
  */
-function collectEnums(tools) {
-  const perTool = new Map();
-  for (const tool of tools) {
-    const props = tool.inputSchema?.properties ?? {};
-    for (const [paramName, schema] of Object.entries(props)) {
-      if (schema.type !== "string" || !Array.isArray(schema.enum) || schema.enum.length === 0) continue;
-      let params = perTool.get(tool.name);
-      if (!params) {
-        params = new Map();
-        perTool.set(tool.name, params);
-      }
-      params.set(paramName, {
-        typeName: enumTypeName(tool.name, paramName),
-        values: schema.enum,
-        title: schema.description ?? paramName,
-      });
-    }
-  }
-  return perTool;
-}
-
-function renderAppEnum(entry) {
-  const { typeName, values, title } = entry;
-  const caseList = values.map(enumCaseName).join(", ");
-  const caseMap = values
-    .map((v) => `        .${enumCaseName(v)}: "${enumCaseDisplayLabel(v)}"`)
-    .join(",\n");
-  // AppEnum's protocol requirements are `static var { get set }` so we
-  // can't use `let`. `nonisolated(unsafe)` matches the pattern used on
-  // generated intent structs — Swift 6 strict concurrency sees the var
-  // as mutable, but in practice AppEnum metadata is set-once-at-load by
-  // the framework and never mutated, so the unsafe annotation is correct.
-  return `@available(iOS 16, macOS 13, *)
-public enum ${typeName}: String, AppEnum {
-    case ${caseList}
-    nonisolated(unsafe) public static var typeDisplayRepresentation: TypeDisplayRepresentation = "${swiftLit(title).slice(0, 80)}"
-    nonisolated(unsafe) public static var caseDisplayRepresentations: [Self: DisplayRepresentation] = [
-${caseMap}
-    ]
-}`;
-}
+// collectEnums imported from scripts/lib/codegen-helpers.mjs.
+// renderAppEnum (CLI wrapper at top) wraps the throwing lib version.
 
 // swiftDefaultLiteral imported from scripts/lib/codegen-helpers.mjs.
 

--- a/scripts/lib/codegen-helpers.mjs
+++ b/scripts/lib/codegen-helpers.mjs
@@ -256,3 +256,56 @@ export function systemImageFor(toolName) {
   }
   return "app.connected.to.app.below.fill";
 }
+
+// ── AppEnum collection + rendering ─────────────────────────────────────
+
+// Scan every tool's input schema and collect string enums. Returns
+// Map<toolName, Map<paramName, { typeName, values, title }>>. Caller
+// uses this to override @Parameter types inside generateIntent and to
+// emit the AppEnum struct block.
+export function collectEnums(tools) {
+  const perTool = new Map();
+  for (const tool of tools) {
+    const props = tool.inputSchema?.properties ?? {};
+    for (const [paramName, schema] of Object.entries(props)) {
+      if (schema.type !== "string" || !Array.isArray(schema.enum) || schema.enum.length === 0) continue;
+      let params = perTool.get(tool.name);
+      if (!params) {
+        params = new Map();
+        perTool.set(tool.name, params);
+      }
+      params.set(paramName, {
+        typeName: enumTypeName(tool.name, paramName),
+        values: schema.enum,
+        title: schema.description ?? paramName,
+      });
+    }
+  }
+  return perTool;
+}
+
+// Render one entry from `collectEnums` output as a Swift AppEnum
+// declaration. AppEnum's protocol requirements are `static var { get
+// set }` so we can't use `let`; `nonisolated(unsafe)` matches the
+// pattern on generated intent struct statics — Swift 6 strict
+// concurrency sees the var as mutable, but in practice AppEnum
+// metadata is set-once-at-load framework state.
+//
+// Throws via `enumCaseName` if any value is not a Swift-identifier-safe
+// string. Callers in the CLI path wrap with process.exit(2); tests can
+// assert the exact error.
+export function renderAppEnum(entry) {
+  const { typeName, values, title } = entry;
+  const caseList = values.map(enumCaseName).join(", ");
+  const caseMap = values
+    .map((v) => `        .${enumCaseName(v)}: "${enumCaseDisplayLabel(v)}"`)
+    .join(",\n");
+  return `@available(iOS 16, macOS 13, *)
+public enum ${typeName}: String, AppEnum {
+    case ${caseList}
+    nonisolated(unsafe) public static var typeDisplayRepresentation: TypeDisplayRepresentation = "${swiftLit(title).slice(0, 80)}"
+    nonisolated(unsafe) public static var caseDisplayRepresentations: [Self: DisplayRepresentation] = [
+${caseMap}
+    ]
+}`;
+}

--- a/tests/codegen-helpers.test.js
+++ b/tests/codegen-helpers.test.js
@@ -30,6 +30,8 @@ import {
   snippetViewNameFor,
   detectSnippetShape,
   systemImageFor,
+  collectEnums,
+  renderAppEnum,
 } from "../scripts/lib/codegen-helpers.mjs";
 
 describe("toPascalCase", () => {
@@ -491,5 +493,126 @@ describe("systemImageFor", () => {
   test("unknown tool → default catch-all SF Symbol", () => {
     expect(systemImageFor("unknown_tool_name")).toBe("app.connected.to.app.below.fill");
     expect(systemImageFor("")).toBe("app.connected.to.app.below.fill");
+  });
+});
+
+describe("collectEnums", () => {
+  test("picks up a single tool with one enum param", () => {
+    const result = collectEnums([
+      {
+        name: "playback_control",
+        inputSchema: {
+          properties: {
+            action: {
+              type: "string",
+              enum: ["play", "pause", "nextTrack", "previousTrack"],
+              description: "Playback action",
+            },
+          },
+        },
+      },
+    ]);
+    expect(result.size).toBe(1);
+    const params = result.get("playback_control");
+    expect(params.size).toBe(1);
+    const entry = params.get("action");
+    expect(entry.typeName).toBe("PlaybackControlActionOption");
+    expect(entry.values).toEqual(["play", "pause", "nextTrack", "previousTrack"]);
+    expect(entry.title).toBe("Playback action");
+  });
+
+  test("falls back to param name when description is missing", () => {
+    const result = collectEnums([
+      {
+        name: "foo",
+        inputSchema: { properties: { bar: { type: "string", enum: ["a", "b"] } } },
+      },
+    ]);
+    expect(result.get("foo").get("bar").title).toBe("bar");
+  });
+
+  test("non-string params, empty-enum params, and enumless params are skipped", () => {
+    const result = collectEnums([
+      {
+        name: "mix",
+        inputSchema: {
+          properties: {
+            plain: { type: "string" },
+            intEnum: { type: "integer", enum: [1, 2] }, // not type:string — skip
+            emptyEnum: { type: "string", enum: [] },
+            actual: { type: "string", enum: ["x"] },
+          },
+        },
+      },
+    ]);
+    const params = result.get("mix");
+    expect([...params.keys()]).toEqual(["actual"]);
+  });
+
+  test("two tools sharing a param name emit distinct scoped types", () => {
+    const result = collectEnums([
+      { name: "memory_put", inputSchema: { properties: { kind: { type: "string", enum: ["fact"] } } } },
+      { name: "memory_query", inputSchema: { properties: { kind: { type: "string", enum: ["fact"] } } } },
+    ]);
+    expect(result.get("memory_put").get("kind").typeName).toBe("MemoryPutKindOption");
+    expect(result.get("memory_query").get("kind").typeName).toBe("MemoryQueryKindOption");
+  });
+
+  test("tool with no inputSchema is a no-op", () => {
+    const result = collectEnums([{ name: "no_input_tool" }]);
+    expect(result.size).toBe(0);
+  });
+
+  test("empty tool list returns empty map", () => {
+    expect(collectEnums([]).size).toBe(0);
+  });
+});
+
+describe("renderAppEnum", () => {
+  test("emits the expected struct shape with iOS 16 / macOS 13 gate", () => {
+    const swift = renderAppEnum({
+      typeName: "PlaybackControlActionOption",
+      values: ["play", "pause", "nextTrack", "previousTrack"],
+      title: "Playback action",
+    });
+
+    expect(swift).toContain("@available(iOS 16, macOS 13, *)");
+    expect(swift).toContain("public enum PlaybackControlActionOption: String, AppEnum {");
+    expect(swift).toContain("case play, pause, nextTrack, previousTrack");
+    expect(swift).toContain(
+      'nonisolated(unsafe) public static var typeDisplayRepresentation: TypeDisplayRepresentation = "Playback action"',
+    );
+    expect(swift).toContain('.play: "Play"');
+    expect(swift).toContain('.nextTrack: "Next Track"');
+    expect(swift).toContain("caseDisplayRepresentations: [Self: DisplayRepresentation]");
+  });
+
+  test("title > 80 chars is truncated via slice (not ellipsized — matches swiftLit behavior)", () => {
+    const long = "a".repeat(120);
+    const swift = renderAppEnum({ typeName: "X", values: ["v"], title: long });
+    // slice(0, 80) — no "…" suffix at this layer
+    expect(swift).toContain(`TypeDisplayRepresentation = "${"a".repeat(80)}"`);
+    expect(swift).not.toContain("a".repeat(81));
+  });
+
+  test("title escapes quotes / backslashes via swiftLit", () => {
+    const swift = renderAppEnum({
+      typeName: "X",
+      values: ["v"],
+      title: 'label with "quote" and \\ slash',
+    });
+    expect(swift).toContain('TypeDisplayRepresentation = "label with \\"quote\\" and \\\\ slash"');
+  });
+
+  test("throws on unsafe enum value (propagates from enumCaseName)", () => {
+    expect(() =>
+      renderAppEnum({ typeName: "X", values: ["next-track"], title: "bad" }),
+    ).toThrow(/not a safe Swift identifier/);
+  });
+
+  test("single-value enum still renders valid Swift", () => {
+    const swift = renderAppEnum({ typeName: "OneOption", values: ["only"], title: "One" });
+    expect(swift).toContain("case only");
+    expect(swift).toContain('.only: "Only"');
   });
 });


### PR DESCRIPTION
## Summary

Continues the codegen helper extraction from [#126](https://github.com/heznpc/AirMCP/pull/126) / [#127](https://github.com/heznpc/AirMCP/pull/127). Moves the last two pure-ish functions from [scripts/gen-swift-intents.mjs](scripts/gen-swift-intents.mjs) to [scripts/lib/codegen-helpers.mjs](scripts/lib/codegen-helpers.mjs) so the full AppEnum pipeline is unit-testable without spinning up the manifest.

Stacked on [#128](https://github.com/heznpc/AirMCP/pull/128).

## Note on parallel extraction

A **different session** (\`4357d67\` on \`claude/wonderful-pascal-d7a224\`, branched off pre-stack main) extracted some of these same helpers (\`toPascalCase\`, \`swiftIdent\`, \`isNullableUnion\`, \`nonNullType\`) into a different file \`scripts/lib/swift-intents-codegen.mjs\`. That work also adds \`isCodableSafe\` / \`swiftOutputType\` / \`renderStruct\` which **aren't in the current stack yet** — overlap requires resolution at merge time (one \`lib/\` file, not two). Not touching that branch from here; flag for merge adjudication.

## Extracted

- **\`collectEnums(tools)\`** — scans every tool's input schema for string enums, keyed by \`(tool, param)\`. Returns the same \`Map<...>\` shape the generator already consumes.
- **\`renderAppEnum(entry)\`** — emits the Swift \`public enum <Foo>: String, AppEnum { ... }\` block with \`typeDisplayRepresentation\` + \`caseDisplayRepresentations\`. Throws via \`enumCaseName\` on unsafe values; a CLI wrapper in \`gen-swift-intents.mjs\` converts the throw into the historic \`process.exit(2)\`.

## AppEnum for enum OUTPUT fields — deferred (and why)

The fresh session and prior recommendation listed "AppEnum for enum output fields" as a follow-up. On inspection there are **only 4 output enum fields** in the entire manifest:

| Tool | Field | Values |
|---|---|---|
| \`audit_log\` | \`entries[].status\` | \`ok\`, \`error\` |
| \`memory_put\` | \`stored.kind\` | \`fact\`, \`entity\`, \`episode\` |
| \`memory_query\` | \`entries[].kind\` | \`fact\`, \`entity\`, \`episode\` |
| \`proactive_context\` | \`timeContext.period\` | \`morning\`, \`afternoon\`, \`evening\`, \`night\` |

The scalar snippet view's current \`String(describing:)\` render path doesn't surface typed enums differently, so typing these as AppEnum is pure Swift-side hygiene with no user-visible UX delta. Re-evaluate when LLM-Siri actually demonstrates a different output-enum rendering (e.g. picker-style inline selection).

## Test coverage (+11, total 77)

- \`collectEnums\` — single-tool happy path, description-fallback, non-string/empty-enum/enumless filter, two-tools-same-param scope isolation, missing inputSchema no-op, empty list no-op
- \`renderAppEnum\` — Swift-shape invariants (iOS 16/macOS 13 gate, AppEnum conformance, case list, both static vars), title > 80 chars truncation, special-char escaping, throws on unsafe value, single-value enum

## Test plan

- [x] \`npm test -- tests/codegen-helpers.test.js\` → 77 passed
- [x] \`npm run gen:intents:check\` — byte-identical (229 intents)
- [x] \`swift build\` passes (7.1s)