### PR TITLE
feat: well-known discovery card — tool + module inventory for registries

### DIFF
--- a/src/server/http-transport.ts
+++ b/src/server/http-transport.ts
@@ -11,8 +11,10 @@ import { LIMITS, TIMEOUT } from "../shared/constants.js";
 import { printBanner } from "../shared/banner.js";
 import { auditLog } from "../shared/audit.js";
 import { SERVER_ICON, WEBSITE_URL } from "../shared/icons.js";
+import { toolRegistry } from "../shared/tool-registry.js";
 import { createServer, type CreateServerOptions } from "./mcp-setup.js";
 import { registerShutdownHook } from "./shutdown.js";
+import { buildServerCard } from "./well-known-card.js";
 
 // ── Per-IP rate limiter (token bucket, no external dependency) ────────
 const RATE_WINDOW_MS = 60_000;
@@ -314,27 +316,34 @@ export async function startHttpServer(options: HttpServerOptions): Promise<void>
     });
   });
 
-  // MCP Server Card — spec 2025-11-25 .well-known discovery
-  const serverCard = {
-    name: NPM_PACKAGE_NAME,
-    version: pkg.version,
-    description: pkg.description,
-    websiteUrl: WEBSITE_URL,
-    icons: [SERVER_ICON],
-    transport: { type: "streamable-http" as const, url: "/mcp" },
-    capabilities: {
-      tools: { listChanged: true },
-      prompts: { listChanged: true },
-      resources: { listChanged: true },
-    },
-    ...(httpToken ? { authorization: { type: "bearer" as const } } : {}),
-    // Expose the declarative network policy so Managed Agents / discovery
-    // clients can reason about the exposure before they connect (RFC 0002).
-    network_policy: allowNetwork,
-    ...(allowedOrigins.size > 0 ? { allowed_origins: [...allowedOrigins] } : {}),
-    ...(allowNetwork === "unauthenticated" ? { security: "insecure" as const } : {}),
-  };
-  app.get("/.well-known/mcp.json", (_req, res) => res.json(serverCard));
+  // MCP Server Card — .well-known discovery for registry crawlers.
+  // Shape + rationale lives in well-known-card.ts; we capture the
+  // enabled-module list via closure so it reflects the live module
+  // selection once `createServer` runs (depends on config + OS gates).
+  let enabledModuleNames: string[] = [];
+  app.get("/.well-known/mcp.json", (_req, res) => {
+    res.json(
+      buildServerCard({
+        name: NPM_PACKAGE_NAME,
+        version: pkg.version,
+        description: pkg.description,
+        license: pkg.license,
+        homepage: pkg.homepage,
+        websiteUrl: WEBSITE_URL,
+        icon: SERVER_ICON,
+        httpToken,
+        allowNetwork,
+        allowedOrigins: [...allowedOrigins],
+        // Read tool inventory at request time so a hot-reload or a
+        // later `listChanged` notification doesn't leave the card stale.
+        tools: {
+          count: toolRegistry.getToolCount(),
+          names: toolRegistry.getToolNames(),
+        },
+        modules: enabledModuleNames,
+      }),
+    );
+  });
 
   // Request ID middleware for tracing
   app.use((req, res, next) => {
@@ -506,6 +515,10 @@ export async function startHttpServer(options: HttpServerOptions): Promise<void>
   } = await createServer(serverOptions);
   warmupCleanup();
   warmupServer.close?.();
+  // Publish the resolved enabled-module list into the .well-known
+  // card's closure so registry crawlers see what's actually loaded
+  // on this host (module enablement depends on config + OS gates).
+  enabledModuleNames = bi.modulesEnabled;
   const host = bindAll ? "0.0.0.0" : "127.0.0.1";
   const httpServer = app.listen(port, host, async () => {
     bi.transport = "http";

--- a/src/server/mcp-setup.ts
+++ b/src/server/mcp-setup.ts
@@ -37,7 +37,7 @@ export interface CreateServerOptions {
   config: AirMcpConfig;
   hitlClient: HitlClient | null;
   osVersion: number;
-  pkg: { version: string; description?: string };
+  pkg: { version: string; description?: string; license?: string; homepage?: string };
 }
 
 export async function createServer(

--- a/src/server/well-known-card.ts
+++ b/src/server/well-known-card.ts
@@ -1,0 +1,80 @@
+/**
+ * `.well-known/mcp.json` — MCP Server Card builder.
+ *
+ * Pure function that assembles the discovery card served at
+ * `/.well-known/mcp.json`. Lives in its own module so the card shape
+ * can be unit-tested without spinning up an Express server.
+ *
+ * Registry crawlers (Anthropic MCP Registry, Smithery, PulseMCP,
+ * Glama) hit this endpoint to build their catalog. Beyond the MCP
+ * spec minimum (2025-11-25: name, version, transport, capabilities),
+ * AirMCP adds:
+ *   - `tools: { count, names[] }` — full tool inventory so crawlers
+ *     can surface the surface area without opening a session
+ *   - `modules[]` — the enabled module list for this host (depends
+ *     on config + OS compatibility gates)
+ *   - `license` / `homepage` — standard registry metadata
+ *   - `schema_version` — pins the spec revision the card conforms to
+ *   - `network_policy` + `allowed_origins` — from RFC 0002 so
+ *     Managed Agents can reason about exposure before connecting
+ */
+
+// Kept as an inline union instead of importing AllowNetwork from
+// http-transport.ts so this module stays free of Express / MCP SDK
+// dependencies — tests can load it without mocking either.
+type AllowNetwork = "loopback-only" | "with-token" | "with-token+origin" | "unauthenticated";
+
+export interface ServerCardInput {
+  /** npm package name, used as the card's primary identifier. */
+  name: string;
+  version: string;
+  description?: string;
+  license?: string;
+  homepage?: string;
+  websiteUrl: string;
+  /** Full icon descriptor per MCP spec — `{ src, mimeType, sizes }`
+   *  or a bare data/https URL. Embedded verbatim into `icons[]`. */
+  icon: string | { src: string; mimeType?: string; sizes?: string[] };
+  httpToken?: string;
+  allowNetwork: AllowNetwork;
+  allowedOrigins: string[];
+  tools: { count: number; names: string[] };
+  modules: string[];
+}
+
+/** MCP spec revision this card shape conforms to. Bumped when the
+ *  published spec changes its top-level contract.  */
+export const SCHEMA_VERSION = "2025-11-25" as const;
+
+export function buildServerCard(input: ServerCardInput): Record<string, unknown> {
+  const card: Record<string, unknown> = {
+    name: input.name,
+    version: input.version,
+    schema_version: SCHEMA_VERSION,
+    websiteUrl: input.websiteUrl,
+    icons: [input.icon],
+    transport: { type: "streamable-http", url: "/mcp" },
+    capabilities: {
+      tools: { listChanged: true },
+      prompts: { listChanged: true },
+      resources: { listChanged: true },
+    },
+    network_policy: input.allowNetwork,
+    tools: {
+      count: input.tools.count,
+      names: input.tools.names,
+    },
+    modules: input.modules,
+  };
+
+  // Optional fields — only emit when present so the card stays tight
+  // on stdio-first deployments where most of this is absent.
+  if (input.description) card.description = input.description;
+  if (input.license) card.license = input.license;
+  if (input.homepage) card.homepage = input.homepage;
+  if (input.httpToken) card.authorization = { type: "bearer" };
+  if (input.allowedOrigins.length > 0) card.allowed_origins = input.allowedOrigins;
+  if (input.allowNetwork === "unauthenticated") card.security = "insecure";
+
+  return card;
+}

--- a/tests/http-transport.test.js
+++ b/tests/http-transport.test.js
@@ -32,8 +32,18 @@ jest.unstable_mockModule('../dist/shared/audit.js', () => ({
 jest.unstable_mockModule('../dist/server/mcp-setup.js', () => ({
   createServer: jest.fn(async () => ({
     server: { connect: jest.fn(), close: jest.fn(), sendResourceListChanged: jest.fn() },
-    bannerInfo: { transport: 'http', version: '2.6.0' },
+    bannerInfo: { transport: 'http', version: '2.6.0', modulesEnabled: [] },
   })),
+}));
+// tool-registry's transitive deps (usage-tracker, audit) touch
+// PATHS + FS — not relevant to http-transport's surface tests, so
+// stub the only two methods the .well-known handler reads at request
+// time.
+jest.unstable_mockModule('../dist/shared/tool-registry.js', () => ({
+  toolRegistry: {
+    getToolCount: () => 0,
+    getToolNames: () => [],
+  },
 }));
 
 describe('HTTP transport module', () => {

--- a/tests/well-known-card.test.js
+++ b/tests/well-known-card.test.js
@@ -1,0 +1,170 @@
+// `.well-known/mcp.json` discovery card shape tests.
+//
+// The card is how registry crawlers (Anthropic MCP Registry, Smithery,
+// PulseMCP, Glama) build their catalog without connecting. A silent
+// shape regression breaks crawler parsing upstream — pin the contract.
+
+import { describe, test, expect } from "@jest/globals";
+import { buildServerCard, SCHEMA_VERSION } from "../dist/server/well-known-card.js";
+
+const baseInput = () => ({
+  name: "airmcp",
+  version: "2.11.0",
+  description: "MCP server for the entire Apple ecosystem",
+  license: "MIT",
+  homepage: "https://github.com/heznpc/AirMCP",
+  websiteUrl: "https://github.com/heznpc/AirMCP",
+  icon: "https://example.com/icon.png",
+  allowNetwork: "loopback-only",
+  allowedOrigins: [],
+  tools: { count: 270, names: ["list_events", "read_note", "search_contacts"] },
+  modules: ["calendar", "notes", "contacts"],
+});
+
+describe("buildServerCard — required fields", () => {
+  test("always emits name / version / schema_version / transport / capabilities", () => {
+    const card = buildServerCard(baseInput());
+    expect(card.name).toBe("airmcp");
+    expect(card.version).toBe("2.11.0");
+    expect(card.schema_version).toBe(SCHEMA_VERSION);
+    expect(card.transport).toEqual({ type: "streamable-http", url: "/mcp" });
+    expect(card.capabilities).toEqual({
+      tools: { listChanged: true },
+      prompts: { listChanged: true },
+      resources: { listChanged: true },
+    });
+  });
+
+  test("SCHEMA_VERSION matches MCP spec 2025-11-25", () => {
+    // Const-assertion pinning — if the spec date changes, update here
+    // intentionally so crawlers know we re-audited the card shape.
+    expect(SCHEMA_VERSION).toBe("2025-11-25");
+  });
+
+  test("network_policy is always present (RFC 0002 contract)", () => {
+    const card = buildServerCard(baseInput());
+    expect(card.network_policy).toBe("loopback-only");
+  });
+});
+
+describe("buildServerCard — tool + module inventory (registry discovery)", () => {
+  test("tools object carries count + full name list", () => {
+    const card = buildServerCard(baseInput());
+    expect(card.tools).toEqual({
+      count: 270,
+      names: ["list_events", "read_note", "search_contacts"],
+    });
+  });
+
+  test("modules array is verbatim", () => {
+    const card = buildServerCard(baseInput());
+    expect(card.modules).toEqual(["calendar", "notes", "contacts"]);
+  });
+
+  test("empty inventory still renders a well-formed card (fresh install edge case)", () => {
+    const card = buildServerCard({
+      ...baseInput(),
+      tools: { count: 0, names: [] },
+      modules: [],
+    });
+    expect(card.tools).toEqual({ count: 0, names: [] });
+    expect(card.modules).toEqual([]);
+  });
+});
+
+describe("buildServerCard — icons", () => {
+  test("accepts a string icon URL", () => {
+    const card = buildServerCard(baseInput());
+    expect(card.icons).toEqual(["https://example.com/icon.png"]);
+  });
+
+  test("accepts an MCP-spec icon descriptor object", () => {
+    const card = buildServerCard({
+      ...baseInput(),
+      icon: { src: "data:image/svg+xml;base64,abc", mimeType: "image/svg+xml", sizes: ["any"] },
+    });
+    expect(card.icons).toEqual([
+      { src: "data:image/svg+xml;base64,abc", mimeType: "image/svg+xml", sizes: ["any"] },
+    ]);
+  });
+});
+
+describe("buildServerCard — optional field emission", () => {
+  test("omits description when absent", () => {
+    const card = buildServerCard({ ...baseInput(), description: undefined });
+    expect("description" in card).toBe(false);
+  });
+
+  test("omits license / homepage when absent", () => {
+    const card = buildServerCard({ ...baseInput(), license: undefined, homepage: undefined });
+    expect("license" in card).toBe(false);
+    expect("homepage" in card).toBe(false);
+  });
+
+  test("emits authorization bearer when httpToken present", () => {
+    const card = buildServerCard({ ...baseInput(), httpToken: "secret" });
+    expect(card.authorization).toEqual({ type: "bearer" });
+  });
+
+  test("omits authorization when no token (stdio/loopback)", () => {
+    const card = buildServerCard(baseInput());
+    expect("authorization" in card).toBe(false);
+  });
+
+  test("emits allowed_origins when non-empty", () => {
+    const card = buildServerCard({
+      ...baseInput(),
+      allowedOrigins: ["https://claude.ai", "https://cursor.com"],
+    });
+    expect(card.allowed_origins).toEqual(["https://claude.ai", "https://cursor.com"]);
+  });
+
+  test("omits allowed_origins when empty (default loopback)", () => {
+    const card = buildServerCard(baseInput());
+    expect("allowed_origins" in card).toBe(false);
+  });
+});
+
+describe("buildServerCard — network policy flags", () => {
+  test("loopback-only: no auth flag, no security flag", () => {
+    const card = buildServerCard(baseInput());
+    expect(card.network_policy).toBe("loopback-only");
+    expect("authorization" in card).toBe(false);
+    expect("security" in card).toBe(false);
+  });
+
+  test("with-token: emits authorization when token is set", () => {
+    const card = buildServerCard({
+      ...baseInput(),
+      allowNetwork: "with-token",
+      httpToken: "secret",
+    });
+    expect(card.network_policy).toBe("with-token");
+    expect(card.authorization).toEqual({ type: "bearer" });
+  });
+
+  test("unauthenticated: adds security: insecure flag", () => {
+    const card = buildServerCard({
+      ...baseInput(),
+      allowNetwork: "unauthenticated",
+    });
+    expect(card.network_policy).toBe("unauthenticated");
+    expect(card.security).toBe("insecure");
+  });
+});
+
+describe("buildServerCard — JSON round-trip", () => {
+  test("full card serializes cleanly (no circular refs, no undefined leaves)", () => {
+    const card = buildServerCard({
+      ...baseInput(),
+      httpToken: "x",
+      allowedOrigins: ["https://claude.ai"],
+      allowNetwork: "with-token+origin",
+    });
+    const serialized = JSON.stringify(card);
+    expect(() => JSON.parse(serialized)).not.toThrow();
+    const parsed = JSON.parse(serialized);
+    expect(parsed.name).toBe("airmcp");
+    expect(parsed.tools.count).toBe(270);
+  });
+});


### PR DESCRIPTION
## Summary

Registry crawlers (Anthropic MCP Registry, Smithery, PulseMCP, Glama) hit \`/.well-known/mcp.json\` to build their catalog without opening a live MCP session. The spec-minimum card was already served from v2.10 (network_policy + allowed_origins from RFC 0002), but crawlers still had to fall back to the npm README or connect live to discover what the server actually does.

This PR extends the card with registry-friendly inventory fields. **P0 item from the external-trends roadmap mapping.**

Stacked on [#131](https://github.com/heznpc/AirMCP/pull/131).

## New fields in the card

\`\`\`json
{
  "name": "airmcp",
  "version": "2.11.0",
  "schema_version": "2025-11-25",
  "license": "MIT",
  "homepage": "https://github.com/heznpc/AirMCP",
  "tools": {
    "count": 270,
    "names": ["list_events", "read_note", "search_contacts", ...]
  },
  "modules": ["calendar", "notes", "contacts", ...],
  "network_policy": "loopback-only",
  ...
}
\`\`\`

## Reading strategy

- **Tool count/names** read from \`toolRegistry\` at request time — so a \`listChanged\` notification doesn't leave the card stale
- **Enabled module list** captured via closure from \`createServer\`'s \`bannerInfo\` (reflects OS gates + user config, not just \`MODULE_NAMES\`)
- **License / homepage** pulled from \`package.json\`; omitted cleanly if absent
- **\`schema_version: "2025-11-25"\`** pins the MCP spec revision the card conforms to; a future spec bump is a 1-line change + test update

## Refactor

- \`buildServerCard\` extracted to [src/server/well-known-card.ts](src/server/well-known-card.ts) as a **pure function** — no Express or MCP-SDK deps, unit-testable. The Express handler becomes a 3-line \`res.json\` wrapper.

## Test coverage (+18, total 1463 suite-wide)

[tests/well-known-card.test.js](tests/well-known-card.test.js):
- Required fields: \`name\` / \`version\` / \`schema_version\` / \`transport\` / \`capabilities\` / \`network_policy\` always present
- \`SCHEMA_VERSION\` const pin — sentinel for MCP spec revision
- Inventory shape: \`tools: { count, names }\`, \`modules[]\`, including fresh-install zero-state
- Icon accepts string OR MCP-spec descriptor (\`{ src, mimeType, sizes }\`)
- Optional field emission (\`description\` / \`license\` / \`homepage\` / \`authorization\` / \`allowed_origins\` / \`security\`)
- All 4 \`allowNetwork\` branches (loopback-only / with-token / with-token+origin / unauthenticated)
- JSON round-trip (no circular refs, no \`undefined\` leaves)

Also: [tests/http-transport.test.js](tests/http-transport.test.js) mock list expanded with a \`toolRegistry\` stub — transitive deps (\`usage-tracker\`, \`audit\`) would otherwise fail the existing tests now that \`http-transport\` imports \`toolRegistry\`.

## Test plan

- [x] \`npm test\` → 1463 passed (94 suites)
- [x] \`npm run typecheck\` passes
- [x] \`npm run smoke\` → 125 tools registered
- [x] \`npm run gen:intents:check\` byte-identical
- [x] \`node scripts/verify-tool-manifest.mjs\` + \`node scripts/verify-golden-intents.mjs\` green
- [ ] Manual: curl a running HTTP server on \`/.well-known/mcp.json\` and confirm shape. Unit coverage pins the builder; running confirms routing.