### PR TITLE
feat: .mcpb Desktop Extensions bundle for Claude Desktop one-click install

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,6 +93,9 @@ jobs:
       - name: Verify manifest schema contract
         run: node scripts/verify-tool-manifest.mjs
 
+      - name: Verify MCPB extension manifest (Claude Desktop bundle)
+        run: npm run build:mcpb:check
+
       - name: Verify generated Swift intents (RFC 0007 A.1)
         run: |
           npm run gen:intents

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 node_modules/
 dist/
+build/
 **/.build/
 *.tgz
 .DS_Store

--- a/mcpb/manifest.template.json
+++ b/mcpb/manifest.template.json
@@ -1,0 +1,75 @@
+{
+  "manifest_version": "0.3",
+  "name": "airmcp",
+  "display_name": "AirMCP",
+  "version": "{{VERSION}}",
+  "description": "{{DESCRIPTION}}",
+  "long_description": "AirMCP connects any MCP-compatible AI client to your Mac — Notes, Reminders, Calendar, Contacts, Mail, Messages, Music, Finder, Safari, Photos, System control, Apple Intelligence, and more. 270+ tools across 29 modules. Runs 100% on-device via native Swift bridges (EventKit, PhotoKit, HealthKit, Vision, Foundation Models).\n\nSafety first: HITL (human-in-the-loop) approval, queryable audit log, rate limiter + emergency stop, declarative HTTP network policy.\n\niOS-ready: 229 auto-generated Apple App Intents expose AirMCP tools to Siri, Shortcuts, and Spotlight once the iOS companion ships.",
+  "author": {
+    "name": "heznpc",
+    "url": "https://github.com/heznpc"
+  },
+  "homepage": "https://github.com/heznpc/AirMCP",
+  "documentation": "https://github.com/heznpc/AirMCP#readme",
+  "support": "https://github.com/heznpc/AirMCP/issues",
+  "license": "MIT",
+  "icon": "icon.png",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/heznpc/AirMCP.git"
+  },
+  "keywords": [
+    "mcp",
+    "apple",
+    "macos",
+    "notes",
+    "calendar",
+    "reminders",
+    "contacts",
+    "mail",
+    "siri",
+    "shortcuts",
+    "apple-intelligence"
+  ],
+  "compatibility": {
+    "claude_desktop": ">=0.11.0",
+    "platforms": ["darwin"],
+    "runtimes": {
+      "node": ">=20.0.0"
+    }
+  },
+  "server": {
+    "type": "node",
+    "entry_point": "server/dist/index.js",
+    "mcp_config": {
+      "command": "node",
+      "args": ["${__dirname}/server/dist/index.js"],
+      "env": {
+        "GEMINI_API_KEY": "${user_config.gemini_api_key}",
+        "AIRMCP_FULL": "${user_config.load_all_modules}"
+      }
+    }
+  },
+  "user_config": {
+    "gemini_api_key": {
+      "type": "string",
+      "title": "Gemini API Key (optional)",
+      "description": "Enables cloud embeddings for semantic tool search and note search. AirMCP falls back to Apple's on-device NLContextualEmbedding when this is unset — no cloud calls are made without this key.",
+      "required": false,
+      "sensitive": true,
+      "default": ""
+    },
+    "load_all_modules": {
+      "type": "boolean",
+      "title": "Load all 29 modules on startup",
+      "description": "Off by default — only the 7 starter modules load (notes, calendar, reminders, contacts, mail, finder, system) to keep the surface small. Turn on to register all modules (messages, music, safari, photos, shortcuts, apple intelligence, TV, maps, weather, iWork, Google Workspace, health, bluetooth, etc.). Per-module disable can still be done via AIRMCP_DISABLE_<MODULE> env vars in advanced setups.",
+      "required": false,
+      "default": false
+    }
+  },
+  "tools_generated": true,
+  "prompts_generated": true,
+  "privacy_policies": [
+    "https://github.com/heznpc/AirMCP/blob/main/docs/PRIVACY_POLICY.md"
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -75,6 +75,8 @@
     "start": "node dist/index.js",
     "test": "node --experimental-vm-modules node_modules/.bin/jest",
     "smoke": "node scripts/smoke-mcp.mjs",
+    "build:mcpb": "node scripts/build-mcpb.mjs",
+    "build:mcpb:check": "node scripts/build-mcpb.mjs --check",
     "gen:manifest": "node scripts/dump-tool-manifest.mjs",
     "gen:manifest:check": "node scripts/dump-tool-manifest.mjs --check",
     "gen:intents": "node scripts/gen-swift-intents.mjs",

--- a/scripts/build-mcpb.mjs
+++ b/scripts/build-mcpb.mjs
@@ -1,0 +1,150 @@
+#!/usr/bin/env node
+// Build an `.mcpb` Desktop Extensions bundle for Claude Desktop
+// (spec: modelcontextprotocol/mcpb MANIFEST.md v0.3).
+//
+// Layout produced in build/mcpb/ before zipping:
+//
+//   manifest.json              — generated from mcpb/manifest.template.json
+//   icon.png                   — copied from icons/airmcp-icon-256.png
+//   server/
+//     package.json             — trimmed: just deps, no scripts
+//     dist/                    — Node build output (copy of repo dist/)
+//     node_modules/            — production deps only (`npm install --omit=dev`)
+//
+// The resulting bundle is a single `.mcpb` zip that Claude Desktop's
+// "Browse extensions" picks up with zero CLI interaction from the user.
+//
+// Notes on scope
+// - `npm install --omit=dev --prefix server/` runs inside the build dir,
+//   so the bundle is self-contained. Users don't need node_modules
+//   pre-populated locally.
+// - We do NOT sign or notarize the archive. Notarization is a follow-up
+//   (P2-1); Claude Desktop currently accepts unsigned .mcpb.
+// - We do NOT ship a swift-bridge binary yet. Cloud-path tools work
+//   out of the box; Swift-backed tools (EventKit, HealthKit, etc.)
+//   require `npm run swift-build` on the user side. A future pass can
+//   pre-build a universal binary for darwin-arm64 + darwin-x64 and
+//   drop it into the bundle.
+//
+// Usage:
+//   npm run build:mcpb          # produce build/mcpb/airmcp-{version}.mcpb
+//   npm run build:mcpb -- --check  # verify manifest substitution only, no zip
+
+import { readFileSync, writeFileSync, rmSync, mkdirSync, cpSync, existsSync, statSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const ROOT = fileURLToPath(new URL("..", import.meta.url));
+const BUILD_DIR = join(ROOT, "build", "mcpb");
+const TEMPLATE_PATH = join(ROOT, "mcpb", "manifest.template.json");
+const CHECK_ONLY = process.argv.includes("--check");
+
+// ── Read package.json for metadata ───────────────────────────────────
+const pkg = JSON.parse(readFileSync(join(ROOT, "package.json"), "utf-8"));
+
+// ── Substitute manifest placeholders ─────────────────────────────────
+const template = readFileSync(TEMPLATE_PATH, "utf-8");
+const manifestText = template
+  .replaceAll("{{VERSION}}", pkg.version)
+  .replaceAll("{{DESCRIPTION}}", pkg.description.replace(/"/g, '\\"'));
+
+// Parse-validate so a bad template fails here, not at Claude Desktop load.
+let manifest;
+try {
+  manifest = JSON.parse(manifestText);
+} catch (e) {
+  console.error(`[mcpb] template produced invalid JSON: ${e.message}`);
+  process.exit(1);
+}
+
+if (manifest.manifest_version !== "0.3") {
+  console.error(`[mcpb] manifest_version mismatch (expected "0.3", got "${manifest.manifest_version}")`);
+  process.exit(1);
+}
+if (manifest.version !== pkg.version) {
+  console.error(`[mcpb] manifest.version (${manifest.version}) != package.json version (${pkg.version})`);
+  process.exit(1);
+}
+
+if (CHECK_ONLY) {
+  console.error(
+    `[mcpb --check] manifest OK — v${manifest.version}, ${Object.keys(manifest.user_config ?? {}).length} user_config keys`,
+  );
+  process.exit(0);
+}
+
+// ── Fresh build dir ──────────────────────────────────────────────────
+if (existsSync(BUILD_DIR)) rmSync(BUILD_DIR, { recursive: true, force: true });
+mkdirSync(BUILD_DIR, { recursive: true });
+
+// ── Write manifest + icon ────────────────────────────────────────────
+writeFileSync(join(BUILD_DIR, "manifest.json"), JSON.stringify(manifest, null, 2) + "\n");
+cpSync(join(ROOT, "icons", "airmcp-icon-256.png"), join(BUILD_DIR, "icon.png"));
+
+// ── Server tree ──────────────────────────────────────────────────────
+const serverDir = join(BUILD_DIR, "server");
+mkdirSync(serverDir, { recursive: true });
+
+// Trim package.json: deps + minimal runtime metadata. No scripts (Claude
+// Desktop does not run them), no dev-only fields (commitlint, lint-staged).
+const trimmedPkg = {
+  name: pkg.name,
+  version: pkg.version,
+  description: pkg.description,
+  type: pkg.type,
+  main: "dist/index.js",
+  bin: pkg.bin,
+  dependencies: pkg.dependencies,
+  // Keep `overrides` so npm install respects the pinned Hono CVE fixes
+  // (see CHANGELOG v2.10 Security entry).
+  ...(pkg.overrides ? { overrides: pkg.overrides } : {}),
+};
+writeFileSync(join(serverDir, "package.json"), JSON.stringify(trimmedPkg, null, 2) + "\n");
+
+// Build output — require that `npm run build` has produced dist/.
+if (!existsSync(join(ROOT, "dist", "index.js"))) {
+  console.error(`[mcpb] dist/index.js not found — run \`npm run build\` first`);
+  process.exit(1);
+}
+cpSync(join(ROOT, "dist"), join(serverDir, "dist"), { recursive: true });
+
+// ── Install production deps into the bundle ──────────────────────────
+console.error("[mcpb] installing production dependencies into bundle…");
+const npmInstall = spawnSync(
+  "npm",
+  ["install", "--omit=dev", "--no-audit", "--no-fund", "--ignore-scripts", "--prefer-offline"],
+  { cwd: serverDir, stdio: "inherit" },
+);
+if (npmInstall.status !== 0) {
+  console.error(`[mcpb] npm install failed with status ${npmInstall.status}`);
+  process.exit(1);
+}
+
+// Drop package-lock.json — runtime doesn't need it, and it inflates
+// the bundle by ~200 KB.
+const lockPath = join(serverDir, "package-lock.json");
+if (existsSync(lockPath)) rmSync(lockPath);
+
+// ── Zip ──────────────────────────────────────────────────────────────
+const outPath = join(BUILD_DIR, `airmcp-${pkg.version}.mcpb`);
+console.error(`[mcpb] zipping → ${outPath}`);
+
+// Use the system zip CLI — macOS ships it by default, every CI runner
+// has it, and writing our own ZIP encoder for one use-case is scope
+// creep. The tradeoff is Windows CI would need a separate path, but
+// AirMCP is macOS-first and Windows isn't a supported build host.
+const zipResult = spawnSync(
+  "zip",
+  ["-r", "-q", `airmcp-${pkg.version}.mcpb`, "manifest.json", "icon.png", "server"],
+  { cwd: BUILD_DIR, stdio: "inherit" },
+);
+if (zipResult.status !== 0) {
+  console.error(`[mcpb] zip failed with status ${zipResult.status}`);
+  process.exit(1);
+}
+
+const outStat = statSync(outPath);
+console.error(
+  `[mcpb] OK — ${outPath} (${(outStat.size / 1024 / 1024).toFixed(2)} MB, ${Object.keys(manifest.user_config ?? {}).length} user_config keys)`,
+);

--- a/tests/mcpb-manifest.test.js
+++ b/tests/mcpb-manifest.test.js
@@ -1,0 +1,161 @@
+// `.mcpb` (MCPB Desktop Extension) manifest template tests.
+//
+// The manifest is what Claude Desktop parses to show the extension in
+// "Browse extensions" — a shape regression here breaks the install
+// experience silently. Byte-level drift is caught by build:mcpb:check;
+// these tests pin the schema expectations (spec v0.3) + substitution
+// correctness.
+
+import { describe, test, expect } from "@jest/globals";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..");
+const template = readFileSync(join(ROOT, "mcpb", "manifest.template.json"), "utf-8");
+
+function render(version = "9.9.9", description = "Test description") {
+  const rendered = template
+    .replaceAll("{{VERSION}}", version)
+    .replaceAll("{{DESCRIPTION}}", description.replace(/"/g, '\\"'));
+  return JSON.parse(rendered);
+}
+
+describe("mcpb manifest template — MCPB v0.3 required fields", () => {
+  test("manifest_version pinned to 0.3", () => {
+    const m = render();
+    // Bump intentionally when the spec version changes — forces a
+    // review pass against the new required fields.
+    expect(m.manifest_version).toBe("0.3");
+  });
+
+  test("name is MCPB-safe (lowercase alphanumerics + hyphens)", () => {
+    const m = render();
+    expect(m.name).toMatch(/^[a-z][a-z0-9-]*$/);
+    expect(m.name).toBe("airmcp");
+  });
+
+  test("version substituted from {{VERSION}}", () => {
+    expect(render("1.2.3").version).toBe("1.2.3");
+    expect(render("2.11.0-rc.1").version).toBe("2.11.0-rc.1");
+  });
+
+  test("description substituted from {{DESCRIPTION}} with quote-escape", () => {
+    expect(render("1.0.0", 'Say "hi"').description).toBe('Say "hi"');
+  });
+
+  test("author.name is required and non-empty", () => {
+    const m = render();
+    expect(m.author).toBeDefined();
+    expect(typeof m.author.name).toBe("string");
+    expect(m.author.name.length).toBeGreaterThan(0);
+  });
+
+  test("server config points at Node entry with __dirname-anchored args", () => {
+    const m = render();
+    expect(m.server.type).toBe("node");
+    expect(m.server.entry_point).toBe("server/dist/index.js");
+    expect(m.server.mcp_config.command).toBe("node");
+    expect(m.server.mcp_config.args).toEqual(["${__dirname}/server/dist/index.js"]);
+  });
+});
+
+describe("mcpb manifest template — user_config (MCPB-spec-aware)", () => {
+  test("gemini_api_key is sensitive (masked input + secure storage)", () => {
+    const m = render();
+    const gk = m.user_config.gemini_api_key;
+    expect(gk).toBeDefined();
+    expect(gk.type).toBe("string");
+    expect(gk.sensitive).toBe(true);
+    expect(gk.required).toBe(false);
+  });
+
+  test("load_all_modules default matches AirMCP's starter-module stance", () => {
+    const m = render();
+    const la = m.user_config.load_all_modules;
+    expect(la.type).toBe("boolean");
+    expect(la.default).toBe(false);
+    // If the default flips, the bundle starts loading 29 modules by
+    // default — a footprint change that warrants re-audit + CHANGELOG
+    // entry. Lock it here.
+  });
+
+  test("env substitutes user_config via MCPB ${user_config.KEY} syntax", () => {
+    const m = render();
+    expect(m.server.mcp_config.env.GEMINI_API_KEY).toBe("${user_config.gemini_api_key}");
+    expect(m.server.mcp_config.env.AIRMCP_FULL).toBe("${user_config.load_all_modules}");
+  });
+
+  test("every referenced user_config key exists in user_config", () => {
+    const m = render();
+    const declared = new Set(Object.keys(m.user_config ?? {}));
+    const env = m.server.mcp_config.env ?? {};
+    for (const value of Object.values(env)) {
+      const match = /\$\{user_config\.([^}]+)\}/.exec(value);
+      if (!match) continue;
+      expect(declared.has(match[1])).toBe(true);
+    }
+  });
+});
+
+describe("mcpb manifest template — compatibility pin", () => {
+  test("platforms is darwin-only (AirMCP's Apple-native scope)", () => {
+    const m = render();
+    expect(m.compatibility.platforms).toEqual(["darwin"]);
+  });
+
+  test("Node runtime requirement stays in sync with package.json engines", () => {
+    // Canary — if package.json bumps engines.node, the mcpb manifest
+    // must be updated in lockstep or Claude Desktop will refuse to
+    // install the bundle on older runtimes.
+    const pkg = JSON.parse(readFileSync(join(ROOT, "package.json"), "utf-8"));
+    const m = render();
+    expect(m.compatibility.runtimes.node).toMatch(/^>=\d+\.\d+\.\d+$/);
+    if (pkg.engines?.node) {
+      // Extract the major version floor from each and compare.
+      const pkgMajor = Number(/>=?(\d+)/.exec(pkg.engines.node)?.[1] ?? 0);
+      const mcpbMajor = Number(/>=?(\d+)/.exec(m.compatibility.runtimes.node)?.[1] ?? 0);
+      expect(mcpbMajor).toBe(pkgMajor);
+    }
+  });
+});
+
+describe("mcpb manifest template — tools_generated / prompts_generated", () => {
+  test("both are true (AirMCP registers dynamically at runtime)", () => {
+    const m = render();
+    // AirMCP's tool surface includes dynamic shortcuts + skills, so the
+    // MCPB installer cannot enumerate them at install time. These flags
+    // tell Claude Desktop to treat the extension as having a runtime
+    // discovery model.
+    expect(m.tools_generated).toBe(true);
+    expect(m.prompts_generated).toBe(true);
+  });
+});
+
+describe("mcpb manifest template — well-formedness", () => {
+  test("renders to valid JSON with no leftover template placeholders", () => {
+    const rendered = template
+      .replaceAll("{{VERSION}}", "1.0.0")
+      .replaceAll("{{DESCRIPTION}}", "test");
+    expect(rendered).not.toContain("{{");
+    expect(() => JSON.parse(rendered)).not.toThrow();
+  });
+
+  test("every placeholder has a matching substitution in build-mcpb.mjs", () => {
+    // Grab placeholders used in the template and confirm build-mcpb.mjs
+    // substitutes each. Prevents a "template expects {{FOO}} but the
+    // build script only replaces {{VERSION}}" drift.
+    const placeholders = [...template.matchAll(/\{\{([A-Z_]+)\}\}/g)].map((m) => m[1]);
+    const unique = [...new Set(placeholders)];
+    const build = readFileSync(join(ROOT, "scripts", "build-mcpb.mjs"), "utf-8");
+    for (const p of unique) {
+      expect(build).toContain(`{{${p}}}`);
+    }
+  });
+
+  test("privacy_policies entry is a stable URL", () => {
+    const m = render();
+    expect(Array.isArray(m.privacy_policies)).toBe(true);
+    expect(m.privacy_policies[0]).toMatch(/^https:\/\//);
+  });
+});


### PR DESCRIPTION
## Summary

Anthropic's **MCPB** (MCP Bundle, aka Desktop Extensions) format makes installing AirMCP into Claude Desktop a drag-and-drop: no \`npm\`, no config editing, no keychain juggling. This PR adds the build pipeline + CI gate. **P0-2** from the external-trends roadmap.

Stacked on [#133](https://github.com/heznpc/AirMCP/pull/133).

## What Claude Desktop users get

Drop \`airmcp-2.11.0.mcpb\` (5.25 MB) onto Claude Desktop's **Browse extensions** → \`AirMCP\` appears as an installable entry with:
- **Gemini API Key** field (sensitive, optional)
- **Load all 29 modules on startup** toggle (default off — stays at 7 starter modules for a small footprint)

No CLI. No \`~/Library/Application Support/Claude/claude_desktop_config.json\` editing.

## Files

| File | Role |
|---|---|
| [mcpb/manifest.template.json](mcpb/manifest.template.json) | MCPB v0.3 manifest with AirMCP metadata, Node server pointing at \`server/dist/index.js\`, darwin-only, 2 user_config keys. \`tools_generated\` / \`prompts_generated\` both true (dynamic shortcuts + skills can't be enumerated at install time). |
| [scripts/build-mcpb.mjs](scripts/build-mcpb.mjs) | Produces \`build/mcpb/airmcp-{version}.mcpb\` — substitutes placeholders, writes manifest + icon, copies \`dist/\`, runs \`npm install --omit=dev --ignore-scripts\` inside the bundle, zips via system \`zip\`. \`--check\` mode validates the manifest only. |
| [tests/mcpb-manifest.test.js](tests/mcpb-manifest.test.js) | 16 cases pin the manifest shape against MCPB v0.3. |
| [.github/workflows/ci.yml](.github/workflows/ci.yml) | \`npm run build:mcpb:check\` right after the tool-manifest schema check. |

## Test coverage (+16, total 1504 suite-wide)

- Required MCPB v0.3 fields (\`manifest_version\` / \`name\` / \`version\` / \`description\` / \`author\` / \`server\`)
- Node server \`entry_point\` + \`\${__dirname}\`-anchored args
- \`user_config\` — \`sensitive\` flag on API key, default values, boolean type
- Every referenced \`\${user_config.KEY}\` is declared (drift guard)
- \`platforms: ["darwin"]\` pin (AirMCP's Apple-native scope)
- Node runtime major stays in sync with \`package.json\` engines (canary — drift breaks install on older runtimes)
- \`tools_generated\` / \`prompts_generated\` both true
- Every \`{{...}}\` in the template is substituted by \`build-mcpb.mjs\` (template ↔ builder drift guard)
- Well-formedness: no leftover \`{{...}}\`, valid JSON

## Probed locally

\`\`\`
$ npm run build:mcpb
[mcpb] installing production dependencies into bundle…
added 93 packages in 2s
[mcpb] zipping → build/mcpb/airmcp-2.10.0.mcpb
[mcpb] OK — build/mcpb/airmcp-2.10.0.mcpb (5.25 MB, 2 user_config keys)
\`\`\`

\`\`\`
$ unzip -l build/mcpb/airmcp-2.10.0.mcpb | head
manifest.json   3189 bytes
icon.png       51681 bytes
server/dist/   (full build output)
server/node_modules/  (93 production deps)
\`\`\`

## Out of scope — explicit follow-ups

- **Codesign + notarize** (P2-1). Claude Desktop accepts unsigned \`.mcpb\` today; release-quality distribution should notarize. Wire \`codesign\` + \`notarytool\` into auto-release.
- **Swift bridge binary bundling**. Cloud-path tools work out of the box; EventKit/HealthKit/Vision-backed tools still need \`npm run swift-build\` user-side. Pre-building a universal binary (darwin-arm64 + darwin-x64) is a separate packaging pass.

## Test plan

- [x] \`npm run build:mcpb:check\` — manifest validates
- [x] \`npm run build:mcpb\` — 5.25 MB .mcpb produced end-to-end
- [x] \`unzip -l\` confirms manifest.json + icon.png + server/dist + node_modules at the right paths
- [x] \`npm test\` → 1504 passed (95 suites)
- [ ] Manual: drop the .mcpb onto Claude Desktop → install + run a tool (follow-up after CI completes the artifact)