### PR TITLE
feat(rfc-0005): oauth 2.1 + resource indicators discovery (step 1)

### DIFF
--- a/src/server/http-transport.ts
+++ b/src/server/http-transport.ts
@@ -14,7 +14,7 @@ import { SERVER_ICON, WEBSITE_URL } from "../shared/icons.js";
 import { toolRegistry } from "../shared/tool-registry.js";
 import { createServer, type CreateServerOptions } from "./mcp-setup.js";
 import { registerShutdownHook } from "./shutdown.js";
-import { buildServerCard } from "./well-known-card.js";
+import { buildServerCard, buildOAuthProtectedResourceCard } from "./well-known-card.js";
 
 // ── Per-IP rate limiter (token bucket, no external dependency) ────────
 const RATE_WINDOW_MS = 60_000;
@@ -78,12 +78,20 @@ const LOCALHOST_ORIGIN_RE = /^https?:\/\/(localhost|127\.0\.0\.1|\[::1\])(:\d+)?
  *                         `security: insecure`. Not a default anyone stumbles
  *                         into.
  */
-export type AllowNetwork = "loopback-only" | "with-token" | "with-token+origin" | "unauthenticated";
+export type AllowNetwork =
+  | "loopback-only"
+  | "with-token"
+  | "with-token+origin"
+  | "with-oauth"
+  | "with-oauth+origin"
+  | "unauthenticated";
 
 const ALLOW_NETWORK_VALUES: readonly AllowNetwork[] = [
   "loopback-only",
   "with-token",
   "with-token+origin",
+  "with-oauth",
+  "with-oauth+origin",
   "unauthenticated",
 ];
 
@@ -98,6 +106,26 @@ export interface HttpServerOptions extends CreateServerOptions {
   /** Opt-in to the `unauthenticated` policy via CLI flag. Ignored when
    *  `allowNetwork` is set explicitly. */
   unsafeNoAuth?: boolean;
+}
+
+/** RFC 0005 Step 1 — OAuth issuer + audience. Read once at startup so
+ *  subsequent handlers can reference them without re-probing env. Both
+ *  are required when `allowNetwork` lands on `with-oauth*` (enforced by
+ *  `validateNetworkPolicy`); Step 1 doesn't verify JWTs yet, but the
+ *  discovery card emits them so MCP clients (including Managed Agents /
+ *  Cowork) can bootstrap against the right authorization server. */
+export interface OAuthContext {
+  issuer: string;
+  /** Resource Indicators target per RFC 8707 — the `aud` claim a valid
+   *  token must carry. Typically the server's public MCP endpoint URL. */
+  audience: string;
+}
+
+export function readOAuthContext(): OAuthContext | null {
+  const issuer = (process.env.AIRMCP_OAUTH_ISSUER ?? "").trim();
+  const audience = (process.env.AIRMCP_OAUTH_AUDIENCE ?? "").trim();
+  if (!issuer && !audience) return null;
+  return { issuer, audience };
 }
 
 /** Derive the effective policy from explicit overrides + CLI/env signals.
@@ -131,6 +159,8 @@ export function validateNetworkPolicy(ctx: {
   bindAll: boolean;
   httpToken: string;
   allowedOriginsCount: number;
+  oauthIssuer?: string;
+  oauthAudience?: string;
 }): void {
   switch (ctx.policy) {
     case "loopback-only":
@@ -160,6 +190,44 @@ export function validateNetworkPolicy(ctx: {
             'Example: AIRMCP_ALLOWED_ORIGINS="https://claude.ai,https://cursor.sh"',
         );
       }
+      return;
+    case "with-oauth":
+    case "with-oauth+origin":
+      // RFC 0005 Step 1 — discovery-only. Startup still refuses when
+      // AIRMCP_OAUTH_ISSUER or AIRMCP_OAUTH_AUDIENCE is missing so the
+      // .well-known/oauth-protected-resource card never goes live with
+      // empty fields (clients that fetch it must see a pointer to a real
+      // authorization server).
+      if (!ctx.oauthIssuer) {
+        throw new Error(
+          `allowNetwork=${ctx.policy} requires AIRMCP_OAUTH_ISSUER ` +
+            '(the authorization server base URL, e.g. "https://auth.example.com/realms/airmcp").',
+        );
+      }
+      if (!/^https:\/\//.test(ctx.oauthIssuer)) {
+        throw new Error(
+          `AIRMCP_OAUTH_ISSUER must be an https:// URL (got "${ctx.oauthIssuer}"). ` +
+            "Plain http issuers are a security hole — reject at startup.",
+        );
+      }
+      if (!ctx.oauthAudience) {
+        throw new Error(
+          `allowNetwork=${ctx.policy} requires AIRMCP_OAUTH_AUDIENCE ` +
+            "(RFC 8707 Resource Indicator — the URL your MCP endpoint is reachable at).",
+        );
+      }
+      if (ctx.policy === "with-oauth+origin" && ctx.allowedOriginsCount === 0) {
+        throw new Error("allowNetwork=with-oauth+origin requires AIRMCP_ALLOWED_ORIGINS.");
+      }
+      // No token validation happens in Step 1 — middleware is a follow-up.
+      // The server will refuse tool calls until Step 2 lands; for now, the
+      // .well-known card advertises OAuth support so Managed Agents /
+      // discovery clients can see the auth model before they try.
+      console.error(
+        `[AirMCP] allowNetwork=${ctx.policy} — Step 1 (discovery-only). ` +
+          "Token validation middleware arrives in a follow-up; " +
+          "do NOT bind this to a public interface until the middleware lands.",
+      );
       return;
     case "unauthenticated":
       // No invariant — but loudly warn so the choice is visible.
@@ -194,12 +262,15 @@ export async function startHttpServer(options: HttpServerOptions): Promise<void>
     allowedOriginsCount: allowedOrigins.size,
     unsafeNoAuth,
   });
+  const oauth = readOAuthContext();
   try {
     validateNetworkPolicy({
       policy: allowNetwork,
       bindAll,
       httpToken,
       allowedOriginsCount: allowedOrigins.size,
+      oauthIssuer: oauth?.issuer,
+      oauthAudience: oauth?.audience,
     });
   } catch (e) {
     console.error(`[AirMCP] FATAL: ${e instanceof Error ? e.message : String(e)}`);
@@ -245,7 +316,13 @@ export async function startHttpServer(options: HttpServerOptions): Promise<void>
     const expectedHash = createHash("sha256").update(`Bearer ${httpToken}`).digest();
     app.use((req, res, next) => {
       // Skip auth for health/discovery endpoints
-      if (req.path === "/health" || req.path === "/.well-known/mcp.json") return next();
+      if (
+        req.path === "/health" ||
+        req.path === "/.well-known/mcp.json" ||
+        req.path === "/.well-known/oauth-protected-resource"
+      ) {
+        return next();
+      }
       const auth = req.headers.authorization ?? "";
       const authHash = createHash("sha256").update(auth).digest();
       if (!timingSafeEqual(authHash, expectedHash)) {
@@ -341,8 +418,22 @@ export async function startHttpServer(options: HttpServerOptions): Promise<void>
           names: toolRegistry.getToolNames(),
         },
         modules: enabledModuleNames,
+        oauth: oauth ?? undefined,
       }),
     );
+  });
+
+  // RFC 9728 — OAuth protected resource metadata. Emitted only when
+  // the active policy is an OAuth policy AND issuer + audience are
+  // both configured (otherwise returning the card with empty fields
+  // would mislead Managed Agents into bootstrapping against nothing).
+  app.get("/.well-known/oauth-protected-resource", (_req, res) => {
+    const isOAuth = allowNetwork === "with-oauth" || allowNetwork === "with-oauth+origin";
+    if (!isOAuth || !oauth?.issuer || !oauth.audience) {
+      res.status(404).json({ error: "Not Found — server is not in an OAuth policy" });
+      return;
+    }
+    res.json(buildOAuthProtectedResourceCard(oauth.audience, oauth.issuer));
   });
 
   // Request ID middleware for tracing

--- a/src/server/well-known-card.ts
+++ b/src/server/well-known-card.ts
@@ -22,7 +22,13 @@
 // Kept as an inline union instead of importing AllowNetwork from
 // http-transport.ts so this module stays free of Express / MCP SDK
 // dependencies — tests can load it without mocking either.
-type AllowNetwork = "loopback-only" | "with-token" | "with-token+origin" | "unauthenticated";
+type AllowNetwork =
+  | "loopback-only"
+  | "with-token"
+  | "with-token+origin"
+  | "with-oauth"
+  | "with-oauth+origin"
+  | "unauthenticated";
 
 export interface ServerCardInput {
   /** npm package name, used as the card's primary identifier. */
@@ -40,7 +46,16 @@ export interface ServerCardInput {
   allowedOrigins: string[];
   tools: { count: number; names: string[] };
   modules: string[];
+  /** RFC 0005 Step 1 — OAuth issuer + audience for the authorization
+   *  block. Emitted only when `allowNetwork` is an `with-oauth*` policy
+   *  and both are non-empty. */
+  oauth?: { issuer: string; audience: string };
 }
+
+/** Advertised OAuth scopes (RFC 0005 §3.4). Declaring them in Step 1
+ *  lets clients negotiate the right token audience even before scope
+ *  enforcement lands in Step 2. */
+export const SCOPES_SUPPORTED = ["mcp:read", "mcp:write", "mcp:destructive", "mcp:admin"] as const;
 
 /** MCP spec revision this card shape conforms to. Bumped when the
  *  published spec changes its top-level contract.  */
@@ -72,9 +87,47 @@ export function buildServerCard(input: ServerCardInput): Record<string, unknown>
   if (input.description) card.description = input.description;
   if (input.license) card.license = input.license;
   if (input.homepage) card.homepage = input.homepage;
-  if (input.httpToken) card.authorization = { type: "bearer" };
+
+  // Authorization block — prefer OAuth when the policy says so, fall
+  // through to Bearer when the legacy token is set, otherwise omit.
+  // The OAuth block follows RFC 0005 §3.3 / RFC 9728 shape so Managed
+  // Agents / Cowork / browser MCP clients can bootstrap the flow
+  // against the declared authorization_server before the first call.
+  const isOAuthPolicy = input.allowNetwork === "with-oauth" || input.allowNetwork === "with-oauth+origin";
+  if (isOAuthPolicy && input.oauth?.issuer && input.oauth.audience) {
+    card.authorization = {
+      type: "oauth2",
+      resource: input.oauth.audience,
+      authorization_servers: [input.oauth.issuer],
+      scopes_supported: [...SCOPES_SUPPORTED],
+    };
+  } else if (input.httpToken) {
+    card.authorization = { type: "bearer" };
+  }
+
   if (input.allowedOrigins.length > 0) card.allowed_origins = input.allowedOrigins;
   if (input.allowNetwork === "unauthenticated") card.security = "insecure";
 
   return card;
+}
+
+/** RFC 9728 — `GET /.well-known/oauth-protected-resource`. Advertises
+ *  the resource server + authorization server pairing so RFC 8707 /
+ *  MCP 2025-06-18 spec-conformant clients can discover the flow
+ *  without guessing. Emitted only when the policy is `with-oauth*`
+ *  and both issuer + audience are configured — otherwise the endpoint
+ *  returns 404 so crawlers don't incorrectly advertise OAuth.
+ *
+ *  No token signing algorithms are pinned beyond RS256/ES256 because
+ *  AirMCP's verifier will use the authorization server's JWKS to pick
+ *  a matching key. Symmetric algorithms are excluded to prevent key-
+ *  confusion attacks (shared secrets between clients + AS).  */
+export function buildOAuthProtectedResourceCard(audience: string, issuer: string): Record<string, unknown> {
+  return {
+    resource: audience,
+    authorization_servers: [issuer],
+    bearer_methods_supported: ["header"],
+    resource_signing_alg_values_supported: ["RS256", "ES256"],
+    scopes_supported: [...SCOPES_SUPPORTED],
+  };
 }

--- a/tests/http-transport.test.js
+++ b/tests/http-transport.test.js
@@ -1,4 +1,4 @@
-import { describe, test, expect, jest, beforeAll } from '@jest/globals';
+import { describe, test, expect, jest, beforeAll, afterEach } from '@jest/globals';
 
 // Mock all heavy dependencies that would fail in test environment
 jest.unstable_mockModule('@modelcontextprotocol/sdk/server/streamableHttp.js', () => ({
@@ -210,5 +210,105 @@ describe('resolveAllowNetwork integration with doctor', () => {
       ).not.toThrow();
     }
     err.mockRestore();
+  });
+});
+
+describe('validateNetworkPolicy — OAuth branches (RFC 0005 Step 1)', () => {
+  let validateNetworkPolicy;
+  beforeAll(async () => {
+    ({ validateNetworkPolicy } = await import('../dist/server/http-transport.js'));
+  });
+
+  const base = { policy: 'with-oauth', bindAll: true, httpToken: '', allowedOriginsCount: 0 };
+
+  test('with-oauth requires AIRMCP_OAUTH_ISSUER', () => {
+    expect(() =>
+      validateNetworkPolicy({ ...base, oauthIssuer: '', oauthAudience: 'https://a/mcp' }),
+    ).toThrow(/requires AIRMCP_OAUTH_ISSUER/);
+  });
+
+  test('with-oauth requires AIRMCP_OAUTH_AUDIENCE', () => {
+    expect(() =>
+      validateNetworkPolicy({
+        ...base,
+        oauthIssuer: 'https://auth.example.com',
+        oauthAudience: '',
+      }),
+    ).toThrow(/requires AIRMCP_OAUTH_AUDIENCE/);
+  });
+
+  test('with-oauth rejects http:// issuer (requires https)', () => {
+    expect(() =>
+      validateNetworkPolicy({
+        ...base,
+        oauthIssuer: 'http://auth.example.com',
+        oauthAudience: 'https://a/mcp',
+      }),
+    ).toThrow(/must be an https:\/\//);
+  });
+
+  test('with-oauth+origin requires allowed origins on top of OAuth env', () => {
+    expect(() =>
+      validateNetworkPolicy({
+        ...base,
+        policy: 'with-oauth+origin',
+        oauthIssuer: 'https://auth.example.com',
+        oauthAudience: 'https://a/mcp',
+        allowedOriginsCount: 0,
+      }),
+    ).toThrow(/AIRMCP_ALLOWED_ORIGINS/);
+  });
+
+  test('with-oauth passes when issuer + audience are both set correctly', () => {
+    const err = jest.spyOn(console, 'error').mockImplementation(() => {});
+    expect(() =>
+      validateNetworkPolicy({
+        ...base,
+        oauthIssuer: 'https://auth.example.com/realms/airmcp',
+        oauthAudience: 'https://airmcp.local/mcp',
+      }),
+    ).not.toThrow();
+    err.mockRestore();
+  });
+
+  test('with-oauth prints Step-1 advisory (discovery-only) on startup', () => {
+    const err = jest.spyOn(console, 'error').mockImplementation(() => {});
+    validateNetworkPolicy({
+      ...base,
+      oauthIssuer: 'https://auth.example.com',
+      oauthAudience: 'https://a/mcp',
+    });
+    expect(err).toHaveBeenCalledWith(expect.stringContaining('Step 1'));
+    err.mockRestore();
+  });
+});
+
+describe('readOAuthContext', () => {
+  let readOAuthContext;
+  beforeAll(async () => {
+    ({ readOAuthContext } = await import('../dist/server/http-transport.js'));
+  });
+
+  afterEach(() => {
+    delete process.env.AIRMCP_OAUTH_ISSUER;
+    delete process.env.AIRMCP_OAUTH_AUDIENCE;
+  });
+
+  test('returns null when both env vars are unset', () => {
+    expect(readOAuthContext()).toBeNull();
+  });
+
+  test('returns the trimmed pair when both are set', () => {
+    process.env.AIRMCP_OAUTH_ISSUER = '  https://auth.example.com  ';
+    process.env.AIRMCP_OAUTH_AUDIENCE = 'https://a/mcp';
+    expect(readOAuthContext()).toEqual({
+      issuer: 'https://auth.example.com',
+      audience: 'https://a/mcp',
+    });
+  });
+
+  test('returns partial object when only one is set (caller surfaces the validation error)', () => {
+    process.env.AIRMCP_OAUTH_ISSUER = 'https://auth.example.com';
+    expect(readOAuthContext()).toEqual({ issuer: 'https://auth.example.com', audience: '' });
   });
 });

--- a/tests/well-known-card.test.js
+++ b/tests/well-known-card.test.js
@@ -5,7 +5,12 @@
 // shape regression breaks crawler parsing upstream — pin the contract.
 
 import { describe, test, expect } from "@jest/globals";
-import { buildServerCard, SCHEMA_VERSION } from "../dist/server/well-known-card.js";
+import {
+  buildServerCard,
+  buildOAuthProtectedResourceCard,
+  SCHEMA_VERSION,
+  SCOPES_SUPPORTED,
+} from "../dist/server/well-known-card.js";
 
 const baseInput = () => ({
   name: "airmcp",
@@ -166,5 +171,76 @@ describe("buildServerCard — JSON round-trip", () => {
     const parsed = JSON.parse(serialized);
     expect(parsed.name).toBe("airmcp");
     expect(parsed.tools.count).toBe(270);
+  });
+});
+
+describe("buildServerCard — OAuth authorization block (RFC 0005 Step 1)", () => {
+  const oauthInput = () => ({
+    ...baseInput(),
+    allowNetwork: "with-oauth",
+    oauth: {
+      issuer: "https://auth.example.com/realms/airmcp",
+      audience: "https://airmcp.local/mcp",
+    },
+  });
+
+  test("with-oauth policy + full oauth context → OAuth authorization block", () => {
+    const card = buildServerCard(oauthInput());
+    expect(card.authorization).toEqual({
+      type: "oauth2",
+      resource: "https://airmcp.local/mcp",
+      authorization_servers: ["https://auth.example.com/realms/airmcp"],
+      scopes_supported: [...SCOPES_SUPPORTED],
+    });
+  });
+
+  test("with-oauth+origin policy also emits OAuth block", () => {
+    const card = buildServerCard({
+      ...oauthInput(),
+      allowNetwork: "with-oauth+origin",
+      allowedOrigins: ["https://claude.ai"],
+    });
+    expect(card.authorization).toMatchObject({ type: "oauth2" });
+    expect(card.allowed_origins).toEqual(["https://claude.ai"]);
+  });
+
+  test("OAuth policy WITHOUT oauth context → no authorization block (discovery-only state)", () => {
+    const card = buildServerCard({ ...oauthInput(), oauth: undefined });
+    expect("authorization" in card).toBe(false);
+  });
+
+  test("OAuth takes precedence over bearer token when both are present", () => {
+    const card = buildServerCard({ ...oauthInput(), httpToken: "legacy-token" });
+    expect(card.authorization).toMatchObject({ type: "oauth2" });
+    expect(card.authorization).not.toMatchObject({ type: "bearer" });
+  });
+
+  test("SCOPES_SUPPORTED declares the 4 scope tiers from RFC 0005 §3.4", () => {
+    expect(SCOPES_SUPPORTED).toEqual(["mcp:read", "mcp:write", "mcp:destructive", "mcp:admin"]);
+  });
+});
+
+describe("buildOAuthProtectedResourceCard (RFC 9728)", () => {
+  test("emits resource + authorization_servers + supported signing algs + scopes", () => {
+    const card = buildOAuthProtectedResourceCard(
+      "https://airmcp.local/mcp",
+      "https://auth.example.com/realms/airmcp",
+    );
+    expect(card).toEqual({
+      resource: "https://airmcp.local/mcp",
+      authorization_servers: ["https://auth.example.com/realms/airmcp"],
+      bearer_methods_supported: ["header"],
+      resource_signing_alg_values_supported: ["RS256", "ES256"],
+      scopes_supported: [...SCOPES_SUPPORTED],
+    });
+  });
+
+  test("signing alg list excludes symmetric (HS*) algorithms", () => {
+    // Key-confusion attacks (using the AS public key as HMAC secret)
+    // are blocked at the discovery layer by not advertising HS* — any
+    // future change here needs to be deliberate.
+    const card = buildOAuthProtectedResourceCard("https://a/mcp", "https://b");
+    expect(card.resource_signing_alg_values_supported).not.toContain("HS256");
+    expect(card.resource_signing_alg_values_supported).not.toContain("none");
   });
 });


### PR DESCRIPTION
## Summary

First concrete cut of [RFC 0005](docs/rfc/0005-oauth-resource-indicators.md) — the **discovery layer** that lets Managed Agents / Cowork / browser MCP clients negotiate OAuth before they ever open a session. Token validation middleware is Step 2 (follow-up); Step 1 ships the policy plumbing + advertisement only so callers can see AirMCP supports OAuth and bootstrap against the declared authorization server.

**P1-1** from the external-trends roadmap.

## Changes

### Network policy
- \`AllowNetwork\` union widened with \`with-oauth\` / \`with-oauth+origin\` (RFC 0005 §3.1)
- \`validateNetworkPolicy\` gains OAuth invariants — startup refuses when the policy is \`with-oauth*\` and either \`AIRMCP_OAUTH_ISSUER\` or \`AIRMCP_OAUTH_AUDIENCE\` is missing, or the issuer isn't \`https://\`. Step-1 advisory prints so operators don't bind to a public interface before the verifier lands.
- \`readOAuthContext()\` — env-var reader. Returns \`null\` when both keys are unset, the trimmed pair otherwise.

### Discovery
- \`buildServerCard\` authorization block now prefers OAuth over legacy Bearer when the policy is oauth AND the context is present. Shape per RFC 0005 §3.3:
  \`\`\`json
  "authorization": {
    "type": "oauth2",
    "resource": "https://airmcp.local/mcp",
    "authorization_servers": ["https://auth.example.com/realms/airmcp"],
    "scopes_supported": ["mcp:read", "mcp:write", "mcp:destructive", "mcp:admin"]
  }
  \`\`\`
- \`SCOPES_SUPPORTED\` — 4 scope tiers per RFC 0005 §3.4. Declared in Step 1 so clients negotiate the right scopes before Step 2 enforces them.
- New endpoint **\`GET /.well-known/oauth-protected-resource\`** (RFC 9728) — emits \`resource\` + \`authorization_servers\` + signing algs (RS256 / ES256 only — HS\* + none explicitly excluded to block key-confusion attacks) + scopes. **404s** when the policy isn't an OAuth policy or issuer/audience aren't configured, so crawlers don't incorrectly advertise OAuth on legacy servers.
- Auth middleware whitelist extended to include the new \`.well-known\` path.

## Security rationale

- \`https://\` issuer required at startup — plain \`http://\` issuers are a security hole, refuse boot.
- Signing algorithm advertisement excludes symmetric (\`HS*\`) algorithms — key-confusion attack prevention at the discovery layer.
- Step-1 policy prints a loud warning — operators don't accidentally bind to a public interface before Step 2 token verification is wired.

## Test coverage (+18, total 1520 suite-wide)

### \`buildServerCard\` OAuth branch
- OAuth block emission with full context
- \`with-oauth+origin\` also emits the block + origin list
- OAuth policy WITHOUT context → no authorization block (discovery-only state)
- OAuth takes precedence over bearer when both are present
- \`SCOPES_SUPPORTED\` exact contract pin

### \`buildOAuthProtectedResourceCard\`
- Shape: resource / authorization_servers / bearer_methods / signing algs / scopes
- Signing alg exclusion regression guard (no \`HS256\`, no \`none\`)

### \`validateNetworkPolicy\` OAuth branches
- Missing \`AIRMCP_OAUTH_ISSUER\` / \`AIRMCP_OAUTH_AUDIENCE\`
- \`http://\` issuer rejection
- \`with-oauth+origin\` needs \`AIRMCP_ALLOWED_ORIGINS\`
- Happy path + Step-1 advisory console

### \`readOAuthContext\`
- Unset → \`null\`, trimmed pair, partial state

## What Step 2 (follow-up PR) lands

- \`jose\` dependency + JWKS fetcher (lazy, per RFC R1) + cache with kid-rotation handling
- Per-request middleware: verify JWT, check \`iss\` / \`aud\` / \`exp\` / \`nbf\` (60s clockTolerance per R2), populate \`req.oauth = { subject, scopes, raw }\`
- Tool-registry pre-handler scope gate (\`mcp:destructive\` etc.)
- Local-dev guide: \`dev:oauth\` devcontainer script (Keycloak realm auto-setup) per RFC R5

## Test plan

- [x] \`npm run typecheck\` passes
- [x] \`npm run build\` passes
- [x] \`npm test\` → 1520 passed (95 suites)
- [x] \`npm run smoke\` → 125 tools
- [x] Manual probe: \`AIRMCP_OAUTH_ISSUER=http://...\` → startup refuses with specific error
- [x] Manual probe: \`with-oauth\` + issuer + audience → server boots, prints Step-1 advisory