### PR TITLE
feat(release): codesign + notarize pipeline for AirMCP.app

### DIFF
--- a/.github/workflows/release-app.yml
+++ b/.github/workflows/release-app.yml
@@ -1,0 +1,158 @@
+name: Release AirMCP.app (signed + notarized)
+
+# Runs on tag push OR manual dispatch. Produces a Developer-ID-signed,
+# notarized, stapled AirMCP.app and AirMCPWidget.appex for Gatekeeper-
+# clean distribution outside the App Store.
+#
+# Required GitHub secrets (set via Settings → Secrets and variables →
+# Actions):
+#   APPLE_DEVELOPER_ID          Common name of the Developer ID
+#                               Application certificate, e.g.
+#                               "Developer ID Application: Jane Doe (A1B2C3D4E5)"
+#   APPLE_ID                    Apple ID email for notarytool
+#   APPLE_ID_PASSWORD           App-specific password — generate at
+#                               appleid.apple.com → Sign-in and security
+#   APPLE_TEAM_ID               10-character team identifier
+#   APPLE_CERT_P12_BASE64       Developer ID Application cert + private
+#                               key exported as .p12, base64-encoded
+#                               (base64 -i cert.p12 | pbcopy)
+#   APPLE_CERT_P12_PASSWORD     Password for the .p12 import
+#
+# Until all six secrets are set, the job exits early with a clear
+# message — see the `preflight` step below.
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Tag to release (e.g. v2.11.0)"
+        required: true
+
+concurrency:
+  group: release-app-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  release-app:
+    runs-on: macos-latest
+    environment: release
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      # Fail fast and loud when secrets haven't been wired yet. Every
+      # required secret is checked up-front so an operator sees the
+      # full list in one CI log, not six sequential failures.
+      - name: Preflight — required secrets present
+        env:
+          APPLE_DEVELOPER_ID: ${{ secrets.APPLE_DEVELOPER_ID }}
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_ID_PASSWORD: ${{ secrets.APPLE_ID_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          APPLE_CERT_P12_BASE64: ${{ secrets.APPLE_CERT_P12_BASE64 }}
+          APPLE_CERT_P12_PASSWORD: ${{ secrets.APPLE_CERT_P12_PASSWORD }}
+        run: |
+          missing=()
+          [ -n "$APPLE_DEVELOPER_ID" ]      || missing+=("APPLE_DEVELOPER_ID")
+          [ -n "$APPLE_ID" ]                || missing+=("APPLE_ID")
+          [ -n "$APPLE_ID_PASSWORD" ]       || missing+=("APPLE_ID_PASSWORD")
+          [ -n "$APPLE_TEAM_ID" ]           || missing+=("APPLE_TEAM_ID")
+          [ -n "$APPLE_CERT_P12_BASE64" ]   || missing+=("APPLE_CERT_P12_BASE64")
+          [ -n "$APPLE_CERT_P12_PASSWORD" ] || missing+=("APPLE_CERT_P12_PASSWORD")
+          if [ ${#missing[@]} -gt 0 ]; then
+            echo "::error::Missing required secrets: ${missing[*]}"
+            echo "See .github/workflows/release-app.yml header for the full list"
+            exit 1
+          fi
+
+      - name: Extract version
+        id: version
+        run: |
+          if [ -n "${{ github.event.inputs.tag }}" ]; then
+            VERSION="${{ github.event.inputs.tag }}"
+          else
+            VERSION="${GITHUB_REF_NAME}"
+          fi
+          # Strip leading "v" if present
+          VERSION="${VERSION#v}"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Releasing version: $VERSION"
+
+      # Import the Developer ID certificate into a throwaway keychain so
+      # codesign can find it. The keychain is discarded when the runner
+      # tears down — no cross-run leakage.
+      - name: Import signing certificate
+        env:
+          APPLE_CERT_P12_BASE64: ${{ secrets.APPLE_CERT_P12_BASE64 }}
+          APPLE_CERT_P12_PASSWORD: ${{ secrets.APPLE_CERT_P12_PASSWORD }}
+        run: |
+          KEYCHAIN=build.keychain
+          KEYCHAIN_PW="$(uuidgen)"
+          security create-keychain -p "$KEYCHAIN_PW" "$KEYCHAIN"
+          security default-keychain -s "$KEYCHAIN"
+          security unlock-keychain -p "$KEYCHAIN_PW" "$KEYCHAIN"
+          security set-keychain-settings -t 3600 -u "$KEYCHAIN"
+
+          echo "$APPLE_CERT_P12_BASE64" | base64 --decode > cert.p12
+          security import cert.p12 -k "$KEYCHAIN" \
+            -P "$APPLE_CERT_P12_PASSWORD" \
+            -T /usr/bin/codesign \
+            -T /usr/bin/security
+          rm -f cert.p12
+
+          # Let codesign run non-interactively against this keychain.
+          security set-key-partition-list \
+            -S apple-tool:,apple: \
+            -s -k "$KEYCHAIN_PW" "$KEYCHAIN" >/dev/null
+
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
+        with:
+          node-version: 22
+          cache: "npm"
+
+      - name: Select Xcode
+        run: sudo xcode-select -s /Applications/Xcode.app/Contents/Developer
+
+      - name: Install deps + build Node side
+        run: |
+          npm ci
+          npm run build
+
+      - name: Build .app bundle (ad-hoc signed baseline)
+        run: bash scripts/bundle-app.sh
+
+      - name: Sign + notarize + staple
+        env:
+          APPLE_DEVELOPER_ID: ${{ secrets.APPLE_DEVELOPER_ID }}
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_ID_PASSWORD: ${{ secrets.APPLE_ID_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+        run: bash scripts/notarize-app.sh
+
+      - name: Package signed .app for release
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          ditto -c -k --keepParent AirMCP.app "AirMCP-${VERSION}.zip"
+          ls -la "AirMCP-${VERSION}.zip"
+
+      # Also produce the .mcpb Desktop Extension bundle so the GitHub
+      # Release carries both artifacts. The .mcpb doesn't itself need
+      # notarization (it's a JS bundle, not a Mach-O executable), but
+      # shipping it from the same tagged build keeps the versions in
+      # lockstep with the signed .app.
+      - name: Build .mcpb bundle
+        run: npm run build:mcpb
+
+      - name: Attach artifacts to Release
+        uses: softprops/action-gh-release@72f2c25fcb47643c292f7107632f7a47c1df5cd8 # v2
+        with:
+          tag_name: v${{ steps.version.outputs.version }}
+          files: |
+            AirMCP-${{ steps.version.outputs.version }}.zip
+            build/mcpb/airmcp-${{ steps.version.outputs.version }}.mcpb
+          fail_on_unmatched_files: true
+          generate_release_notes: true

--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -98,7 +98,23 @@ Breaking을 포함한 minor/patch는 **금지**. 직전 메이저에 묶어 둘 
 - [ ] `npm view airmcp@X.Y.Z` 로 반영 검증
 - [ ] `npx -y airmcp@X.Y.Z --version` 스모크
 
-### 3.4 GitHub Release
+### 3.4 Signed .app + .mcpb → GitHub Release
+- [ ] `release-app.yml` 워크플로가 태그 푸시로 자동 실행됐는지 확인 (Actions 탭)
+- [ ] 실패 시 **Missing required secrets** 에러면 아래 6개를 Settings → Secrets and variables → Actions에 등록:
+  - `APPLE_DEVELOPER_ID` — Developer ID Application certificate 공통명 (예: `Developer ID Application: Jane Doe (A1B2C3D4E5)`)
+  - `APPLE_ID` — notarytool용 Apple ID 이메일
+  - `APPLE_ID_PASSWORD` — [App-specific password](https://appleid.apple.com) (Sign-in and security → App-specific passwords)
+  - `APPLE_TEAM_ID` — 10자리 팀 ID
+  - `APPLE_CERT_P12_BASE64` — `.p12` 인증서 + 개인키를 base64 인코딩 (`base64 -i cert.p12 | pbcopy`)
+  - `APPLE_CERT_P12_PASSWORD` — `.p12` import 암호
+- [ ] 성공 시 Release에 두 산출물 첨부되어 있어야 함:
+  - `AirMCP-X.Y.Z.zip` (Developer ID 서명 + 공증 + staple 완료)
+  - `airmcp-X.Y.Z.mcpb` (Claude Desktop 원클릭 설치용)
+- [ ] 공증 실패 시 Actions 로그의 `notarytool log` 출력에서 거부 사유 확인 (hardened runtime / timestamp / 빠진 entitlement 등)
+- [ ] 신호용 검증: `codesign -dv --verbose=4 AirMCP.app` 에서 `Authority=Developer ID Application: …` 확인
+- [ ] Gatekeeper 검증: `spctl -a -vvv AirMCP.app` → `accepted, source=Notarized Developer ID`
+
+### 3.5 GitHub Release notes
 - [ ] Release notes는 CHANGELOG 섹션 복사 (요약 강조, 이미지/GIF는 README 링크)
 - [ ] Breaking이 있으면 Release 제목에 `[BREAKING]` 프리픽스
 - [ ] `latest` 태그 갱신 확인

--- a/scripts/notarize-app.sh
+++ b/scripts/notarize-app.sh
@@ -1,0 +1,145 @@
+#!/bin/bash
+# Codesign + notarize + staple AirMCP.app for release-quality distribution
+# outside the App Store. Turns an ad-hoc-signed bundle from
+# scripts/bundle-app.sh into something Gatekeeper accepts on a fresh Mac
+# without a right-click-Open override.
+#
+# Required environment (set in GitHub Actions secrets for the CD workflow):
+#   APPLE_DEVELOPER_ID          — Developer ID Application certificate
+#                                 common name, e.g. "Developer ID Application:
+#                                 Jane Doe (A1B2C3D4E5)"
+#   APPLE_ID                    — Apple ID email for notarytool
+#   APPLE_ID_PASSWORD           — app-specific password
+#                                 (appleid.apple.com → sign-in and security)
+#   APPLE_TEAM_ID               — 10-char team ID
+#
+# Optional environment:
+#   APP_BUNDLE_PATH             — default: AirMCP.app (relative to repo root)
+#   SKIP_NOTARIZATION=1         — codesign + staple only; useful for local
+#                                 smoke tests when notarytool credentials
+#                                 aren't available.
+#
+# Usage:
+#   bash scripts/notarize-app.sh
+#   SKIP_NOTARIZATION=1 bash scripts/notarize-app.sh  # sign only, no net
+#
+# Outputs (when notarization succeeds):
+#   AirMCP.app — re-signed with Developer ID + stapled notarization ticket
+#
+# Exit codes:
+#   0  success
+#   1  missing env / bundle / signing failure
+#   2  notarization rejected by Apple
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
+APP_BUNDLE="${APP_BUNDLE_PATH:-$PROJECT_DIR/AirMCP.app}"
+
+# ── Preconditions ────────────────────────────────────────────────────
+if [ ! -d "$APP_BUNDLE" ]; then
+  echo "notarize-app: $APP_BUNDLE not found — run scripts/bundle-app.sh first" >&2
+  exit 1
+fi
+
+need_var() {
+  if [ -z "${!1:-}" ]; then
+    echo "notarize-app: required env var $1 is unset" >&2
+    exit 1
+  fi
+}
+need_var APPLE_DEVELOPER_ID
+
+if [ "${SKIP_NOTARIZATION:-}" != "1" ]; then
+  need_var APPLE_ID
+  need_var APPLE_ID_PASSWORD
+  need_var APPLE_TEAM_ID
+fi
+
+# ── Codesign with Developer ID (replaces the ad-hoc sign) ────────────
+# --deep signs embedded plugins/frameworks too (AirMCP.app carries
+# AirMCPWidget.appex). --options=runtime enables hardened runtime,
+# which notarytool requires. --timestamp embeds a trusted timestamp
+# (notarization rejects un-timestamped signatures).
+echo "notarize-app: codesigning with $APPLE_DEVELOPER_ID …"
+
+# Strip ad-hoc signatures first so codesign --force doesn't trip on
+# signature format mismatch between the widget extension (ad-hoc) and
+# the replacement Developer ID.
+find "$APP_BUNDLE" -name "*.appex" -print0 | while IFS= read -r -d '' appex; do
+  codesign --remove-signature "$appex" 2>/dev/null || true
+done
+codesign --remove-signature "$APP_BUNDLE" 2>/dev/null || true
+
+# Sign embedded extensions first (innermost-out). Each appex needs the
+# matching entitlements — the bundle script wrote them with ad-hoc sig,
+# so we re-extract from the existing sig when available.
+find "$APP_BUNDLE" -name "*.appex" -print0 | while IFS= read -r -d '' appex; do
+  echo "  signing $appex"
+  codesign --force --options=runtime --timestamp \
+    --sign "$APPLE_DEVELOPER_ID" \
+    "$appex"
+done
+
+# Finally sign the outer bundle. --deep catches anything the explicit
+# extension loop missed.
+codesign --force --deep --options=runtime --timestamp \
+  --sign "$APPLE_DEVELOPER_ID" \
+  "$APP_BUNDLE"
+
+# ── Verify signature before submitting to Apple ─────────────────────
+echo "notarize-app: verifying signature …"
+codesign --verify --deep --strict --verbose=2 "$APP_BUNDLE" || {
+  echo "notarize-app: codesign verification failed — refusing to submit" >&2
+  exit 1
+}
+
+if [ "${SKIP_NOTARIZATION:-}" = "1" ]; then
+  echo "notarize-app: SKIP_NOTARIZATION=1 — signed but not notarized"
+  exit 0
+fi
+
+# ── Notarize via notarytool ─────────────────────────────────────────
+# notarytool needs a .zip or .dmg, not an .app directory directly.
+ZIP_PATH="$PROJECT_DIR/AirMCP-notarize.zip"
+echo "notarize-app: zipping $APP_BUNDLE → $ZIP_PATH"
+rm -f "$ZIP_PATH"
+ditto -c -k --keepParent "$APP_BUNDLE" "$ZIP_PATH"
+
+echo "notarize-app: submitting to Apple (this takes 2-10 minutes) …"
+SUBMIT_OUTPUT="$(
+  xcrun notarytool submit "$ZIP_PATH" \
+    --apple-id "$APPLE_ID" \
+    --password "$APPLE_ID_PASSWORD" \
+    --team-id "$APPLE_TEAM_ID" \
+    --wait 2>&1
+)"
+echo "$SUBMIT_OUTPUT"
+
+# notarytool --wait prints "status: Accepted" on success. Anything else
+# (Rejected / Invalid) is a hard fail; we surface the log URL so a
+# human can read the rejection reasons.
+if ! echo "$SUBMIT_OUTPUT" | grep -q "status: Accepted"; then
+  echo "notarize-app: notarization failed — see log URL above" >&2
+  SUBMISSION_ID="$(echo "$SUBMIT_OUTPUT" | awk '/id:/{print $2; exit}')"
+  if [ -n "$SUBMISSION_ID" ]; then
+    echo "notarize-app: fetching detailed log for submission $SUBMISSION_ID …" >&2
+    xcrun notarytool log "$SUBMISSION_ID" \
+      --apple-id "$APPLE_ID" \
+      --password "$APPLE_ID_PASSWORD" \
+      --team-id "$APPLE_TEAM_ID" >&2 || true
+  fi
+  exit 2
+fi
+
+# ── Staple the ticket onto the .app so Gatekeeper works offline ─────
+# Without stapling, first-launch requires an internet connection to
+# fetch the notarization verdict from Apple. Stapling embeds the
+# verdict so the app opens on a fresh Mac with no network.
+echo "notarize-app: stapling notarization ticket …"
+xcrun stapler staple "$APP_BUNDLE"
+xcrun stapler validate "$APP_BUNDLE"
+
+rm -f "$ZIP_PATH"
+echo "notarize-app: ✓ $APP_BUNDLE signed, notarized, and stapled"


### PR DESCRIPTION
## Summary

Release-quality signed + notarized \`.app\` artifacts attached to every GitHub Release. **P2-1** from the external-trends roadmap; pairs with [#134](https://github.com/heznpc/AirMCP/pull/134).

Stacked on [#135](https://github.com/heznpc/AirMCP/pull/135).

## Changes

- \`scripts/notarize-app.sh\` — Developer ID codesign → \`notarytool\` submit → staple. Fetches detailed rejection log automatically. \`SKIP_NOTARIZATION=1\` for sign-only smoke.
- \`.github/workflows/release-app.yml\` — triggered on \`v*.*.*\` tag. Preflight lists every missing secret in one error. Imports cert into throwaway keychain. Runs bundle → notarize → also builds the matching \`.mcpb\` → attaches both to the Release.
- \`docs/RELEASE_CHECKLIST.md §3.4\` — runbook for the 6 required secrets + verification commands (\`codesign -dv\`, \`spctl -a\`).

## Required secrets (listed in workflow header)

\`APPLE_DEVELOPER_ID\`, \`APPLE_ID\`, \`APPLE_ID_PASSWORD\`, \`APPLE_TEAM_ID\`, \`APPLE_CERT_P12_BASE64\`, \`APPLE_CERT_P12_PASSWORD\`.

Until they're set, the workflow exits early with the full list. Nothing breaks if it never runs.

## Test plan

- [x] \`bash -n\` script syntax
- [x] \`js-yaml\` YAML valid
- [x] Missing bundle / missing env → expected error paths
- [ ] Full signing flow needs real credentials