### PR TITLE
feat: outputSchema Wave 5 — 4 photos read tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **outputSchema Wave 5 — 4 photos read tools** (`list_photos`, `search_photos`, `get_photo_info`, `list_favorites`) — extends Wave 4's pattern to the photos module. `list_photos` / `search_photos` / `list_favorites` route through `okUntrustedLinkedStructured` (photo metadata is user content); `get_photo_info` uses `okUntrustedStructured`. `list_albums` deferred — bare `AlbumItem[]` return shape, same array-vs-object breaking-change risk as `compare_notes`. Weather forecast tools (`get_daily_forecast` / `get_hourly_forecast`) also deferred for the same reason. 7 new drift guards in `tests/output-schema-wave5.test.js` covering full / null-EXIF / empty-list shapes; `tests/output-schema-structured.test.js` exhaustive coverage check picks up 4 fixtures so any future tool that adds outputSchema without a fixture breaks the build.
+
 ### Fixed
 - **`AskAirMCPIntent` rejects empty / whitespace-only prompts** ([`swift/Sources/AirMCPKit/AskAirMCPIntent.swift`](swift/Sources/AirMCPKit/AskAirMCPIntent.swift)) — Siri "Ask AirMCP" with no follow-up text used to hit `LanguageModelSession.respond(to: "")` → opaque framework error → generic Shortcuts failure. Now trim and return a recoverable user-facing message ("Please ask a question — I need something to look up.").
 - **`gen-llms-txt.mjs` count drift fully closed** ([`scripts/gen-llms-txt.mjs`](scripts/gen-llms-txt.mjs)) — was reporting `265 tools / 32 modules` while `count-stats.mjs` (canonical) said `269 / 29`. Two roots: strict `extractTools` regex missed 4 tools whose registration spans the regex boundary; `walkDir` overcounted cross / semantic / skills / server / shared as separate modules. Fix: broad-regex pass for totals (matches `count-stats`), canonical module count parsed from `MODULE_NAMES`. Per-module list keeps strict regex for rich rendering. Headline now `269 / 29` everywhere.

--- a/docs/tool-manifest.json
+++ b/docs/tool-manifest.json
@@ -2947,7 +2947,94 @@
         "additionalProperties": false,
         "$schema": "http://json-schema.org/draft-07/schema#"
       },
-      "outputSchema": null,
+      "outputSchema": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "filename": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "name": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "description": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "date": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "width": {
+            "type": "number"
+          },
+          "height": {
+            "type": "number"
+          },
+          "altitude": {
+            "type": [
+              "number",
+              "null"
+            ]
+          },
+          "location": {
+            "anyOf": [
+              {
+                "type": "array",
+                "items": {
+                  "type": "number"
+                }
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "favorite": {
+            "type": "boolean"
+          },
+          "keywords": {
+            "anyOf": [
+              {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "required": [
+          "id",
+          "filename",
+          "name",
+          "description",
+          "date",
+          "width",
+          "height",
+          "altitude",
+          "location",
+          "favorite",
+          "keywords"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
       "annotations": {
         "readOnlyHint": true,
         "destructiveHint": false,
@@ -4951,7 +5038,72 @@
         "additionalProperties": false,
         "$schema": "http://json-schema.org/draft-07/schema#"
       },
-      "outputSchema": null,
+      "outputSchema": {
+        "type": "object",
+        "properties": {
+          "total": {
+            "type": "number"
+          },
+          "returned": {
+            "type": "number"
+          },
+          "photos": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string"
+                },
+                "filename": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "name": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "date": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "width": {
+                  "type": "number"
+                },
+                "height": {
+                  "type": "number"
+                },
+                "favorite": {
+                  "type": "boolean"
+                }
+              },
+              "required": [
+                "id",
+                "filename",
+                "name",
+                "date",
+                "width",
+                "height",
+                "favorite"
+              ],
+              "additionalProperties": false
+            }
+          }
+        },
+        "required": [
+          "total",
+          "returned",
+          "photos"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
       "annotations": {
         "readOnlyHint": true,
         "destructiveHint": false,
@@ -5515,7 +5667,76 @@
         "additionalProperties": false,
         "$schema": "http://json-schema.org/draft-07/schema#"
       },
-      "outputSchema": null,
+      "outputSchema": {
+        "type": "object",
+        "properties": {
+          "total": {
+            "type": "number"
+          },
+          "offset": {
+            "type": "number"
+          },
+          "returned": {
+            "type": "number"
+          },
+          "photos": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string"
+                },
+                "filename": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "name": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "date": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "width": {
+                  "type": "number"
+                },
+                "height": {
+                  "type": "number"
+                },
+                "favorite": {
+                  "type": "boolean"
+                }
+              },
+              "required": [
+                "id",
+                "filename",
+                "name",
+                "date",
+                "width",
+                "height",
+                "favorite"
+              ],
+              "additionalProperties": false
+            }
+          }
+        },
+        "required": [
+          "total",
+          "offset",
+          "returned",
+          "photos"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
       "annotations": {
         "readOnlyHint": true,
         "destructiveHint": false,
@@ -9780,7 +10001,67 @@
         "additionalProperties": false,
         "$schema": "http://json-schema.org/draft-07/schema#"
       },
-      "outputSchema": null,
+      "outputSchema": {
+        "type": "object",
+        "properties": {
+          "total": {
+            "type": "number"
+          },
+          "photos": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string"
+                },
+                "filename": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "name": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "date": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "favorite": {
+                  "type": "boolean"
+                },
+                "description": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                }
+              },
+              "required": [
+                "id",
+                "filename",
+                "name",
+                "date",
+                "favorite",
+                "description"
+              ],
+              "additionalProperties": false
+            }
+          }
+        },
+        "required": [
+          "total",
+          "photos"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
       "annotations": {
         "readOnlyHint": true,
         "destructiveHint": false,

--- a/src/photos/tools.ts
+++ b/src/photos/tools.ts
@@ -3,7 +3,7 @@ import { z } from "zod";
 import { runSwift } from "../shared/swift.js";
 import { runAutomation } from "../shared/automation.js";
 import type { AirMcpConfig } from "../shared/config.js";
-import { ok, okUntrusted, toolError } from "../shared/result.js";
+import { ok, okUntrusted, okUntrustedLinkedStructured, okUntrustedStructured, toolError } from "../shared/result.js";
 import { zFilePath, resolveAndGuard } from "../shared/validate.js";
 import {
   listAlbumsScript,
@@ -124,6 +124,22 @@ export function registerPhotosTools(server: McpServer, _config: AirMcpConfig): v
         limit: z.number().int().min(1).max(500).optional().default(50).describe("Max photos (default: 50)"),
         offset: z.number().int().min(0).optional().default(0).describe("Offset for pagination (default: 0)"),
       },
+      outputSchema: {
+        total: z.number(),
+        offset: z.number(),
+        returned: z.number(),
+        photos: z.array(
+          z.object({
+            id: z.string(),
+            filename: z.string().nullable(),
+            name: z.string().nullable(),
+            date: z.string().nullable(),
+            width: z.number(),
+            height: z.number(),
+            favorite: z.boolean(),
+          }),
+        ),
+      },
       annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: false },
     },
     async ({ album, limit, offset }) => {
@@ -135,7 +151,7 @@ export function registerPhotosTools(server: McpServer, _config: AirMcpConfig): v
           },
           jxa: () => listPhotosScript(album, limit, offset),
         });
-        return okUntrusted(result);
+        return okUntrustedLinkedStructured("list_photos", result);
       } catch (e) {
         return toolError("list photos", e);
       }
@@ -151,6 +167,19 @@ export function registerPhotosTools(server: McpServer, _config: AirMcpConfig): v
         query: z.string().max(500).describe("Search keyword"),
         limit: z.number().int().min(1).max(200).optional().default(30).describe("Max results (default: 30)"),
       },
+      outputSchema: {
+        total: z.number(),
+        photos: z.array(
+          z.object({
+            id: z.string(),
+            filename: z.string().nullable(),
+            name: z.string().nullable(),
+            date: z.string().nullable(),
+            favorite: z.boolean(),
+            description: z.string().nullable(),
+          }),
+        ),
+      },
       annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: false },
     },
     async ({ query, limit }) => {
@@ -162,7 +191,7 @@ export function registerPhotosTools(server: McpServer, _config: AirMcpConfig): v
           },
           jxa: () => searchPhotosScript(query, limit),
         });
-        return okUntrusted(result);
+        return okUntrustedLinkedStructured("search_photos", result);
       } catch (e) {
         return toolError("search photos", e);
       }
@@ -177,6 +206,21 @@ export function registerPhotosTools(server: McpServer, _config: AirMcpConfig): v
       inputSchema: {
         id: z.string().max(500).describe("Photo media item ID"),
       },
+      outputSchema: {
+        id: z.string(),
+        filename: z.string().nullable(),
+        name: z.string().nullable(),
+        description: z.string().nullable(),
+        date: z.string().nullable(),
+        width: z.number(),
+        height: z.number(),
+        altitude: z.number().nullable(),
+        // GPS coordinates as a [lat, lon] pair when EXIF carries them.
+        // Sensitive — clients should treat as PII.
+        location: z.array(z.number()).nullable(),
+        favorite: z.boolean(),
+        keywords: z.array(z.string()).nullable(),
+      },
       annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: false },
     },
     async ({ id }) => {
@@ -188,7 +232,7 @@ export function registerPhotosTools(server: McpServer, _config: AirMcpConfig): v
           },
           jxa: () => getPhotoInfoScript(id),
         });
-        return okUntrusted(result);
+        return okUntrustedStructured(result);
       } catch (e) {
         return toolError("get photo info", e);
       }
@@ -203,6 +247,21 @@ export function registerPhotosTools(server: McpServer, _config: AirMcpConfig): v
       inputSchema: {
         limit: z.number().int().min(1).max(500).optional().default(50).describe("Max photos (default: 50)"),
       },
+      outputSchema: {
+        total: z.number(),
+        returned: z.number(),
+        photos: z.array(
+          z.object({
+            id: z.string(),
+            filename: z.string().nullable(),
+            name: z.string().nullable(),
+            date: z.string().nullable(),
+            width: z.number(),
+            height: z.number(),
+            favorite: z.boolean(),
+          }),
+        ),
+      },
       annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: false },
     },
     async ({ limit }) => {
@@ -214,7 +273,7 @@ export function registerPhotosTools(server: McpServer, _config: AirMcpConfig): v
           },
           jxa: () => listFavoritesScript(limit),
         });
-        return ok(result);
+        return okUntrustedLinkedStructured("list_favorites", result);
       } catch (e) {
         return toolError("list favorites", e);
       }

--- a/swift/Sources/AirMCPKit/Generated/MCPIntents.swift
+++ b/swift/Sources/AirMCPKit/Generated/MCPIntents.swift
@@ -3,7 +3,7 @@
 // Source: docs/tool-manifest.json
 // Generator: scripts/gen-swift-intents.mjs
 // RFC 0007 Phase A.2b.2 + A.4.1 — 229 auto-selected read-only
-// tools (61 with typed drift-guards + Interactive Snippet
+// tools (65 with typed drift-guards + Interactive Snippet
 // SwiftUI views) + 9 AppShortcutsProvider entries.
 // Run `npm run gen:intents` to refresh after tool metadata changes.
 // CI guards against drift via `npm run gen:intents:check`.
@@ -123,6 +123,21 @@ public struct MCPGetFrontmostAppOutput: Codable, Sendable {
     public let name: String
     public let bundleIdentifier: String
     public let pid: Double
+}
+
+// Output type for: get_photo_info
+public struct MCPGetPhotoInfoOutput: Codable, Sendable {
+    public let id: String
+    public let filename: String?
+    public let name: String?
+    public let description: String?
+    public let date: String?
+    public let width: Double
+    public let height: Double
+    public let altitude: Double?
+    public let location: String
+    public let favorite: Bool
+    public let keywords: String
 }
 
 // Output type for: get_shortcut_detail
@@ -267,6 +282,23 @@ public struct MCPListEventsOutput: Codable, Sendable {
     public let events: [EventsItem]
 }
 
+// Output type for: list_favorites
+public struct MCPListFavoritesOutput: Codable, Sendable {
+    public struct PhotosItem: Codable, Sendable {
+        public let id: String
+        public let filename: String?
+        public let name: String?
+        public let date: String?
+        public let width: Double
+        public let height: Double
+        public let favorite: Bool
+    }
+
+    public let total: Double
+    public let returned: Double
+    public let photos: [PhotosItem]
+}
+
 // Output type for: list_folders
 public struct MCPListFoldersOutput: Codable, Sendable {
     public struct FoldersItem: Codable, Sendable {
@@ -360,6 +392,24 @@ public struct MCPListParticipantsOutput: Codable, Sendable {
     public let chatId: String
     public let chatName: String?
     public let participants: [ParticipantsItem]
+}
+
+// Output type for: list_photos
+public struct MCPListPhotosOutput: Codable, Sendable {
+    public struct PhotosItem: Codable, Sendable {
+        public let id: String
+        public let filename: String?
+        public let name: String?
+        public let date: String?
+        public let width: Double
+        public let height: Double
+        public let favorite: Bool
+    }
+
+    public let total: Double
+    public let offset: Double
+    public let returned: Double
+    public let photos: [PhotosItem]
 }
 
 // Output type for: list_playlists
@@ -773,6 +823,21 @@ public struct MCPSearchNotesOutput: Codable, Sendable {
     public let returned: Double
     public let offset: Double
     public let notes: [NotesItem]
+}
+
+// Output type for: search_photos
+public struct MCPSearchPhotosOutput: Codable, Sendable {
+    public struct PhotosItem: Codable, Sendable {
+        public let id: String
+        public let filename: String?
+        public let name: String?
+        public let date: String?
+        public let favorite: Bool
+        public let description: String?
+    }
+
+    public let total: Double
+    public let photos: [PhotosItem]
 }
 
 // Output type for: search_reminders
@@ -2453,6 +2518,16 @@ public struct GetPhotoInfoIntent: AppIntent {
             tool: "get_photo_info",
             args: ["id": id]
         )
+        guard let data = result.data(using: .utf8) else {
+            throw MCPIntentError.toolCallFailed(tool: "get_photo_info", message: "empty result from router")
+        }
+        let decoded = try JSONDecoder().decode(MCPGetPhotoInfoOutput.self, from: data)
+        #if canImport(SwiftUI) && compiler(>=6.3)
+        if #available(macOS 26, iOS 26, *) {
+            return .result(value: result, view: MCPGetPhotoInfoSnippetView(data: decoded))
+        }
+        #endif
+        _ = decoded
         return .result(value: result)
     }
 }
@@ -3522,6 +3597,16 @@ public struct ListFavoritesIntent: AppIntent {
             tool: "list_favorites",
             args: ["limit": limit]
         )
+        guard let data = result.data(using: .utf8) else {
+            throw MCPIntentError.toolCallFailed(tool: "list_favorites", message: "empty result from router")
+        }
+        let decoded = try JSONDecoder().decode(MCPListFavoritesOutput.self, from: data)
+        #if canImport(SwiftUI) && compiler(>=6.3)
+        if #available(macOS 26, iOS 26, *) {
+            return .result(value: result, view: MCPListFavoritesSnippetView(data: decoded))
+        }
+        #endif
+        _ = decoded
         return .result(value: result)
     }
 }
@@ -3776,6 +3861,16 @@ public struct ListPhotosIntent: AppIntent {
             tool: "list_photos",
             args: ["album": album, "limit": limit, "offset": offset]
         )
+        guard let data = result.data(using: .utf8) else {
+            throw MCPIntentError.toolCallFailed(tool: "list_photos", message: "empty result from router")
+        }
+        let decoded = try JSONDecoder().decode(MCPListPhotosOutput.self, from: data)
+        #if canImport(SwiftUI) && compiler(>=6.3)
+        if #available(macOS 26, iOS 26, *) {
+            return .result(value: result, view: MCPListPhotosSnippetView(data: decoded))
+        }
+        #endif
+        _ = decoded
         return .result(value: result)
     }
 }
@@ -5614,6 +5709,16 @@ public struct SearchPhotosIntent: AppIntent {
             tool: "search_photos",
             args: ["query": query, "limit": limit]
         )
+        guard let data = result.data(using: .utf8) else {
+            throw MCPIntentError.toolCallFailed(tool: "search_photos", message: "empty result from router")
+        }
+        let decoded = try JSONDecoder().decode(MCPSearchPhotosOutput.self, from: data)
+        #if canImport(SwiftUI) && compiler(>=6.3)
+        if #available(macOS 26, iOS 26, *) {
+            return .result(value: result, view: MCPSearchPhotosSnippetView(data: decoded))
+        }
+        #endif
+        _ = decoded
         return .result(value: result)
     }
 }
@@ -7237,6 +7342,95 @@ public struct MCPGetFrontmostAppSnippetView: View {
     }
 }
 
+// Snippet view for: get_photo_info  (shape: scalar)
+@available(macOS 26, iOS 26, *)
+public struct MCPGetPhotoInfoSnippetView: View {
+    public let data: MCPGetPhotoInfoOutput
+    public init(data: MCPGetPhotoInfoOutput) { self.data = data }
+    public var body: some View {
+        VStack(alignment: .leading, spacing: 2) {
+            HStack {
+                Text("Id")
+                Spacer()
+                Text(data.id)
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+            }
+            HStack {
+                Text("Filename")
+                Spacer()
+                Text((data.filename ?? "—"))
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+            }
+            HStack {
+                Text("Name")
+                Spacer()
+                Text((data.name ?? "—"))
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+            }
+            HStack {
+                Text("Description")
+                Spacer()
+                Text((data.description ?? "—"))
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+            }
+            HStack {
+                Text("Date")
+                Spacer()
+                Text((data.date ?? "—"))
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+            }
+            HStack {
+                Text("Width")
+                Spacer()
+                Text(data.width.formatted())
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+            }
+            HStack {
+                Text("Height")
+                Spacer()
+                Text(data.height.formatted())
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+            }
+            HStack {
+                Text("Altitude")
+                Spacer()
+                Text((data.altitude?.formatted() ?? "—"))
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+            }
+            HStack {
+                Text("Location")
+                Spacer()
+                Text(String(describing: data.location))
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+            }
+            HStack {
+                Text("Favorite")
+                Spacer()
+                Text((data.favorite ? "Yes" : "No"))
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+            }
+            HStack {
+                Text("Keywords")
+                Spacer()
+                Text(String(describing: data.keywords))
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+            }
+        }
+        .padding()
+    }
+}
+
 // Snippet view for: get_shortcut_detail  (shape: scalar)
 @available(macOS 26, iOS 26, *)
 public struct MCPGetShortcutDetailSnippetView: View {
@@ -7461,6 +7655,23 @@ public struct MCPListEventsSnippetView: View {
     }
 }
 
+// Snippet view for: list_favorites  (shape: list-object)
+@available(macOS 26, iOS 26, *)
+public struct MCPListFavoritesSnippetView: View {
+    public let data: MCPListFavoritesOutput
+    public init(data: MCPListFavoritesOutput) { self.data = data }
+    public var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            ForEach(Array(data.photos.enumerated()), id: \.offset) { _, row in
+                Text((row.filename ?? ""))
+                    .font(.body)
+                    .lineLimit(1)
+            }
+        }
+        .padding()
+    }
+}
+
 // Snippet view for: list_folders  (shape: list-object)
 @available(macOS 26, iOS 26, *)
 public struct MCPListFoldersSnippetView: View {
@@ -7578,6 +7789,23 @@ public struct MCPListParticipantsSnippetView: View {
         VStack(alignment: .leading, spacing: 4) {
             ForEach(Array(data.participants.enumerated()), id: \.offset) { _, row in
                 Text((row.name ?? ""))
+                    .font(.body)
+                    .lineLimit(1)
+            }
+        }
+        .padding()
+    }
+}
+
+// Snippet view for: list_photos  (shape: list-object)
+@available(macOS 26, iOS 26, *)
+public struct MCPListPhotosSnippetView: View {
+    public let data: MCPListPhotosOutput
+    public init(data: MCPListPhotosOutput) { self.data = data }
+    public var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            ForEach(Array(data.photos.enumerated()), id: \.offset) { _, row in
+                Text((row.filename ?? ""))
                     .font(.body)
                     .lineLimit(1)
             }
@@ -8422,6 +8650,23 @@ public struct MCPSearchNotesSnippetView: View {
                         .lineLimit(1)
                 }
                 .buttonStyle(.plain)
+            }
+        }
+        .padding()
+    }
+}
+
+// Snippet view for: search_photos  (shape: list-object)
+@available(macOS 26, iOS 26, *)
+public struct MCPSearchPhotosSnippetView: View {
+    public let data: MCPSearchPhotosOutput
+    public init(data: MCPSearchPhotosOutput) { self.data = data }
+    public var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            ForEach(Array(data.photos.enumerated()), id: \.offset) { _, row in
+                Text((row.filename ?? ""))
+                    .font(.body)
+                    .lineLimit(1)
             }
         }
         .padding()

--- a/tests/output-schema-structured.test.js
+++ b/tests/output-schema-structured.test.js
@@ -36,6 +36,7 @@ const { registerHealthTools } = await import('../dist/health/tools.js');
 const { registerMessagesTools } = await import('../dist/messages/tools.js');
 const { registerShortcutsTools } = await import('../dist/shortcuts/tools.js');
 const { registerWeatherTools } = await import('../dist/weather/tools.js');
+const { registerPhotosTools } = await import('../dist/photos/tools.js');
 const { fetchCurrentWeather } = await import('../dist/weather/api.js');
 
 // ── Per-tool args and mock responses ────────────────────────────────
@@ -339,6 +340,36 @@ const TOOL_FIXTURES = {
     args: { limit: 100, offset: 0, previewLength: 300 },
     mock: { total: 0, offset: 0, returned: 0, notes: [] },
   },
+  // ── Wave 5 additions ──
+  // photos
+  list_photos: {
+    args: { album: 'Recents', limit: 50, offset: 0 },
+    mock: { total: 0, offset: 0, returned: 0, photos: [] },
+  },
+  search_photos: {
+    args: { query: 'beach', limit: 30 },
+    mock: { total: 0, photos: [] },
+  },
+  get_photo_info: {
+    args: { id: 'abc-123' },
+    mock: {
+      id: 'abc-123',
+      filename: 'IMG.JPG',
+      name: null,
+      description: null,
+      date: '2026-04-30T10:00:00Z',
+      width: 4032,
+      height: 3024,
+      altitude: null,
+      location: null,
+      favorite: false,
+      keywords: null,
+    },
+  },
+  list_favorites: {
+    args: { limit: 50 },
+    mock: { total: 0, returned: 0, photos: [] },
+  },
 };
 
 // ── Test suite ──────────────────────────────────────────────────────
@@ -362,6 +393,7 @@ describe('outputSchema → structuredContent contract', () => {
     registerMessagesTools(server, config);
     registerShortcutsTools(server, config);
     registerWeatherTools(server, config);
+    registerPhotosTools(server, config);
   });
 
   beforeEach(() => {

--- a/tests/output-schema-wave5.test.js
+++ b/tests/output-schema-wave5.test.js
@@ -1,0 +1,195 @@
+/**
+ * outputSchema Wave 5 — drift guard for photos read tools.
+ *
+ * Wave 4 covered mail / finder / safari / notes (7 tools). Wave 5
+ * extends to photos: `list_photos`, `search_photos`, `get_photo_info`,
+ * `list_favorites`. `list_albums` is intentionally deferred — it
+ * returns a bare `AlbumItem[]` and outputSchema requires top-level
+ * `type: object`; wrapping would be a breaking change for clients
+ * already JSON.parse-ing the text content as an array.
+ *
+ * Each case seeds `runAutomation` (the Photos module's transport
+ * dispatch) and asserts `structuredContent` parses through the tool's
+ * own `outputSchema` under strict Zod.
+ */
+import { describe, test, expect, beforeEach } from '@jest/globals';
+import { z } from 'zod';
+import { setupPlatformMocks } from './helpers/mock-runtime.js';
+import { createMockServer } from './helpers/mock-server.js';
+import { createMockConfig } from './helpers/mock-config.js';
+
+const { mockRunAutomation } = setupPlatformMocks();
+const { registerPhotosTools } = await import('../dist/photos/tools.js');
+
+function schemaFor(server, toolName) {
+  const tool = server._tools.get(toolName);
+  expect(tool).toBeDefined();
+  expect(tool.opts.outputSchema).toBeDefined();
+  return z.object(tool.opts.outputSchema).strict();
+}
+
+function assertConforms(server, toolName, structured) {
+  const schema = schemaFor(server, toolName);
+  const parsed = schema.safeParse(structured);
+  if (!parsed.success) {
+    throw new Error(`${toolName} drift: ${JSON.stringify(parsed.error.issues, null, 2)}`);
+  }
+}
+
+function resetAll() {
+  mockRunAutomation.mockReset();
+}
+
+// ── photos.list_photos ────────────────────────────────────────────────
+
+describe('Wave 5 — photos.list_photos', () => {
+  beforeEach(resetAll);
+
+  test('structuredContent matches outputSchema with full row', async () => {
+    const server = createMockServer();
+    registerPhotosTools(server, createMockConfig());
+    mockRunAutomation.mockResolvedValue({
+      total: 2,
+      offset: 0,
+      returned: 2,
+      photos: [
+        {
+          id: 'abc-1',
+          filename: 'IMG_0001.HEIC',
+          name: null,
+          date: '2026-04-30T09:00:00Z',
+          width: 4032,
+          height: 3024,
+          favorite: false,
+        },
+        {
+          id: 'abc-2',
+          filename: null,
+          name: null,
+          date: null,
+          width: 1920,
+          height: 1080,
+          favorite: true,
+        },
+      ],
+    });
+    const result = await server.callTool('list_photos', { album: 'Recents', limit: 50, offset: 0 });
+    assertConforms(server, 'list_photos', result.structuredContent);
+  });
+
+  test('structuredContent handles empty album', async () => {
+    const server = createMockServer();
+    registerPhotosTools(server, createMockConfig());
+    mockRunAutomation.mockResolvedValue({ total: 0, offset: 0, returned: 0, photos: [] });
+    const result = await server.callTool('list_photos', { album: 'Empty', limit: 50, offset: 0 });
+    assertConforms(server, 'list_photos', result.structuredContent);
+  });
+});
+
+// ── photos.search_photos ──────────────────────────────────────────────
+
+describe('Wave 5 — photos.search_photos', () => {
+  beforeEach(resetAll);
+
+  test('structuredContent matches outputSchema', async () => {
+    const server = createMockServer();
+    registerPhotosTools(server, createMockConfig());
+    mockRunAutomation.mockResolvedValue({
+      total: 1,
+      photos: [
+        {
+          id: 'xyz-1',
+          filename: 'beach.jpg',
+          name: 'Sunset',
+          date: '2026-04-30T18:00:00Z',
+          favorite: true,
+          description: 'Warm light over the water',
+        },
+      ],
+    });
+    const result = await server.callTool('search_photos', { query: 'beach', limit: 30 });
+    assertConforms(server, 'search_photos', result.structuredContent);
+  });
+});
+
+// ── photos.get_photo_info ─────────────────────────────────────────────
+
+describe('Wave 5 — photos.get_photo_info', () => {
+  beforeEach(resetAll);
+
+  test('structuredContent matches outputSchema (with GPS + keywords)', async () => {
+    const server = createMockServer();
+    registerPhotosTools(server, createMockConfig());
+    mockRunAutomation.mockResolvedValue({
+      id: 'abc-1',
+      filename: 'IMG.HEIC',
+      name: 'Sunset',
+      description: 'Beach',
+      date: '2026-04-30T18:00:00Z',
+      width: 4032,
+      height: 3024,
+      altitude: 12.5,
+      location: [37.7749, -122.4194],
+      favorite: true,
+      keywords: ['sunset', 'beach'],
+    });
+    const result = await server.callTool('get_photo_info', { id: 'abc-1' });
+    assertConforms(server, 'get_photo_info', result.structuredContent);
+  });
+
+  test('structuredContent tolerates all-null EXIF metadata', async () => {
+    const server = createMockServer();
+    registerPhotosTools(server, createMockConfig());
+    mockRunAutomation.mockResolvedValue({
+      id: 'abc-2',
+      filename: null,
+      name: null,
+      description: null,
+      date: null,
+      width: 0,
+      height: 0,
+      altitude: null,
+      location: null,
+      favorite: false,
+      keywords: null,
+    });
+    const result = await server.callTool('get_photo_info', { id: 'abc-2' });
+    assertConforms(server, 'get_photo_info', result.structuredContent);
+  });
+});
+
+// ── photos.list_favorites ─────────────────────────────────────────────
+
+describe('Wave 5 — photos.list_favorites', () => {
+  beforeEach(resetAll);
+
+  test('structuredContent matches outputSchema', async () => {
+    const server = createMockServer();
+    registerPhotosTools(server, createMockConfig());
+    mockRunAutomation.mockResolvedValue({
+      total: 1,
+      returned: 1,
+      photos: [
+        {
+          id: 'fav-1',
+          filename: 'IMG.HEIC',
+          name: 'Family',
+          date: '2026-04-29T15:00:00Z',
+          width: 4032,
+          height: 3024,
+          favorite: true,
+        },
+      ],
+    });
+    const result = await server.callTool('list_favorites', { limit: 50 });
+    assertConforms(server, 'list_favorites', result.structuredContent);
+  });
+
+  test('structuredContent handles empty list', async () => {
+    const server = createMockServer();
+    registerPhotosTools(server, createMockConfig());
+    mockRunAutomation.mockResolvedValue({ total: 0, returned: 0, photos: [] });
+    const result = await server.callTool('list_favorites', { limit: 50 });
+    assertConforms(server, 'list_favorites', result.structuredContent);
+  });
+});


### PR DESCRIPTION
## Summary

Extends Wave 4's pattern to the photos module — 4 new typed `outputSchema` declarations.

| Tool | Helper | Shape |
|------|--------|-------|
| `list_photos` | `okUntrustedLinkedStructured` | `total`/`offset`/`returned` + `photos[]` |
| `search_photos` | `okUntrustedLinkedStructured` | `total` + `photos[]` (with `description`) |
| `get_photo_info` | `okUntrustedStructured` | full `PhotoDetail` (GPS, keywords, dimensions) |
| `list_favorites` | `okUntrustedLinkedStructured` | `total`/`returned` + `photos[]` |

All four use `Untrusted*` because filenames / names / descriptions can carry prompt-injection vectors.

## Deferred (same breaking-change risk as `compare_notes`)

- `list_albums` — bare `AlbumItem[]` return
- `get_daily_forecast`, `get_hourly_forecast` — bare daily/hourly arrays

`outputSchema` requires a top-level `type: object`; wrapping these would break clients that already `JSON.parse` the text content as an array.

## Tests

- `tests/output-schema-wave5.test.js` (+7 cases): full row, null EXIF metadata, empty album, empty favorites
- `tests/output-schema-structured.test.js` exhaustive coverage check picks up 4 fixtures (registers photos module)

## Verification

- `npm run typecheck` clean (lesson from #156 applied — typecheck before push)
- 100 suites / 1588 tests pass
- `gen:manifest:check` + `gen:intents:check` regenerated for new schemas
- `stats:check`, `llms:check`, `npm audit --omit=dev` all green