### PR TITLE
refactor: drop unused basename import in MemoryStore.save (simplify pass)

### DIFF
--- a/src/memory/store.ts
+++ b/src/memory/store.ts
@@ -19,7 +19,7 @@
  */
 
 import { readFile, writeFile, mkdir, rename } from "node:fs/promises";
-import { dirname, basename } from "node:path";
+import { dirname } from "node:path";
 import { randomBytes } from "node:crypto";
 import { PATHS } from "../shared/constants.js";
 
@@ -184,9 +184,6 @@ export class MemoryStore {
       } catch {
         // ignore — temp may not have been created at all
       }
-      // Anchor the failure to a recognizable basename so stack traces
-      // identify the partial-write site even after rename strips it.
-      void basename;
       throw err;
     }
     this.cache = data;


### PR DESCRIPTION
## Summary

`/simplify` review of [#154](https://github.com/heznpc/AirMCP/pull/154) flagged a single actionable item — the rest were YAGNI / acceptable-as-is.

PR #154 imported `basename` and added `void basename;` inside `MemoryStore.save()`'s catch block to silence the unused-import lint. The accompanying comment claimed it "anchors the failure to a recognizable basename so stack traces identify the partial-write site" — but the `throw err` already carries the full stack, and the temp file path is in the catch's local scope. The whole construct is a workaround for an import I added speculatively and then never used.

This PR drops the import + `void basename;` + comment.

## Skipped (recorded for future reference)

- **`enqueue` wrapper repetition in `put`/`forget`/`stats`** — 3 sites, explicit wrap is readable, refactor would add abstraction. YAGNI.
- **`mkdir(..., recursive: true)` on every save** — syscall is cheap when dir exists; gains aren't worth caching state.
- **Dynamic `import("node:fs/promises")` in catch** — error path only, not hot.

## Verification

- 99 suites / 1577 tests pass unchanged