### PR TITLE
test(rfc-0007): extract outputSchema Codable codegen primitives

### DIFF
--- a/scripts/gen-swift-intents.mjs
+++ b/scripts/gen-swift-intents.mjs
@@ -64,6 +64,10 @@ import {
   buildArgsBlock,
   resolveFollowUpMap as _resolveFollowUpMap,
   deriveFollowUpFactorySpecs,
+  isCodableSafe,
+  swiftOutputType,
+  renderStruct,
+  hasTypedOutput,
 } from "./lib/codegen-helpers.mjs";
 
 // CLI wrappers: the lib throws on invalid enum value so tests can
@@ -236,120 +240,9 @@ for (const name of APP_SHORTCUTS_TOP) {
 // Everything else (oneOf, allOf, recursive refs) would require AnyCodable
 // or more elaborate machinery — out of A.2b.2 scope.
 
-// isNullableUnion, nonNullType imported from scripts/lib/codegen-helpers.mjs.
-
-function isCodableSafe(schema) {
-  if (!schema || typeof schema !== "object") return true;
-  if (schema.type === "object") {
-    if (schema.additionalProperties === true) return false;
-    if (
-      schema.additionalProperties &&
-      typeof schema.additionalProperties === "object" &&
-      Object.keys(schema.additionalProperties).length === 0
-    ) {
-      return false;
-    }
-    for (const p of Object.values(schema.properties ?? {})) {
-      if (!isCodableSafe(p)) return false;
-    }
-    return true;
-  }
-  if (schema.type === "array") return isCodableSafe(schema.items);
-  return true;
-}
-
-/**
- * Map a JSON-Schema node to a Swift type expression, recording any
- * inline-nested object as a sub-struct declaration on `nested`.
- *
- * `path` is the PascalCased path from the outer struct down to this
- * node — used to name nested structs deterministically.
- */
-function swiftOutputType(schema, path, nested) {
-  if (isNullableUnion(schema)) {
-    const inner = nonNullType(schema);
-    return swiftOutputType({ ...schema, type: inner }, path, nested) + "?";
-  }
-  if (schema.type === "string") return "String";
-  if (schema.type === "number") return "Double";
-  if (schema.type === "integer") return "Int";
-  if (schema.type === "boolean") return "Bool";
-  if (schema.type === "array") {
-    const itemSchema = schema.items ?? {};
-    const itemName = `${path}Item`;
-    const itemType = swiftOutputType(itemSchema, itemName, nested);
-    return `[${itemType}]`;
-  }
-  if (schema.type === "object") {
-    nested.push({ name: path, schema });
-    return path;
-  }
-  // Fallback — shouldn't occur for codable-safe schemas.
-  return "String";
-}
-
-/**
- * Render an object-typed schema into a Swift struct declaration.
- * Nested object fields are rendered as inner structs (Swift doesn't
- * require forward declarations, so order within the file doesn't matter).
- */
-function renderStruct(name, schema, indent = "    ") {
-  const props = schema.properties ?? {};
-  const required = new Set(schema.required ?? []);
-  const nested = [];
-  const fieldLines = [];
-
-  for (const wireName of Object.keys(props)) {
-    const fieldSchema = props[wireName];
-    const fieldName = swiftIdent(wireName);
-    const pascal = toPascalCase(wireName);
-    let fieldType = swiftOutputType(fieldSchema, pascal, nested);
-    if (!required.has(wireName) && !fieldType.endsWith("?")) {
-      fieldType += "?";
-    }
-    fieldLines.push(`${indent}public let ${fieldName}: ${fieldType}`);
-  }
-
-  const nestedLines = nested.map((n) => renderStruct(n.name, n.schema, indent + "    ")).join("\n");
-
-  // Swift synthesizes CodingKeys from property names unless we override.
-  // We override only when at least one wire key had to be escaped (e.g.
-  // `class` → `class_`); in that case *every* key must be listed or the
-  // compiler rejects the partial enum.
-  const anyKeyEscaped = Object.keys(props).some((k) => swiftIdent(k) !== k);
-  const codingKeysBlock = anyKeyEscaped
-    ? `\n${indent}enum CodingKeys: String, CodingKey {\n` +
-      Object.keys(props)
-        .map((k) => {
-          const ident = swiftIdent(k);
-          return `${indent}    case ${ident}${ident !== k ? ` = "${k}"` : ""}`;
-        })
-        .join("\n") +
-      `\n${indent}}`
-    : "";
-
-  const body = [nestedLines ? nestedLines + "\n" : "", fieldLines.join("\n"), codingKeysBlock]
-    .filter(Boolean)
-    .join("\n");
-
-  return `${indent.slice(4)}public struct ${name}: Codable, Sendable {
-${body}
-${indent.slice(4)}}`;
-}
-
-// outputTypeNameFor imported from scripts/lib/codegen-helpers.mjs.
-
-/**
- * Does this tool ship A.2b.2-level typed output? Requires:
- *   • outputSchema present
- *   • top-level is `type: object` (everything else is too free-form)
- *   • no record-like additionalProperties anywhere in the tree
- */
-function hasTypedOutput(tool) {
-  const s = tool.outputSchema;
-  if (!s || s.type !== "object") return false;
-  return isCodableSafe(s);
-}
+// isNullableUnion, nonNullType, isCodableSafe, swiftOutputType,
+// renderStruct, hasTypedOutput, outputTypeNameFor all imported from
+// scripts/lib/codegen-helpers.mjs.
 
 function generateIntent(tool) {
   const structName = intentStructName(tool.name);

--- a/scripts/lib/codegen-helpers.mjs
+++ b/scripts/lib/codegen-helpers.mjs
@@ -257,6 +257,131 @@ export function systemImageFor(toolName) {
   return "app.connected.to.app.below.fill";
 }
 
+// ── outputSchema → Swift Codable struct codegen ────────────────────────
+//
+// Walks an outputSchema JSON and produces a Swift `Codable, Sendable`
+// struct hierarchy. Rules:
+//   • String / Int / Double / Bool → primitive
+//   • Nullable union {type: [X, "null"]} → Optional<SwiftX>
+//   • array → [Element] (Element recursively mapped)
+//   • nested object → nested Swift struct (named by the PascalCased
+//     path from the outer struct — `ListCalendarsOutput.CalendarsItem`)
+//   • additionalProperties: true OR {} → the tool is flagged not-
+//     codable-safe and falls back to ReturnsValue<String>
+//
+// Everything else (oneOf, allOf, recursive refs) would require
+// AnyCodable or more elaborate machinery — out of A.2b.2 scope.
+
+// Is this schema tree fully expressible as Swift Codable types?
+// Rejects record-shaped schemas (additionalProperties: true or {})
+// anywhere in the tree.
+export function isCodableSafe(schema) {
+  if (!schema || typeof schema !== "object") return true;
+  if (schema.type === "object") {
+    if (schema.additionalProperties === true) return false;
+    if (
+      schema.additionalProperties &&
+      typeof schema.additionalProperties === "object" &&
+      Object.keys(schema.additionalProperties).length === 0
+    ) {
+      return false;
+    }
+    for (const p of Object.values(schema.properties ?? {})) {
+      if (!isCodableSafe(p)) return false;
+    }
+    return true;
+  }
+  if (schema.type === "array") return isCodableSafe(schema.items);
+  return true;
+}
+
+// Map a JSON-Schema node to a Swift type expression, recording any
+// inline-nested object as a sub-struct declaration on `nested`.
+//
+// `path` is the PascalCased path from the outer struct down to this
+// node — used to name nested structs deterministically.
+export function swiftOutputType(schema, path, nested) {
+  if (isNullableUnion(schema)) {
+    const inner = nonNullType(schema);
+    return swiftOutputType({ ...schema, type: inner }, path, nested) + "?";
+  }
+  if (schema.type === "string") return "String";
+  if (schema.type === "number") return "Double";
+  if (schema.type === "integer") return "Int";
+  if (schema.type === "boolean") return "Bool";
+  if (schema.type === "array") {
+    const itemSchema = schema.items ?? {};
+    const itemName = `${path}Item`;
+    const itemType = swiftOutputType(itemSchema, itemName, nested);
+    return `[${itemType}]`;
+  }
+  if (schema.type === "object") {
+    nested.push({ name: path, schema });
+    return path;
+  }
+  // Fallback — shouldn't occur for codable-safe schemas.
+  return "String";
+}
+
+// Render an object-typed schema into a Swift `public struct Name:
+// Codable, Sendable { … }`. Nested object fields are rendered as
+// inner structs (Swift doesn't require forward declarations, so
+// order within the file doesn't matter).
+//
+// CodingKeys are synthesized automatically unless at least one wire
+// key needed Swift-identifier escaping (e.g. `class` → `class_`); in
+// that case *every* key must be listed or the compiler rejects the
+// partial enum.
+export function renderStruct(name, schema, indent = "    ") {
+  const props = schema.properties ?? {};
+  const required = new Set(schema.required ?? []);
+  const nested = [];
+  const fieldLines = [];
+
+  for (const wireName of Object.keys(props)) {
+    const fieldSchema = props[wireName];
+    const fieldName = swiftIdent(wireName);
+    const pascal = toPascalCase(wireName);
+    let fieldType = swiftOutputType(fieldSchema, pascal, nested);
+    if (!required.has(wireName) && !fieldType.endsWith("?")) {
+      fieldType += "?";
+    }
+    fieldLines.push(`${indent}public let ${fieldName}: ${fieldType}`);
+  }
+
+  const nestedLines = nested.map((n) => renderStruct(n.name, n.schema, indent + "    ")).join("\n");
+
+  const anyKeyEscaped = Object.keys(props).some((k) => swiftIdent(k) !== k);
+  const codingKeysBlock = anyKeyEscaped
+    ? `\n${indent}enum CodingKeys: String, CodingKey {\n` +
+      Object.keys(props)
+        .map((k) => {
+          const ident = swiftIdent(k);
+          return `${indent}    case ${ident}${ident !== k ? ` = "${k}"` : ""}`;
+        })
+        .join("\n") +
+      `\n${indent}}`
+    : "";
+
+  const body = [nestedLines ? nestedLines + "\n" : "", fieldLines.join("\n"), codingKeysBlock]
+    .filter(Boolean)
+    .join("\n");
+
+  return `${indent.slice(4)}public struct ${name}: Codable, Sendable {
+${body}
+${indent.slice(4)}}`;
+}
+
+// Does this tool ship A.2b.2-level typed output? Requires:
+//   • outputSchema present
+//   • top-level is `type: object` (everything else is too free-form)
+//   • no record-like additionalProperties anywhere in the tree
+export function hasTypedOutput(tool) {
+  const s = tool.outputSchema;
+  if (!s || s.type !== "object") return false;
+  return isCodableSafe(s);
+}
+
 // ── @Parameter declaration + args dict synthesis ───────────────────────
 
 // Keep @Parameter titles short enough to render well in Shortcuts

--- a/tests/codegen-helpers.test.js
+++ b/tests/codegen-helpers.test.js
@@ -37,6 +37,10 @@ import {
   buildArgsBlock,
   resolveFollowUpMap,
   deriveFollowUpFactorySpecs,
+  isCodableSafe,
+  swiftOutputType,
+  renderStruct,
+  hasTypedOutput,
 } from "../scripts/lib/codegen-helpers.mjs";
 
 // Helper for resolveFollowUpMap tests: build a minimal manifest tool
@@ -979,5 +983,265 @@ describe("deriveFollowUpFactorySpecs", () => {
 
   test("empty resolved map → empty specs", () => {
     expect(deriveFollowUpFactorySpecs({})).toEqual([]);
+  });
+});
+
+describe("isCodableSafe", () => {
+  test("primitives are always safe", () => {
+    expect(isCodableSafe({ type: "string" })).toBe(true);
+    expect(isCodableSafe({ type: "integer" })).toBe(true);
+    expect(isCodableSafe({ type: "number" })).toBe(true);
+    expect(isCodableSafe({ type: "boolean" })).toBe(true);
+  });
+
+  test("object with constrained properties is safe", () => {
+    expect(
+      isCodableSafe({
+        type: "object",
+        properties: { name: { type: "string" }, age: { type: "integer" } },
+      }),
+    ).toBe(true);
+  });
+
+  test("additionalProperties: true rejects the schema", () => {
+    expect(
+      isCodableSafe({ type: "object", properties: {}, additionalProperties: true }),
+    ).toBe(false);
+  });
+
+  test("additionalProperties: {} (empty object) rejects the schema — record shape", () => {
+    expect(
+      isCodableSafe({ type: "object", properties: {}, additionalProperties: {} }),
+    ).toBe(false);
+  });
+
+  test("additionalProperties: { type: 'string' } is accepted (constrained map)", () => {
+    expect(
+      isCodableSafe({
+        type: "object",
+        properties: {},
+        additionalProperties: { type: "string" },
+      }),
+    ).toBe(true);
+  });
+
+  test("recurses into nested object properties", () => {
+    expect(
+      isCodableSafe({
+        type: "object",
+        properties: {
+          payload: {
+            type: "object",
+            properties: {},
+            additionalProperties: true, // nested record — still rejects
+          },
+        },
+      }),
+    ).toBe(false);
+  });
+
+  test("recurses into array items", () => {
+    expect(
+      isCodableSafe({
+        type: "array",
+        items: {
+          type: "object",
+          properties: {},
+          additionalProperties: true,
+        },
+      }),
+    ).toBe(false);
+  });
+
+  test("null / undefined schema is treated as safe (no-op node)", () => {
+    expect(isCodableSafe(null)).toBe(true);
+    expect(isCodableSafe(undefined)).toBe(true);
+  });
+});
+
+describe("swiftOutputType", () => {
+  test("primitives map to Swift built-ins", () => {
+    const nested = [];
+    expect(swiftOutputType({ type: "string" }, "Path", nested)).toBe("String");
+    expect(swiftOutputType({ type: "integer" }, "Path", nested)).toBe("Int");
+    expect(swiftOutputType({ type: "number" }, "Path", nested)).toBe("Double");
+    expect(swiftOutputType({ type: "boolean" }, "Path", nested)).toBe("Bool");
+    expect(nested).toEqual([]); // primitives don't accumulate nested structs
+  });
+
+  test("nullable union adds Optional ?", () => {
+    const nested = [];
+    expect(swiftOutputType({ type: ["string", "null"] }, "Path", nested)).toBe("String?");
+    expect(swiftOutputType({ type: ["null", "integer"] }, "Path", nested)).toBe("Int?");
+  });
+
+  test("array wraps element type", () => {
+    const nested = [];
+    expect(
+      swiftOutputType({ type: "array", items: { type: "string" } }, "Tags", nested),
+    ).toBe("[String]");
+  });
+
+  test("array-of-object records nested struct named `<Path>Item`", () => {
+    const nested = [];
+    const result = swiftOutputType(
+      {
+        type: "array",
+        items: { type: "object", properties: { id: { type: "string" } } },
+      },
+      "Events",
+      nested,
+    );
+    expect(result).toBe("[EventsItem]");
+    expect(nested).toHaveLength(1);
+    expect(nested[0].name).toBe("EventsItem");
+  });
+
+  test("object records nested struct + returns the path as type", () => {
+    const nested = [];
+    const result = swiftOutputType(
+      { type: "object", properties: { foo: { type: "string" } } },
+      "Payload",
+      nested,
+    );
+    expect(result).toBe("Payload");
+    expect(nested).toHaveLength(1);
+    expect(nested[0].name).toBe("Payload");
+  });
+
+  test("unknown type falls back to String", () => {
+    const nested = [];
+    expect(swiftOutputType({ type: "mystery" }, "Path", nested)).toBe("String");
+  });
+});
+
+describe("renderStruct", () => {
+  test("flat struct with one required string field", () => {
+    const swift = renderStruct("FooOutput", {
+      type: "object",
+      properties: { name: { type: "string" } },
+      required: ["name"],
+    });
+    expect(swift).toContain("public struct FooOutput: Codable, Sendable {");
+    expect(swift).toContain("public let name: String");
+    expect(swift).not.toContain("CodingKeys"); // no escaping needed
+  });
+
+  test("unrequired field → Optional<T>", () => {
+    const swift = renderStruct("FooOutput", {
+      type: "object",
+      properties: { name: { type: "string" } },
+      // no `required` → every field is optional
+    });
+    expect(swift).toContain("public let name: String?");
+  });
+
+  test("nullable union field doesn't double-? (already Optional via swiftOutputType)", () => {
+    const swift = renderStruct("FooOutput", {
+      type: "object",
+      properties: { name: { type: ["string", "null"] } },
+    });
+    // Wrong behavior would be `String??`; correct is single `?`.
+    expect(swift).toContain("public let name: String?");
+    expect(swift).not.toContain("String??");
+  });
+
+  test("nested object emits inner struct", () => {
+    const swift = renderStruct("ListEventsOutput", {
+      type: "object",
+      properties: {
+        events: {
+          type: "array",
+          items: {
+            type: "object",
+            properties: { id: { type: "string" }, summary: { type: "string" } },
+            required: ["id", "summary"],
+          },
+        },
+      },
+      required: ["events"],
+    });
+    expect(swift).toContain("public struct ListEventsOutput: Codable, Sendable {");
+    expect(swift).toContain("public struct EventsItem: Codable, Sendable {");
+    expect(swift).toContain("public let events: [EventsItem]");
+    expect(swift).toContain("public let id: String");
+  });
+
+  test("reserved-word field triggers full CodingKeys enum", () => {
+    const swift = renderStruct("FooOutput", {
+      type: "object",
+      properties: {
+        class: { type: "string" },
+        id: { type: "string" },
+      },
+      required: ["class", "id"],
+    });
+    expect(swift).toContain("public let class_: String");
+    expect(swift).toContain("public let id: String");
+    // CodingKeys enum required because `class` was escaped
+    expect(swift).toContain("enum CodingKeys: String, CodingKey {");
+    expect(swift).toContain('case class_ = "class"');
+    // Non-escaped keys must also be listed (Swift rejects partial enums)
+    expect(swift).toContain("case id");
+    expect(swift).not.toContain('case id = "id"'); // identity mapping — no rawValue
+  });
+
+  test("empty properties → well-formed empty struct", () => {
+    const swift = renderStruct("EmptyOutput", { type: "object", properties: {}, required: [] });
+    expect(swift).toContain("public struct EmptyOutput: Codable, Sendable {");
+  });
+
+  test("indent param controls nested indentation depth", () => {
+    const swift = renderStruct(
+      "Inner",
+      { type: "object", properties: { x: { type: "string" } }, required: ["x"] },
+      "        ", // 8-space indent (nested inside another struct)
+    );
+    // Outer line uses `indent.slice(4)` = 4 spaces for the struct itself,
+    // fields use the full 8-space indent.
+    expect(swift).toContain("    public struct Inner:");
+    expect(swift).toContain("        public let x: String");
+  });
+});
+
+describe("hasTypedOutput", () => {
+  test("true when outputSchema is a codable-safe object", () => {
+    expect(
+      hasTypedOutput({
+        outputSchema: {
+          type: "object",
+          properties: { count: { type: "integer" } },
+        },
+      }),
+    ).toBe(true);
+  });
+
+  test("false when outputSchema is absent", () => {
+    expect(hasTypedOutput({})).toBe(false);
+    expect(hasTypedOutput({ outputSchema: null })).toBe(false);
+  });
+
+  test("false when top-level is not an object (free-form)", () => {
+    expect(hasTypedOutput({ outputSchema: { type: "string" } })).toBe(false);
+    expect(hasTypedOutput({ outputSchema: { type: "array", items: {} } })).toBe(false);
+  });
+
+  test("false when any node has additionalProperties:true (audit_log case)", () => {
+    expect(
+      hasTypedOutput({
+        outputSchema: {
+          type: "object",
+          properties: {
+            entries: {
+              type: "array",
+              items: {
+                type: "object",
+                properties: { args: { type: "object", additionalProperties: true } },
+              },
+            },
+          },
+        },
+      }),
+    ).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

Closes the codegen extraction stream. \`renderStruct\` / \`swiftOutputType\` / \`isCodableSafe\` / \`hasTypedOutput\` — the output-schema layer the parallel session ([\`4357d67\`](https://github.com/heznpc/AirMCP/commit/4357d67)) started on a different file (\`scripts/lib/swift-intents-codegen.mjs\`) — now live alongside the rest of the helpers in [\`scripts/lib/codegen-helpers.mjs\`](scripts/lib/codegen-helpers.mjs). **One lib, not two**; avoids the merge conflict the parallel branch would have forced.

Stacked on [#132](https://github.com/heznpc/AirMCP/pull/132).

## Extracted (4 more helpers)

- **\`isCodableSafe\`** — recursive "can this outputSchema become Swift Codable?" verdict. Rejects \`additionalProperties: true\` / \`:{}\` anywhere in the tree; accepts constrained \`additionalProperties: { type: … }\` objects.
- **\`swiftOutputType\`** — JSON-Schema node → Swift type expression with nested-struct accumulation. Nullable unions get Optional, array-of-object records \`<Path>Item\`, inline objects record their own struct.
- **\`renderStruct\`** — object schema → \`public struct Name: Codable, Sendable { … }\`. Full \`CodingKeys\` enum emitted **only** when at least one wire key needed identifier escaping (Swift rejects partial enums).
- **\`hasTypedOutput\`** — combines the above as the A.2b.2 eligibility gate.

## Test coverage (+25, total 134 helpers / 1488 suite-wide)

### \`isCodableSafe\`
Primitives always safe; constrained \`additionalProperties\` accepted; record-shaped \`additionalProperties: true\` / \`:{}\` rejected; recursion into nested objects + array items.

### \`swiftOutputType\`
Primitive paths, nullable unions → Optional, array wrapping, array-of-object records \`<Path>Item\`, inline object records its own struct, unknown type → String fallback.

### \`renderStruct\`
- Required vs optional nullability rules
- **Nullable-union double-\`?\` prevention** — regression guard. \`String??\` would compile but leak into downstream decoders.
- Nested struct emission (\`ListEventsOutput\` → \`EventsItem\`)
- Reserved-word \`CodingKeys\` escape: every key listed (Swift rejects partial enums), identity cases get no \`rawValue\`
- Empty properties → well-formed empty struct
- Indent parameter controls nested indentation depth

### \`hasTypedOutput\`
True on codable-safe; false on absent / non-object / additionalProperties-bearing schemas (\`audit_log\` is the canonical false case today).

## Parallel session resolution

[\`4357d67\`](https://github.com/heznpc/AirMCP/commit/4357d67) on \`claude/wonderful-pascal-d7a224\` can now be **closed** — its unique additions land here on top of the RFC 0007 stack. That branch still holds overlapping extractions (\`toPascalCase\`, \`swiftIdent\`, \`isNullableUnion\`, \`nonNullType\`) that this stack already covered in [#126](https://github.com/heznpc/AirMCP/pull/126) / [#127](https://github.com/heznpc/AirMCP/pull/127); no clean merge path, best action is to close.

## Extraction stream final summary

\`gen-swift-intents.mjs\` has gone from **1219 → 752 LOC** across the session. Everything pure now lives in \`codegen-helpers.mjs\` with 134 tests pinning contracts. What remains in the generator is genuine orchestration — manifest load, config hand-picks (\`APP_SHORTCUTS_TOP\`, \`FOLLOW_UP_MAP\`), CLI wrappers for the throwing lib functions, \`generateIntent\` (which uses module-level \`enumsByTool\` / \`followUpMap\`), \`renderScalarRow\` + \`renderSnippetView\` (tightly coupled to generator state), source assembly, and write/check.

## Test plan

- [x] \`npm test -- tests/codegen-helpers.test.js\` → 134 passed
- [x] \`npm test\` → 1488 passed (94 suites)
- [x] \`npm run gen:intents:check\` byte-identical (229 intents)
- [x] \`swift build\` passes (6.9s)
- [x] gen-swift-intents.mjs: 859 → 752 LOC; codegen-helpers.mjs: 473 → 598 LOC