### PR TITLE
test(rfc-0007): extract swiftParamDecl + buildArgsBlock with 21 tests

### DIFF
--- a/scripts/gen-swift-intents.mjs
+++ b/scripts/gen-swift-intents.mjs
@@ -60,6 +60,8 @@ import {
   systemImageFor,
   collectEnums,
   renderAppEnum as _renderAppEnum,
+  swiftParamDecl,
+  buildArgsBlock,
 } from "./lib/codegen-helpers.mjs";
 
 // CLI wrappers: the lib throws on invalid enum value so tests can
@@ -185,11 +187,6 @@ for (const name of APP_SHORTCUTS_TOP) {
 
 // ── Swift codegen helpers ────────────────────────────────────────────
 
-// Keep @Parameter titles short enough to render well in Shortcuts picker
-// UIs. 80 is conservative; Apple doesn't publish a hard limit but longer
-// strings wrap awkwardly.
-const MAX_TITLE_LEN = 80;
-
 // toPascalCase, intentStructName, intentActionNameFor, swiftLit,
 // humanizeKey, enumCaseDisplayLabel, enumTypeName, swiftIdent,
 // SWIFT_RESERVED are imported from scripts/lib/codegen-helpers.mjs.
@@ -211,81 +208,9 @@ const MAX_TITLE_LEN = 80;
 
 // swiftDefaultLiteral imported from scripts/lib/codegen-helpers.mjs.
 
-/**
- * Map a JSON-Schema property to a Swift `@Parameter` declaration.
- * Optional properties (not in inputSchema.required) become Optional<T>
- * unless the schema carries an explicit default.
- * Non-primitive or composite shapes return null; callers must filter
- * the property out of the generated intent entirely.
- */
-function swiftParamDecl(propName, propSchema, isRequired, enumTypeOverride) {
-  const baseType = enumTypeOverride ?? swiftTypeFor(propSchema);
-  if (baseType === null) return null;
-
-  const descParts = [];
-  if (propSchema.description) descParts.push(propSchema.description);
-  // Skip the "Allowed: a, b, c" tail when the param is a real AppEnum —
-  // Shortcuts picker already shows the cases via caseDisplayRepresentations.
-  if (!enumTypeOverride && Array.isArray(propSchema.enum) && propSchema.enum.length > 0) {
-    descParts.push(`Allowed: ${propSchema.enum.join(", ")}`);
-  }
-  const title = descParts.join(" · ") || propName;
-  const safeTitle = swiftLit(title.slice(0, MAX_TITLE_LEN));
-
-  const optsParts = [`title: "${safeTitle}"`];
-  const defaultLiteral = enumTypeOverride
-    ? enumDefaultLiteral(propSchema.default, propSchema.enum)
-    : swiftDefaultLiteral(propSchema.default, baseType);
-  if (defaultLiteral !== null) optsParts.push(`default: ${defaultLiteral}`);
-
-  if (
-    (baseType === "Int" || baseType === "Double") &&
-    typeof propSchema.minimum === "number" &&
-    typeof propSchema.maximum === "number"
-  ) {
-    optsParts.push(`inclusiveRange: (${propSchema.minimum}, ${propSchema.maximum})`);
-  }
-
-  // Optional fields without an explicit default become `T?` so AppIntent
-  // treats them as optional. Fields with a default stay non-optional.
-  const hasDefault = defaultLiteral !== null;
-  const typeName = isRequired || hasDefault ? baseType : `${baseType}?`;
-
-  return `    @Parameter(${optsParts.join(", ")})\n    public var ${propName}: ${typeName}`;
-}
-
-// enumDefaultLiteral, wireExpr imported from scripts/lib/codegen-helpers.mjs.
-
-/**
- * Emit the Swift statements that build the `args` dict for a router call.
- * Returns `{ prelude, argsExpr }` — callers drop `prelude` into the
- * `perform()` body before the call, then pass `argsExpr` to `args:`.
- *
- * Optional properties use `if let ... { args[...] = ... }` so nil fields
- * don't cross the wire as JSON `null` — Node's JSON-Schema validator
- * treats absent-vs-null differently for optionals.
- */
-function buildArgsBlock(decls) {
-  if (decls.length === 0) {
-    return { prelude: "", argsExpr: "[String: any Sendable]()" };
-  }
-
-  const allRequired = decls.every((d) => !d.optional);
-  if (allRequired) {
-    const pairs = decls.map((d) => `"${d.wireName}": ${wireExpr(d.type, d.name, d.isEnum)}`).join(", ");
-    return { prelude: "", argsExpr: `[${pairs}]` };
-  }
-
-  const lines = [`var args: [String: any Sendable] = [:]`];
-  for (const d of decls) {
-    if (!d.optional) {
-      lines.push(`args["${d.wireName}"] = ${wireExpr(d.type, d.name, d.isEnum)}`);
-    } else {
-      lines.push(`if let v = ${d.name} { args["${d.wireName}"] = ${wireExpr(d.type, "v", d.isEnum)} }`);
-    }
-  }
-  return { prelude: lines.map((l) => `        ${l}`).join("\n"), argsExpr: "args" };
-}
+// swiftParamDecl, buildArgsBlock imported from scripts/lib/codegen-helpers.mjs
+// (incl. MAX_TITLE_LEN which swiftParamDecl encapsulates).
+// enumDefaultLiteral, wireExpr also imported from there.
 
 // SWIFT_RESERVED, swiftIdent imported from scripts/lib/codegen-helpers.mjs.
 

--- a/scripts/lib/codegen-helpers.mjs
+++ b/scripts/lib/codegen-helpers.mjs
@@ -257,6 +257,87 @@ export function systemImageFor(toolName) {
   return "app.connected.to.app.below.fill";
 }
 
+// ── @Parameter declaration + args dict synthesis ───────────────────────
+
+// Keep @Parameter titles short enough to render well in Shortcuts
+// picker UIs. 80 is conservative; Apple doesn't publish a hard limit
+// but longer strings wrap awkwardly.
+export const MAX_TITLE_LEN = 80;
+
+// Render a Swift `@Parameter(...) public var foo: T` declaration from a
+// JSON-Schema property. Optional properties (not in `inputSchema.required`)
+// become `Optional<T>` unless the schema carries an explicit default.
+// Non-primitive or composite shapes return null; callers filter the
+// property out of the generated intent entirely.
+//
+// `enumTypeOverride` — when the caller has pre-resolved an AppEnum
+// type for this param (via `collectEnums`), the declaration uses that
+// type and skips the redundant "Allowed: a, b, c" description tail.
+export function swiftParamDecl(propName, propSchema, isRequired, enumTypeOverride) {
+  const baseType = enumTypeOverride ?? swiftTypeFor(propSchema);
+  if (baseType === null) return null;
+
+  const descParts = [];
+  if (propSchema.description) descParts.push(propSchema.description);
+  if (!enumTypeOverride && Array.isArray(propSchema.enum) && propSchema.enum.length > 0) {
+    descParts.push(`Allowed: ${propSchema.enum.join(", ")}`);
+  }
+  const title = descParts.join(" · ") || propName;
+  const safeTitle = swiftLit(title.slice(0, MAX_TITLE_LEN));
+
+  const optsParts = [`title: "${safeTitle}"`];
+  const defaultLiteral = enumTypeOverride
+    ? enumDefaultLiteral(propSchema.default, propSchema.enum)
+    : swiftDefaultLiteral(propSchema.default, baseType);
+  if (defaultLiteral !== null) optsParts.push(`default: ${defaultLiteral}`);
+
+  if (
+    (baseType === "Int" || baseType === "Double") &&
+    typeof propSchema.minimum === "number" &&
+    typeof propSchema.maximum === "number"
+  ) {
+    optsParts.push(`inclusiveRange: (${propSchema.minimum}, ${propSchema.maximum})`);
+  }
+
+  const hasDefault = defaultLiteral !== null;
+  const typeName = isRequired || hasDefault ? baseType : `${baseType}?`;
+
+  return `    @Parameter(${optsParts.join(", ")})\n    public var ${propName}: ${typeName}`;
+}
+
+// Emit the Swift statements that build the `args` dict passed to
+// `MCPIntentRouter.shared.call(tool:, args:)`. Returns `{ prelude,
+// argsExpr }` — the caller drops `prelude` into the `perform()` body
+// before the call, then passes `argsExpr` to `args:`.
+//
+// Optional properties render as `if let ... { args[...] = ... }` so
+// nil fields don't cross the wire as JSON `null` — the Node-side
+// JSON-Schema validator treats absent-vs-null differently for optionals.
+//
+// decls is an array of `{ name, wireName, type, isEnum, optional, ... }`
+// objects produced by the generator when iterating `inputSchema.properties`.
+export function buildArgsBlock(decls) {
+  if (decls.length === 0) {
+    return { prelude: "", argsExpr: "[String: any Sendable]()" };
+  }
+
+  const allRequired = decls.every((d) => !d.optional);
+  if (allRequired) {
+    const pairs = decls.map((d) => `"${d.wireName}": ${wireExpr(d.type, d.name, d.isEnum)}`).join(", ");
+    return { prelude: "", argsExpr: `[${pairs}]` };
+  }
+
+  const lines = [`var args: [String: any Sendable] = [:]`];
+  for (const d of decls) {
+    if (!d.optional) {
+      lines.push(`args["${d.wireName}"] = ${wireExpr(d.type, d.name, d.isEnum)}`);
+    } else {
+      lines.push(`if let v = ${d.name} { args["${d.wireName}"] = ${wireExpr(d.type, "v", d.isEnum)} }`);
+    }
+  }
+  return { prelude: lines.map((l) => `        ${l}`).join("\n"), argsExpr: "args" };
+}
+
 // ── AppEnum collection + rendering ─────────────────────────────────────
 
 // Scan every tool's input schema and collect string enums. Returns

--- a/tests/codegen-helpers.test.js
+++ b/tests/codegen-helpers.test.js
@@ -32,6 +32,9 @@ import {
   systemImageFor,
   collectEnums,
   renderAppEnum,
+  MAX_TITLE_LEN,
+  swiftParamDecl,
+  buildArgsBlock,
 } from "../scripts/lib/codegen-helpers.mjs";
 
 describe("toPascalCase", () => {
@@ -614,5 +617,196 @@ describe("renderAppEnum", () => {
     const swift = renderAppEnum({ typeName: "OneOption", values: ["only"], title: "One" });
     expect(swift).toContain("case only");
     expect(swift).toContain('.only: "Only"');
+  });
+});
+
+describe("swiftParamDecl", () => {
+  test("required string param with description", () => {
+    const decl = swiftParamDecl("query", { type: "string", description: "Search text" }, true);
+    expect(decl).toBe(
+      `    @Parameter(title: "Search text")\n    public var query: String`,
+    );
+  });
+
+  test("optional string param becomes String? without default", () => {
+    const decl = swiftParamDecl("query", { type: "string" }, false);
+    expect(decl).toContain("public var query: String?");
+  });
+
+  test("integer with min/max gets inclusiveRange", () => {
+    const decl = swiftParamDecl(
+      "limit",
+      { type: "integer", minimum: 1, maximum: 200, description: "Max results" },
+      false,
+    );
+    expect(decl).toContain("title: \"Max results\"");
+    expect(decl).toContain("inclusiveRange: (1, 200)");
+    // Optional without default → Int?
+    expect(decl).toContain("public var limit: Int?");
+  });
+
+  test("default literal makes the field non-optional even if unrequired", () => {
+    const decl = swiftParamDecl(
+      "limit",
+      { type: "integer", default: 50, minimum: 1, maximum: 200 },
+      false,
+    );
+    expect(decl).toContain("default: 50");
+    expect(decl).toContain("public var limit: Int");
+    expect(decl).not.toContain("public var limit: Int?");
+  });
+
+  test("date-time string → Date", () => {
+    const decl = swiftParamDecl(
+      "startDate",
+      { type: "string", format: "date-time", description: "Start" },
+      true,
+    );
+    expect(decl).toContain("public var startDate: Date");
+  });
+
+  test("string-array → [String]", () => {
+    const decl = swiftParamDecl(
+      "tags",
+      { type: "array", items: { type: "string" }, description: "Tags" },
+      true,
+    );
+    expect(decl).toContain("public var tags: [String]");
+  });
+
+  test("Boolean with explicit true default", () => {
+    const decl = swiftParamDecl(
+      "flagged",
+      { type: "boolean", default: true, description: "Flag?" },
+      false,
+    );
+    expect(decl).toContain("default: true");
+    expect(decl).toContain("public var flagged: Bool");
+  });
+
+  test("composite shape → null (caller drops the property)", () => {
+    expect(swiftParamDecl("x", { type: "object" }, true)).toBeNull();
+    expect(
+      swiftParamDecl("x", { type: "array", items: { type: "object" } }, true),
+    ).toBeNull();
+  });
+
+  test("enum without override appends Allowed tail to title", () => {
+    const decl = swiftParamDecl(
+      "action",
+      { type: "string", enum: ["play", "pause"], description: "What to do" },
+      true,
+    );
+    expect(decl).toContain('title: "What to do · Allowed: play, pause"');
+    expect(decl).toContain("public var action: String");
+  });
+
+  test("enum WITH override uses AppEnum type + skips Allowed tail", () => {
+    const decl = swiftParamDecl(
+      "action",
+      { type: "string", enum: ["play", "pause"], description: "What to do" },
+      true,
+      "PlaybackControlActionOption",
+    );
+    expect(decl).toContain('title: "What to do"');
+    expect(decl).not.toContain("Allowed:");
+    expect(decl).toContain("public var action: PlaybackControlActionOption");
+  });
+
+  test("enum override + matching default → .case literal", () => {
+    const decl = swiftParamDecl(
+      "action",
+      { type: "string", enum: ["play", "pause"], default: "play" },
+      false,
+      "ActionOption",
+    );
+    expect(decl).toContain("default: .play");
+    expect(decl).toContain("public var action: ActionOption");
+    expect(decl).not.toContain("ActionOption?");
+  });
+
+  test("title exceeding MAX_TITLE_LEN is sliced", () => {
+    const longDesc = "x".repeat(200);
+    const decl = swiftParamDecl("field", { type: "string", description: longDesc }, true);
+    expect(decl).toContain(`title: "${"x".repeat(MAX_TITLE_LEN)}"`);
+    expect(decl).not.toContain("x".repeat(MAX_TITLE_LEN + 1));
+  });
+
+  test("no description and no enum → param name is the title", () => {
+    const decl = swiftParamDecl("id", { type: "string" }, true);
+    expect(decl).toContain('title: "id"');
+  });
+});
+
+describe("buildArgsBlock", () => {
+  test("no decls → inline empty dict, no prelude", () => {
+    const out = buildArgsBlock([]);
+    expect(out.prelude).toBe("");
+    expect(out.argsExpr).toBe("[String: any Sendable]()");
+  });
+
+  test("single required string → inline literal dict", () => {
+    const out = buildArgsBlock([
+      { name: "query", wireName: "query", type: "String", isEnum: false, optional: false },
+    ]);
+    expect(out.prelude).toBe("");
+    expect(out.argsExpr).toBe(`["query": query]`);
+  });
+
+  test("multiple required mixed types → inline literal with correct wireExpr", () => {
+    const out = buildArgsBlock([
+      { name: "startDate", wireName: "startDate", type: "Date", isEnum: false, optional: false },
+      { name: "limit", wireName: "limit", type: "Int", isEnum: false, optional: false },
+      { name: "action", wireName: "action", type: "ActionOption", isEnum: true, optional: false },
+    ]);
+    expect(out.prelude).toBe("");
+    expect(out.argsExpr).toBe(
+      `["startDate": ISO8601DateFormatter().string(from: startDate), "limit": limit, "action": action.rawValue]`,
+    );
+  });
+
+  test("any optional triggers prelude + args dict", () => {
+    const out = buildArgsBlock([
+      { name: "query", wireName: "query", type: "String", isEnum: false, optional: false },
+      { name: "limit", wireName: "limit", type: "Int", isEnum: false, optional: true },
+    ]);
+    expect(out.argsExpr).toBe("args");
+    expect(out.prelude).toContain(`var args: [String: any Sendable] = [:]`);
+    expect(out.prelude).toContain(`args["query"] = query`);
+    expect(out.prelude).toContain(`if let v = limit { args["limit"] = v }`);
+  });
+
+  test("optional Date uses ISO8601 formatter via `v`", () => {
+    const out = buildArgsBlock([
+      { name: "startDate", wireName: "startDate", type: "Date", isEnum: false, optional: true },
+    ]);
+    expect(out.prelude).toContain(
+      `if let v = startDate { args["startDate"] = ISO8601DateFormatter().string(from: v) }`,
+    );
+  });
+
+  test("optional enum uses .rawValue on unwrapped `v`", () => {
+    const out = buildArgsBlock([
+      { name: "action", wireName: "action", type: "ActionOption", isEnum: true, optional: true },
+    ]);
+    expect(out.prelude).toContain(`if let v = action { args["action"] = v.rawValue }`);
+  });
+
+  test("wireName differs from Swift name (reserved-keyword escape)", () => {
+    // Simulates a JSON-Schema property named "default" → Swift ident "default_"
+    const out = buildArgsBlock([
+      { name: "default_", wireName: "default", type: "String", isEnum: false, optional: false },
+    ]);
+    expect(out.argsExpr).toBe(`["default": default_]`);
+  });
+
+  test("prelude lines are indented 8 spaces (matches perform body formatting)", () => {
+    const out = buildArgsBlock([
+      { name: "a", wireName: "a", type: "String", isEnum: false, optional: true },
+    ]);
+    // Every non-empty prelude line starts with exactly 8 spaces
+    for (const line of out.prelude.split("\n")) {
+      expect(line.startsWith("        ")).toBe(true);
+    }
   });
 });


### PR DESCRIPTION
## Summary

Completes the Parameter/args synthesis extraction. These two functions drive every \`@Parameter\` declaration and every router args dict across the 229 generated intents — silent behavior shifts would ripple across the entire Shortcuts surface.

Stacked on [#129](https://github.com/heznpc/AirMCP/pull/129).

## Extracted

| Helper | Role |
|---|---|
| \`MAX_TITLE_LEN\` | 80-char Shortcuts-picker cap |
| \`swiftParamDecl\` | JSON-Schema property → \`@Parameter(...) public var x: T\` declaration. Resolves type via \`swiftTypeFor\` / \`enumTypeOverride\`, defaults via \`swiftDefaultLiteral\` / \`enumDefaultLiteral\`, and handles optional-vs-default nullability. |
| \`buildArgsBlock\` | \`decls[]\` → \`{ prelude, argsExpr }\`. Inline literal when every decl is required; \`var args = [:]\` + per-decl assignment when any is optional. Handles Date ISO8601 conversion and enum \`.rawValue\` via \`wireExpr\`. |

## Test coverage (+21, total 98)

### \`swiftParamDecl\`
- Required vs optional nullability rules
- \`inclusiveRange\` emission for numeric min/max
- Default literal makes a field non-optional
- Date / \`[String]\` / enum type paths
- Composite shapes → null
- Enum override skips "Allowed: …" tail
- Enum override + matching default → \`.case\` literal
- Title exceeding \`MAX_TITLE_LEN\` is sliced (no "…" — \`truncateDescription\` is a different contract)

### \`buildArgsBlock\`
- Empty / all-required / has-optional paths
- Date → \`ISO8601DateFormatter().string(from:)\`, enum → \`.rawValue\`
- Optional Date and optional enum correctly unwrap via \`v\`
- wireName vs Swift name (reserved-keyword escape: \`default\` → \`default_\`)
- Prelude indent discipline — every non-empty line starts with exactly 8 spaces (matches \`perform()\` body formatting)

## Test plan

- [x] \`npm test -- tests/codegen-helpers.test.js\` → 98 passed
- [x] \`npm run gen:intents:check\` — byte-identical (229 intents)
- [x] \`swift build\` passes (6.8s)
- [x] gen-swift-intents.mjs: 1050 → 903 LOC; codegen-helpers.mjs: 339 → 392 LOC