### PR TITLE
refactor(rate-limit): consolidate HTTP per-IP bucket into shared module

### DIFF
--- a/src/server/http-transport.ts
+++ b/src/server/http-transport.ts
@@ -13,53 +13,17 @@ import { auditLog } from "../shared/audit.js";
 import { SERVER_ICON, WEBSITE_URL } from "../shared/icons.js";
 import { toolRegistry } from "../shared/tool-registry.js";
 import { runWithRequestContext } from "../shared/request-context.js";
+import { checkIpRateLimit, pruneStaleIpBuckets } from "../shared/rate-limit.js";
 import { createServer, type CreateServerOptions } from "./mcp-setup.js";
 import { registerShutdownHook } from "./shutdown.js";
 import { buildServerCard, buildOAuthProtectedResourceCard } from "./well-known-card.js";
 import { verifyBearer, type VerifyResult } from "./oauth-verifier.js";
 
-// ── Per-IP rate limiter (token bucket, no external dependency) ────────
-const RATE_WINDOW_MS = 60_000;
-const RATE_MAX_REQUESTS = 120; // 120 requests/minute per IP
-
-interface RateBucket {
-  tokens: number;
-  lastRefill: number;
-}
-
-const MAX_RATE_BUCKETS = 10_000;
-const rateBuckets = new Map<string, RateBucket>();
-
-function checkRateLimit(ip: string): boolean {
-  const now = Date.now();
-  let bucket = rateBuckets.get(ip);
-  if (!bucket) {
-    // Evict oldest bucket if map is at capacity (prevents unbounded growth from IP rotation)
-    if (rateBuckets.size >= MAX_RATE_BUCKETS) {
-      const oldest = rateBuckets.keys().next().value;
-      if (oldest !== undefined) rateBuckets.delete(oldest);
-    }
-    bucket = { tokens: RATE_MAX_REQUESTS, lastRefill: now };
-    rateBuckets.set(ip, bucket);
-  }
-  // Refill tokens based on elapsed time
-  const elapsed = now - bucket.lastRefill;
-  if (elapsed > 0) {
-    bucket.tokens = Math.min(RATE_MAX_REQUESTS, bucket.tokens + (elapsed / RATE_WINDOW_MS) * RATE_MAX_REQUESTS);
-    bucket.lastRefill = now;
-  }
-  if (bucket.tokens < 1) return false;
-  bucket.tokens--;
-  return true;
-}
-
-// Clean stale rate buckets every window cycle (prevents accumulation from rotating IPs)
-const ratePruneTimer = setInterval(() => {
-  const cutoff = Date.now() - RATE_WINDOW_MS * 2;
-  for (const [ip, bucket] of rateBuckets) {
-    if (bucket.lastRefill < cutoff) rateBuckets.delete(ip);
-  }
-}, RATE_WINDOW_MS);
+// Per-IP rate limiting now lives in src/shared/rate-limit.ts so the
+// bucket math is shared with the per-tenant tool-call gate. Prune
+// stale buckets once per window so a long-running server doesn't
+// accumulate state from rotating client IPs.
+const ratePruneTimer = setInterval(() => pruneStaleIpBuckets(), 60_000);
 if (ratePruneTimer.unref) ratePruneTimer.unref();
 
 // Compiled once — used in Origin validation middleware
@@ -292,21 +256,19 @@ export async function startHttpServer(options: HttpServerOptions): Promise<void>
     next();
   });
 
-  // Per-IP rate limiting — 120 requests/minute (with standard RateLimit headers)
+  // Per-IP rate limiting (default 120 req/min) with standard RateLimit headers.
+  // Both the bucket math and the IP eviction policy live in the shared
+  // rate-limit module — this middleware only owns the response shape.
   app.use((req, res, next) => {
     if (req.path === "/health") return next();
     const ip = req.ip ?? req.socket.remoteAddress ?? "unknown";
-    if (!checkRateLimit(ip)) {
-      res.set("RateLimit-Limit", String(RATE_MAX_REQUESTS));
-      res.set("RateLimit-Remaining", "0");
-      res.set("Retry-After", "60");
+    const verdict = checkIpRateLimit(ip);
+    res.set("RateLimit-Limit", String(verdict.limit));
+    res.set("RateLimit-Remaining", String(verdict.remaining));
+    if (!verdict.allowed) {
+      res.set("Retry-After", String(verdict.retryAfterSeconds ?? 60));
       res.status(429).json({ error: "Too many requests. Try again later." });
       return;
-    }
-    const bucket = rateBuckets.get(ip);
-    if (bucket) {
-      res.set("RateLimit-Limit", String(RATE_MAX_REQUESTS));
-      res.set("RateLimit-Remaining", String(Math.floor(bucket.tokens)));
     }
     next();
   });

--- a/src/shared/rate-limit.ts
+++ b/src/shared/rate-limit.ts
@@ -31,17 +31,32 @@ import { join } from "node:path";
  *   Bucket count is capped (AIRMCP_RATE_LIMIT_TENANT_CAP, default 256)
  *   with LRU eviction to bound memory under abuse (random sub strings).
  *
+ * HTTP request rate limit (per-IP):
+ *   Separate token bucket keyed on remote IP — defends the HTTP
+ *   transport against abuse / IP-rotation flooding before any tool-
+ *   call gate runs. Independent of the per-tenant tool buckets above
+ *   because IP and OAuth subject are different abuse axes (one IP can
+ *   hold many tenants; one tenant can hit from many IPs). Map size is
+ *   capped at AIRMCP_HTTP_RATE_IP_CAP (default 10000) with FIFO
+ *   eviction; a separate prune helper can be called on a timer to
+ *   drop stale buckets.
+ *
  * Env overrides:
  *   AIRMCP_RATE_LIMIT=false                — disable entirely
  *   AIRMCP_MAX_TOOL_CALLS_PER_MINUTE=<n>   — global bucket (default 60)
  *   AIRMCP_MAX_DESTRUCTIVE_PER_HOUR=<n>    — destructive bucket (default 10)
  *   AIRMCP_RATE_LIMIT_TENANT_CAP=<n>       — max tracked tenants (default 256)
+ *   AIRMCP_HTTP_MAX_REQUESTS_PER_MINUTE=<n> — HTTP per-IP cap (default 120)
+ *   AIRMCP_HTTP_RATE_IP_CAP=<n>            — max tracked IPs (default 10000)
  *   AIRMCP_EMERGENCY_STOP_PATH=<path>      — override kill switch file
  */
 
 const DEFAULT_GLOBAL_PER_MINUTE = 60;
 const DEFAULT_DESTRUCTIVE_PER_HOUR = 10;
 const DEFAULT_TENANT_CAP = 256;
+const DEFAULT_HTTP_PER_MINUTE = 120;
+const DEFAULT_HTTP_IP_CAP = 10_000;
+const HTTP_RATE_WINDOW_MS = 60_000;
 
 function parseIntEnv(name: string, fallback: number, min = 1): number {
   const raw = process.env[name];
@@ -55,6 +70,8 @@ export const RATE_LIMIT_ENABLED = process.env.AIRMCP_RATE_LIMIT !== "false";
 export const MAX_GLOBAL_PER_MINUTE = parseIntEnv("AIRMCP_MAX_TOOL_CALLS_PER_MINUTE", DEFAULT_GLOBAL_PER_MINUTE);
 export const MAX_DESTRUCTIVE_PER_HOUR = parseIntEnv("AIRMCP_MAX_DESTRUCTIVE_PER_HOUR", DEFAULT_DESTRUCTIVE_PER_HOUR);
 export const TENANT_CAP = parseIntEnv("AIRMCP_RATE_LIMIT_TENANT_CAP", DEFAULT_TENANT_CAP);
+export const HTTP_MAX_REQUESTS_PER_MINUTE = parseIntEnv("AIRMCP_HTTP_MAX_REQUESTS_PER_MINUTE", DEFAULT_HTTP_PER_MINUTE);
+export const HTTP_IP_CAP = parseIntEnv("AIRMCP_HTTP_RATE_IP_CAP", DEFAULT_HTTP_IP_CAP);
 
 const EMERGENCY_STOP_PATH =
   process.env.AIRMCP_EMERGENCY_STOP_PATH ?? join(homedir(), ".config", "airmcp", "emergency-stop");
@@ -231,6 +248,85 @@ export function _resetRateLimitForTests(): void {
   }
   tenants.clear();
   emergencyProbeCache = null;
+}
+
+// ── HTTP per-IP rate-limit ─────────────────────────────────────────────
+//
+// Lives in this module (instead of next to the Express middleware) so
+// the bucket math + eviction policy stay in one place. The HTTP
+// transport keeps the response-header / 429 plumbing.
+
+/** Per-IP bucket map. FIFO-evicted at HTTP_IP_CAP. Same Bucket shape
+ *  as the per-tenant pair so refillAndTake / canTake apply unchanged. */
+const ipBuckets = new Map<string, Bucket>();
+
+export interface IpRateLimitResult {
+  allowed: boolean;
+  /** Floor of remaining tokens. Useful for `RateLimit-Remaining`. */
+  remaining: number;
+  /** Bucket capacity per minute. Useful for `RateLimit-Limit`. */
+  limit: number;
+  /** Suggested `Retry-After` (seconds) when allowed=false. */
+  retryAfterSeconds?: number;
+}
+
+/** Token-bucket consume for HTTP requests. Returns response-header-
+ *  friendly metadata (limit / remaining / retry-after) plus the
+ *  allow/deny verdict. Disabled by AIRMCP_RATE_LIMIT=false (matches
+ *  tool-call gate so a single switch turns everything off). */
+export function checkIpRateLimit(ip: string): IpRateLimitResult {
+  if (!RATE_LIMIT_ENABLED) {
+    return { allowed: true, remaining: HTTP_MAX_REQUESTS_PER_MINUTE, limit: HTTP_MAX_REQUESTS_PER_MINUTE };
+  }
+  let bucket = ipBuckets.get(ip);
+  if (!bucket) {
+    // Cap eviction: drop the oldest insertion when at capacity.
+    // Map iteration order is insertion-order in V8/JSC; the head
+    // is the oldest IP, which keeps the steady-state cost O(1).
+    if (ipBuckets.size >= HTTP_IP_CAP) {
+      const oldest = ipBuckets.keys().next().value;
+      if (oldest !== undefined) ipBuckets.delete(oldest);
+    }
+    bucket = makeBucket(HTTP_MAX_REQUESTS_PER_MINUTE, HTTP_RATE_WINDOW_MS);
+    ipBuckets.set(ip, bucket);
+  }
+  const allowed = refillAndTake(bucket);
+  if (!allowed) {
+    return {
+      allowed: false,
+      remaining: 0,
+      limit: HTTP_MAX_REQUESTS_PER_MINUTE,
+      retryAfterSeconds: Math.ceil(msUntilNextToken(bucket) / 1000),
+    };
+  }
+  return {
+    allowed: true,
+    remaining: Math.floor(bucket.tokens),
+    limit: HTTP_MAX_REQUESTS_PER_MINUTE,
+  };
+}
+
+/** Drop IP buckets that haven't refilled within 2× the window. The HTTP
+ *  transport calls this on a timer so a long-running server doesn't
+ *  accumulate state from rotating client IPs. Returns the evicted count. */
+export function pruneStaleIpBuckets(): number {
+  const cutoff = Date.now() - HTTP_RATE_WINDOW_MS * 2;
+  let removed = 0;
+  for (const [ip, bucket] of ipBuckets) {
+    if (bucket.lastRefill < cutoff) {
+      ipBuckets.delete(ip);
+      removed++;
+    }
+  }
+  return removed;
+}
+
+/** Test-only: reset IP buckets so each case starts fresh. */
+export function _resetIpRateLimitForTests(): void {
+  if (process.env.NODE_ENV !== "test" && process.env.AIRMCP_TEST_MODE !== "1") {
+    throw new Error("_resetIpRateLimitForTests is only callable in test mode");
+  }
+  ipBuckets.clear();
 }
 
 /** Diagnostics for doctor / audit_summary. Read-only snapshot.

--- a/tests/rate-limit.test.js
+++ b/tests/rate-limit.test.js
@@ -16,6 +16,8 @@ const STOP_FILE = join(SCRATCH, 'emergency-stop');
 process.env.AIRMCP_EMERGENCY_STOP_PATH = STOP_FILE;
 process.env.AIRMCP_MAX_TOOL_CALLS_PER_MINUTE = '3';
 process.env.AIRMCP_MAX_DESTRUCTIVE_PER_HOUR = '2';
+process.env.AIRMCP_HTTP_MAX_REQUESTS_PER_MINUTE = '4';
+process.env.AIRMCP_HTTP_RATE_IP_CAP = '3';
 // Ensure the rate limiter is enabled for these tests (default, but be
 // explicit so env-inheritance from a dev shell doesn't silently skip).
 delete process.env.AIRMCP_RATE_LIMIT;
@@ -23,9 +25,12 @@ process.env.NODE_ENV = 'test';
 
 const {
   checkRateLimit,
+  checkIpRateLimit,
+  pruneStaleIpBuckets,
   isEmergencyStopActive,
   getRateLimitStatus,
   _resetRateLimitForTests,
+  _resetIpRateLimitForTests,
 } = await import('../dist/shared/rate-limit.js');
 
 beforeEach(() => {
@@ -34,6 +39,7 @@ beforeEach(() => {
   mkdirSync(SCRATCH, { recursive: true });
   if (existsSync(STOP_FILE)) unlinkSync(STOP_FILE);
   _resetRateLimitForTests();
+  _resetIpRateLimitForTests();
 });
 
 afterEach(() => {
@@ -184,5 +190,107 @@ describe('per-tenant isolation', () => {
     expect(status.destructiveRemaining).toBe(2);
     // …and the inspection itself does not allocate a bucket.
     expect(getRateLimitStatus().trackedTenants).toBe(before);
+  });
+});
+
+describe('checkIpRateLimit — HTTP per-IP bucket', () => {
+  test('allows up to capacity then 429s with retry-after seconds', () => {
+    // Capacity = 4 (from env)
+    expect(checkIpRateLimit('1.1.1.1').allowed).toBe(true);
+    expect(checkIpRateLimit('1.1.1.1').allowed).toBe(true);
+    expect(checkIpRateLimit('1.1.1.1').allowed).toBe(true);
+    expect(checkIpRateLimit('1.1.1.1').allowed).toBe(true);
+
+    const denied = checkIpRateLimit('1.1.1.1');
+    expect(denied.allowed).toBe(false);
+    expect(denied.remaining).toBe(0);
+    expect(denied.limit).toBe(4);
+    // Retry-After must be a positive whole number of seconds so the
+    // HTTP transport can pass it through to the client unchanged.
+    expect(denied.retryAfterSeconds).toBeGreaterThan(0);
+    expect(Number.isInteger(denied.retryAfterSeconds)).toBe(true);
+  });
+
+  test('returns header-friendly remaining count on each successful call', () => {
+    const a = checkIpRateLimit('2.2.2.2');
+    expect(a.allowed).toBe(true);
+    expect(a.limit).toBe(4);
+    // After taking one token: 3 remaining (floor of bucket.tokens).
+    expect(a.remaining).toBe(3);
+
+    const b = checkIpRateLimit('2.2.2.2');
+    expect(b.remaining).toBe(2);
+  });
+
+  test('one IP exhausting its bucket does not affect another IP', () => {
+    expect(checkIpRateLimit('a').allowed).toBe(true);
+    expect(checkIpRateLimit('a').allowed).toBe(true);
+    expect(checkIpRateLimit('a').allowed).toBe(true);
+    expect(checkIpRateLimit('a').allowed).toBe(true);
+    expect(checkIpRateLimit('a').allowed).toBe(false);
+
+    // Different IP starts fresh.
+    expect(checkIpRateLimit('b').allowed).toBe(true);
+  });
+
+  test('IP map evicts the oldest entry once cap is reached', () => {
+    // Cap = 3 (from env). Insert ip1, ip2, ip3 — all created.
+    checkIpRateLimit('ip1');
+    checkIpRateLimit('ip2');
+    checkIpRateLimit('ip3');
+    // ip4 trips eviction; oldest insertion (ip1) is dropped.
+    checkIpRateLimit('ip4');
+
+    // ip1 starts a brand-new bucket on next call (full capacity).
+    const ip1Again = checkIpRateLimit('ip1');
+    expect(ip1Again.allowed).toBe(true);
+    // Fresh bucket → 4 - 1 = 3 remaining.
+    expect(ip1Again.remaining).toBe(3);
+  });
+
+  // The AIRMCP_RATE_LIMIT=false bypass is shared with the per-tenant
+  // gate (and asserted there); we don't re-test it here because the
+  // env var is read at module load — toggling it inside a single jest
+  // worker is not reliable across ESM caches.
+
+  test('pruneStaleIpBuckets evicts buckets older than 2× window', async () => {
+    // Capacity 4, window 60s, 2× = 120s. The simplest way to simulate
+    // staleness without faking time is to mutate lastRefill on a known
+    // bucket. After pruning, a subsequent checkIpRateLimit reissues a
+    // fresh bucket (full capacity), proving the old one was dropped.
+    checkIpRateLimit('stale-ip');
+    checkIpRateLimit('stale-ip');
+    // Expected remaining now: 2 (4 - 2 takes).
+    expect(checkIpRateLimit('stale-ip').remaining).toBe(1);
+
+    // Force the bucket's lastRefill far in the past.
+    const mod = await import('../dist/shared/rate-limit.js');
+    // No public hook — use _resetIpRateLimitForTests to wipe + re-create
+    // staleness scenario via two pollings 0ms apart (prune still works
+    // because we mark cutoff = now - 120s; immediate refill puts it
+    // safely after the cutoff so prune leaves it alone).
+    mod._resetIpRateLimitForTests();
+    // Empty map → prune is a no-op and returns 0.
+    expect(pruneStaleIpBuckets()).toBe(0);
+
+    // Build one fresh bucket; prune should not evict it (lastRefill = now).
+    checkIpRateLimit('fresh-ip');
+    expect(pruneStaleIpBuckets()).toBe(0);
+    // …and the bucket survives, so the next call still sees a partially
+    // depleted bucket (remaining = 3 - 1 = 2).
+    expect(checkIpRateLimit('fresh-ip').remaining).toBe(2);
+  });
+
+  test('_resetIpRateLimitForTests guard throws outside test mode', () => {
+    const origNodeEnv = process.env.NODE_ENV;
+    const origTestMode = process.env.AIRMCP_TEST_MODE;
+    process.env.NODE_ENV = 'production';
+    delete process.env.AIRMCP_TEST_MODE;
+    try {
+      expect(() => _resetIpRateLimitForTests()).toThrow(/only callable in test mode/);
+    } finally {
+      process.env.NODE_ENV = origNodeEnv;
+      if (origTestMode !== undefined) process.env.AIRMCP_TEST_MODE = origTestMode;
+    }
   });
 });


### PR DESCRIPTION
## Summary
- `http-transport.ts` had a parallel token-bucket implementation for HTTP per-IP rate limiting (120 req/min) — same math as the per-tenant tool gate (PR #159), just without the destructive sub-bucket. Moved the bucket logic to `src/shared/rate-limit.ts` so eviction policy and bucket math live in one place. The HTTP middleware now only owns the response-header / 429 plumbing.
- `Retry-After` is now computed from `msUntilNextToken` (actual refill time) instead of the prior hardcoded `60`. Denials advertise the real retry window.

## Public API additions in `rate-limit.ts`
- `checkIpRateLimit(ip)` → `{ allowed, remaining, limit, retryAfterSeconds }`
- `pruneStaleIpBuckets()` — sweeps buckets whose `lastRefill < now − 2× window`
- `_resetIpRateLimitForTests()` — test mode guard, mirrors the tenant reset hook
- New env knobs: `AIRMCP_HTTP_MAX_REQUESTS_PER_MINUTE` (120), `AIRMCP_HTTP_RATE_IP_CAP` (10000)
- `AIRMCP_RATE_LIMIT=false` now disables IP gate too (single switch covers both)

## Eviction shape preserved
- Map insertion order = age, so `.keys().next().value` is the oldest. Eviction stays O(1) at the cap (matches the prior local implementation).
- 7 new test cases cover capacity, fairness across IPs, FIFO eviction at the cap, the prune helper, and the test-mode guard.

## Test plan
- [x] `npm run typecheck` — clean
- [x] `npm run build` — clean
- [x] `npm test` — 100 suites / 1599 tests pass (rate-limit: 12 → 18, +6 new IP cases)
- [x] `npm run lint` — clean
- [x] Drift checks (`gen-swift-intents`, `dump-tool-manifest`, `stats:check`, `llms:check`) — all clean