### PR TITLE
test(rfc-0007): extract resolveFollowUpMap + factory-specs derivation

### DIFF
--- a/scripts/gen-swift-intents.mjs
+++ b/scripts/gen-swift-intents.mjs
@@ -62,6 +62,8 @@ import {
   renderAppEnum as _renderAppEnum,
   swiftParamDecl,
   buildArgsBlock,
+  resolveFollowUpMap as _resolveFollowUpMap,
+  deriveFollowUpFactorySpecs,
 } from "./lib/codegen-helpers.mjs";
 
 // CLI wrappers: the lib throws on invalid enum value so tests can
@@ -628,63 +630,17 @@ function renderScalarRow(key, propSchema) {
 
 // detectSnippetShape imported from scripts/lib/codegen-helpers.mjs.
 
-// Validate FOLLOW_UP_MAP against the manifest so a typo or removed tool
-// surfaces at codegen time rather than as a SwiftUI compile error. Also
-// ensures the list's items carry the expected id field and the target's
-// @Parameter shape matches.
-function resolveFollowUpMap() {
-  const resolved = {};
-  for (const [listName, entry] of Object.entries(FOLLOW_UP_MAP)) {
-    const listTool = byName.get(listName);
-    const target = byName.get(entry.target);
-    if (!listTool) {
-      console.error(`[gen-intents] FOLLOW_UP_MAP: list tool missing: ${listName}`);
-      process.exit(2);
-    }
-    if (!target) {
-      console.error(`[gen-intents] FOLLOW_UP_MAP: target tool missing: ${entry.target}`);
-      process.exit(2);
-    }
-    const info = detectSnippetShape(listTool.outputSchema ?? {});
-    if (info.shape !== "list-object") {
-      console.error(
-        `[gen-intents] FOLLOW_UP_MAP: ${listName} is not a list-object shape (got ${info.shape})`,
-      );
-      process.exit(2);
-    }
-    const itemProps = listTool.outputSchema?.properties?.[info.arrayField]?.items?.properties ?? {};
-    if (itemProps[entry.itemField]?.type !== "string") {
-      console.error(
-        `[gen-intents] FOLLOW_UP_MAP: ${listName} items have no string field "${entry.itemField}" (fields: ${Object.keys(itemProps).join(", ")})`,
-      );
-      process.exit(2);
-    }
-    const targetParams = Object.keys(target.inputSchema?.properties ?? {});
-    if (!targetParams.includes(entry.targetParam)) {
-      console.error(
-        `[gen-intents] FOLLOW_UP_MAP: target ${entry.target} has no @Parameter named "${entry.targetParam}" (params: ${targetParams.join(", ")})`,
-      );
-      process.exit(2);
-    }
-    resolved[listName] = {
-      ...entry,
-      targetIntentName: intentStructName(entry.target),
-      // Factory key by (target, targetParam). Two list tools pointing at
-      // the same read target with the same param share one factory; two
-      // list tools pointing at the same target via different params
-      // (unlikely but possible) each get their own.
-      factoryKey: `${intentStructName(entry.target)}_${entry.targetParam}`,
-    };
-  }
-  return resolved;
+// CLI wrapper: lib's resolveFollowUpMap throws on any invariant
+// violation so tests can assert the specific error; the CLI needs
+// the historic process.exit(2) contract.
+let followUpMap;
+try {
+  followUpMap = _resolveFollowUpMap(FOLLOW_UP_MAP, byName);
+} catch (e) {
+  console.error(`[gen-intents] ${e.message}`);
+  process.exit(2);
 }
-const followUpMap = resolveFollowUpMap();
-// Deduplicate factories by (targetIntentName, targetParam).
-const followUpFactorySpecs = Array.from(
-  new Map(
-    Object.values(followUpMap).map((e) => [e.factoryKey, { targetIntentName: e.targetIntentName, targetParam: e.targetParam }]),
-  ).values(),
-);
+const followUpFactorySpecs = deriveFollowUpFactorySpecs(followUpMap);
 
 // snippetViewNameFor imported from scripts/lib/codegen-helpers.mjs.
 

--- a/scripts/lib/codegen-helpers.mjs
+++ b/scripts/lib/codegen-helpers.mjs
@@ -390,3 +390,84 @@ ${caseMap}
     ]
 }`;
 }
+
+// ── Follow-up intent resolution (RFC 0007 §3.7 / A.4.3) ────────────────
+
+// Validate a FOLLOW_UP_MAP config against the manifest and produce a
+// resolved map keyed by list tool. Throws on any invariant violation so
+// codegen fails fast with a specific error; CLI callers wrap with
+// process.exit(2).
+//
+//   config    = { [listToolName]: { target, itemField, targetParam } }
+//   byName    = Map<toolName, manifestToolEntry>
+//
+// Returns `{ [listToolName]: { target, itemField, targetParam,
+//   targetIntentName, factoryKey } }` where `factoryKey` is the dedupe
+// key for per-`(target, targetParam)` SwiftUI Button factories.
+//
+// Invariants checked:
+//   • list tool exists in manifest
+//   • target tool exists
+//   • list's output schema is a list-object shape (via detectSnippetShape)
+//   • list items have a string field named `itemField`
+//   • target tool has an @Parameter named `targetParam`
+export function resolveFollowUpMap(config, byName) {
+  const resolved = {};
+  for (const [listName, entry] of Object.entries(config)) {
+    const listTool = byName.get(listName);
+    if (!listTool) {
+      throw new Error(`FOLLOW_UP_MAP: list tool missing: ${listName}`);
+    }
+    const target = byName.get(entry.target);
+    if (!target) {
+      throw new Error(`FOLLOW_UP_MAP: target tool missing: ${entry.target}`);
+    }
+
+    const info = detectSnippetShape(listTool.outputSchema ?? {});
+    if (info.shape !== "list-object") {
+      throw new Error(
+        `FOLLOW_UP_MAP: ${listName} is not a list-object shape (got ${info.shape})`,
+      );
+    }
+
+    const itemProps = listTool.outputSchema?.properties?.[info.arrayField]?.items?.properties ?? {};
+    if (itemProps[entry.itemField]?.type !== "string") {
+      throw new Error(
+        `FOLLOW_UP_MAP: ${listName} items have no string field "${entry.itemField}" (fields: ${Object.keys(itemProps).join(", ")})`,
+      );
+    }
+
+    const targetParams = Object.keys(target.inputSchema?.properties ?? {});
+    if (!targetParams.includes(entry.targetParam)) {
+      throw new Error(
+        `FOLLOW_UP_MAP: target ${entry.target} has no @Parameter named "${entry.targetParam}" (params: ${targetParams.join(", ")})`,
+      );
+    }
+
+    const targetIntentName = intentStructName(entry.target);
+    resolved[listName] = {
+      ...entry,
+      targetIntentName,
+      // Factory key by (target, targetParam). Two list tools pointing
+      // at the same read target with the same param share one factory;
+      // two list tools pointing at the same target via different params
+      // (unlikely but possible) each get their own.
+      factoryKey: `${targetIntentName}_${entry.targetParam}`,
+    };
+  }
+  return resolved;
+}
+
+// Deduplicate resolved follow-up entries by `(targetIntentName,
+// targetParam)` so the codegen emits one factory per unique signature
+// even when multiple list tools point at the same target.
+export function deriveFollowUpFactorySpecs(resolvedMap) {
+  return Array.from(
+    new Map(
+      Object.values(resolvedMap).map((e) => [
+        e.factoryKey,
+        { targetIntentName: e.targetIntentName, targetParam: e.targetParam },
+      ]),
+    ).values(),
+  );
+}

--- a/tests/codegen-helpers.test.js
+++ b/tests/codegen-helpers.test.js
@@ -35,7 +35,34 @@ import {
   MAX_TITLE_LEN,
   swiftParamDecl,
   buildArgsBlock,
+  resolveFollowUpMap,
+  deriveFollowUpFactorySpecs,
 } from "../scripts/lib/codegen-helpers.mjs";
+
+// Helper for resolveFollowUpMap tests: build a minimal manifest tool
+// with a list-object outputSchema carrying the named item fields.
+function makeListTool(name, itemFields) {
+  const itemProps = {};
+  for (const [field, type] of Object.entries(itemFields)) {
+    itemProps[field] = { type };
+  }
+  return {
+    name,
+    inputSchema: { properties: {} },
+    outputSchema: {
+      type: "object",
+      properties: {
+        items: { type: "array", items: { type: "object", properties: itemProps } },
+      },
+    },
+  };
+}
+
+function makeReadTool(name, paramNames) {
+  const props = {};
+  for (const p of paramNames) props[p] = { type: "string" };
+  return { name, inputSchema: { properties: props } };
+}
 
 describe("toPascalCase", () => {
   test("snake_case joins without underscore", () => {
@@ -808,5 +835,149 @@ describe("buildArgsBlock", () => {
     for (const line of out.prelude.split("\n")) {
       expect(line.startsWith("        ")).toBe(true);
     }
+  });
+});
+
+describe("resolveFollowUpMap", () => {
+  test("happy path — list + read match, id→id", () => {
+    const byName = new Map([
+      ["list_events", makeListTool("list_events", { id: "string", summary: "string" })],
+      ["read_event", makeReadTool("read_event", ["id"])],
+    ]);
+    const resolved = resolveFollowUpMap(
+      { list_events: { target: "read_event", itemField: "id", targetParam: "id" } },
+      byName,
+    );
+    expect(resolved.list_events).toEqual({
+      target: "read_event",
+      itemField: "id",
+      targetParam: "id",
+      targetIntentName: "ReadEventIntent",
+      factoryKey: "ReadEventIntent_id",
+    });
+  });
+
+  test("rename case — itemField id → targetParam chatId", () => {
+    const byName = new Map([
+      ["list_chats", makeListTool("list_chats", { id: "string", name: "string" })],
+      ["read_chat", makeReadTool("read_chat", ["chatId"])],
+    ]);
+    const resolved = resolveFollowUpMap(
+      { list_chats: { target: "read_chat", itemField: "id", targetParam: "chatId" } },
+      byName,
+    );
+    expect(resolved.list_chats.factoryKey).toBe("ReadChatIntent_chatId");
+  });
+
+  test("throws on missing list tool", () => {
+    expect(() =>
+      resolveFollowUpMap(
+        { missing: { target: "read_event", itemField: "id", targetParam: "id" } },
+        new Map(),
+      ),
+    ).toThrow(/list tool missing: missing/);
+  });
+
+  test("throws on missing target tool", () => {
+    const byName = new Map([
+      ["list_events", makeListTool("list_events", { id: "string" })],
+    ]);
+    expect(() =>
+      resolveFollowUpMap(
+        { list_events: { target: "read_missing", itemField: "id", targetParam: "id" } },
+        byName,
+      ),
+    ).toThrow(/target tool missing: read_missing/);
+  });
+
+  test("throws when list output is not list-object", () => {
+    const byName = new Map([
+      ["not_list", { name: "not_list", inputSchema: {}, outputSchema: { type: "object", properties: { scalar: { type: "string" } } } }],
+      ["read_event", makeReadTool("read_event", ["id"])],
+    ]);
+    expect(() =>
+      resolveFollowUpMap(
+        { not_list: { target: "read_event", itemField: "id", targetParam: "id" } },
+        byName,
+      ),
+    ).toThrow(/is not a list-object shape \(got scalar\)/);
+  });
+
+  test("throws when items missing the named itemField", () => {
+    const byName = new Map([
+      ["list_events", makeListTool("list_events", { summary: "string" })], // no id
+      ["read_event", makeReadTool("read_event", ["id"])],
+    ]);
+    expect(() =>
+      resolveFollowUpMap(
+        { list_events: { target: "read_event", itemField: "id", targetParam: "id" } },
+        byName,
+      ),
+    ).toThrow(/items have no string field "id" \(fields: summary\)/);
+  });
+
+  test("throws when target missing the named @Parameter", () => {
+    const byName = new Map([
+      ["list_events", makeListTool("list_events", { id: "string", summary: "string" })],
+      ["read_event", makeReadTool("read_event", ["eventId"])], // no `id`
+    ]);
+    expect(() =>
+      resolveFollowUpMap(
+        { list_events: { target: "read_event", itemField: "id", targetParam: "id" } },
+        byName,
+      ),
+    ).toThrow(/target read_event has no @Parameter named "id" \(params: eventId\)/);
+  });
+
+  test("empty config → empty resolved map", () => {
+    expect(resolveFollowUpMap({}, new Map())).toEqual({});
+  });
+});
+
+describe("deriveFollowUpFactorySpecs", () => {
+  test("two list tools → same (target, param) share one factory", () => {
+    const resolved = {
+      list_events: {
+        target: "read_event",
+        itemField: "id",
+        targetParam: "id",
+        targetIntentName: "ReadEventIntent",
+        factoryKey: "ReadEventIntent_id",
+      },
+      search_events: {
+        target: "read_event",
+        itemField: "id",
+        targetParam: "id",
+        targetIntentName: "ReadEventIntent",
+        factoryKey: "ReadEventIntent_id",
+      },
+    };
+    const specs = deriveFollowUpFactorySpecs(resolved);
+    expect(specs).toHaveLength(1);
+    expect(specs[0]).toEqual({ targetIntentName: "ReadEventIntent", targetParam: "id" });
+  });
+
+  test("same target + different param → two factories", () => {
+    const resolved = {
+      list_events: {
+        target: "read_event",
+        targetIntentName: "ReadEventIntent",
+        targetParam: "id",
+        factoryKey: "ReadEventIntent_id",
+      },
+      list_chats: {
+        target: "read_chat",
+        targetIntentName: "ReadChatIntent",
+        targetParam: "chatId",
+        factoryKey: "ReadChatIntent_chatId",
+      },
+    };
+    const specs = deriveFollowUpFactorySpecs(resolved);
+    expect(specs).toHaveLength(2);
+    expect(specs.map((s) => s.targetParam).sort()).toEqual(["chatId", "id"]);
+  });
+
+  test("empty resolved map → empty specs", () => {
+    expect(deriveFollowUpFactorySpecs({})).toEqual([]);
   });
 });


### PR DESCRIPTION
## Summary

Closes out the codegen helper extraction stream (cards ①-④ from the prior session handoff). \`resolveFollowUpMap\` is the last stateful piece — it validates \`FOLLOW_UP_MAP\` against the manifest and produces the resolved per-list entries the snippet-view renderer consumes. Making it pure (\`config\` + \`byName\` as args, throws instead of \`process.exit\`) lets tests exercise every invariant branch.

Stacked on [#130](https://github.com/heznpc/AirMCP/pull/130).

## Extracted

- **\`resolveFollowUpMap(config, byName)\`** — validates every FOLLOW_UP_MAP entry (list tool exists, target tool exists, list is list-object, items carry the named string field, target has the named \`@Parameter\`). Throws with specific error messages. CLI wrapper in \`gen-swift-intents.mjs\` converts throws to \`process.exit(2)\`.
- **\`deriveFollowUpFactorySpecs(resolvedMap)\`** — dedupe resolved entries by \`(targetIntentName, targetParam)\` so the generator emits one SwiftUI Button factory per unique \`(target, param)\` signature.

## Test coverage (+11, total 109)

### \`resolveFollowUpMap\`
- Happy path (id→id) + rename case (\`list_chats.id → read_chat.chatId\`)
- Each invariant throws the expected message:
  - missing list tool
  - missing target tool
  - non-list-object output shape
  - items missing the named field
  - target missing the named \`@Parameter\`
- Empty config → empty resolved map

### \`deriveFollowUpFactorySpecs\`
- Two list tools → same \`(target, param)\` share one factory
- Same target + different param → two factories
- Empty resolved map → empty specs

## Extraction stream — what remains in gen-swift-intents.mjs

**Covered** (all pure, all tested in [tests/codegen-helpers.test.js](tests/codegen-helpers.test.js)):
\`toPascalCase\`, \`swiftIdent\`, \`SWIFT_RESERVED\`, \`swiftLit\`, \`humanizeKey\`, \`enumCaseName\`, \`enumCaseDisplayLabel\`, \`enumTypeName\`, \`intentStructName\`, \`intentActionNameFor\`, \`swiftTypeFor\`, \`swiftDefaultLiteral\`, \`enumDefaultLiteral\`, \`wireExpr\`, \`isNullableUnion\`, \`nonNullType\`, \`outputTypeNameFor\`, \`snippetViewNameFor\`, \`detectSnippetShape\`, \`SYSTEM_IMAGE_BY_PREFIX\`, \`systemImageFor\`, \`collectEnums\`, \`renderAppEnum\`, \`MAX_TITLE_LEN\`, \`swiftParamDecl\`, \`buildArgsBlock\`, \`resolveFollowUpMap\`, \`deriveFollowUpFactorySpecs\`.

**Remaining in the generator** (genuinely orchestration, not pure):
- Manifest load + validation
- \`APP_SHORTCUTS_TOP\` hand-picked config
- \`FOLLOW_UP_MAP\` hand-picked config
- \`INCLUDE_DESTRUCTIVE\` env-var opt-in
- \`generateIntent\` (uses module-level \`enumsByTool\`, \`followUpMap\` — candidate for a future round if the axis needs further cleanup, but shipping as-is is a sensible stopping point since the orchestration needs the full generator context)
- \`renderScalarRow\`, \`renderSnippetView\` (pure but heavily coupled to generator locals)
- \`generateAppShortcuts\` (reads \`appShortcutsPicks\` from module scope)
- Source assembly + write/check

## Test plan

- [x] \`npm test -- tests/codegen-helpers.test.js\` → 109 passed
- [x] \`npm run gen:intents:check\` — byte-identical (229 intents)
- [x] \`swift build\` passes (7.0s)
- [x] gen-swift-intents.mjs: 903 → 859 LOC; codegen-helpers.mjs: 392 → 473 LOC

## Note on the parallel session's branch

The fresh session's \`4357d67\` on \`claude/wonderful-pascal-d7a224\` is still off pre-stack \`main\`. It targets a different file (\`scripts/lib/swift-intents-codegen.mjs\`) with overlapping exports (\`toPascalCase\`, \`swiftIdent\`, \`isNullableUnion\`, \`nonNullType\`) plus new additions (\`isCodableSafe\`, \`swiftOutputType\`, \`renderStruct\`). That branch still needs a merge decision — either cherry-pick its new-additions on top of this stack or reconcile the two \`lib/\` files into one.