### PR TITLE
refactor(rate-limit): unify test-mode guard + cover real prune eviction

### DIFF
--- a/src/shared/pollers.ts
+++ b/src/shared/pollers.ts
@@ -1,4 +1,5 @@
 import type { AirMCPEventType } from "./event-bus.js";
+import { assertTestMode } from "./errors.js";
 
 /**
  * Node-side poller registry. Feature modules (mail, music, …) import
@@ -123,12 +124,9 @@ export function createPollerLogger(name: string): (e: unknown) => void {
   };
 }
 
-/** Test-only: clear all registered pollers. Refuses to run outside test mode
- *  so production callers cannot wipe the registry. */
+/** Test-only: clear all registered pollers. */
 export function _resetPollerRegistryForTests(): void {
-  if (process.env.NODE_ENV !== "test" && process.env.AIRMCP_TEST_MODE !== "1") {
-    throw new Error("_resetPollerRegistryForTests is only callable in test mode");
-  }
+  assertTestMode("_resetPollerRegistryForTests");
   for (const p of pollers.values()) {
     if (p.timer) clearInterval(p.timer);
   }

--- a/src/shared/rate-limit.ts
+++ b/src/shared/rate-limit.ts
@@ -1,6 +1,7 @@
 import { existsSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
+import { assertTestMode } from "./errors.js";
 
 /**
  * Agent-safety rate limit + emergency kill switch.
@@ -241,11 +242,9 @@ export function isEmergencyStopActive(): boolean {
 }
 
 /** Test-only: wipe bucket state and the emergency probe cache so each
- *  case starts fresh. Guarded via NODE_ENV to prevent production misuse. */
+ *  case starts fresh. */
 export function _resetRateLimitForTests(): void {
-  if (process.env.NODE_ENV !== "test" && process.env.AIRMCP_TEST_MODE !== "1") {
-    throw new Error("_resetRateLimitForTests is only callable in test mode");
-  }
+  assertTestMode("_resetRateLimitForTests");
   tenants.clear();
   emergencyProbeCache = null;
 }
@@ -323,10 +322,19 @@ export function pruneStaleIpBuckets(): number {
 
 /** Test-only: reset IP buckets so each case starts fresh. */
 export function _resetIpRateLimitForTests(): void {
-  if (process.env.NODE_ENV !== "test" && process.env.AIRMCP_TEST_MODE !== "1") {
-    throw new Error("_resetIpRateLimitForTests is only callable in test mode");
-  }
+  assertTestMode("_resetIpRateLimitForTests");
   ipBuckets.clear();
+}
+
+/** Test-only: rewind an IP bucket's `lastRefill` so the next prune call
+ *  treats it as stale. Lets pruneStaleIpBuckets be exercised end-to-end
+ *  without faking the system clock. Throws if the IP isn't already
+ *  tracked — caller must check it via checkIpRateLimit first. */
+export function _forceIpBucketStaleForTests(ip: string, lastRefillMs: number): void {
+  assertTestMode("_forceIpBucketStaleForTests");
+  const bucket = ipBuckets.get(ip);
+  if (!bucket) throw new Error(`_forceIpBucketStaleForTests: no bucket for ${ip}`);
+  bucket.lastRefill = lastRefillMs;
 }
 
 /** Diagnostics for doctor / audit_summary. Read-only snapshot.

--- a/src/shared/usage-tracker.ts
+++ b/src/shared/usage-tracker.ts
@@ -2,7 +2,7 @@ import { readFile, writeFile, mkdir } from "node:fs/promises";
 import { writeFileSync, mkdirSync } from "node:fs";
 import { dirname } from "node:path";
 import { PATHS } from "./constants.js";
-import { formatError } from "./errors.js";
+import { assertTestMode, formatError } from "./errors.js";
 
 interface UsageProfile {
   version: number;
@@ -141,14 +141,11 @@ class UsageTracker {
   }
 
   /** Test-only: wipe in-memory state so each case starts from a clean
-   *  singleton. Mirrors the rate-limit reset hook; guarded to prevent
-   *  production misuse. Disk file is not touched — point
+   *  singleton. Disk file is not touched — point
    *  AIRMCP_USAGE_PROFILE_PATH at a tmp file before importing this
    *  module to keep tests off the user's real profile. */
   _resetForTests(): void {
-    if (process.env.NODE_ENV !== "test" && process.env.AIRMCP_TEST_MODE !== "1") {
-      throw new Error("_resetForTests is only callable in test mode");
-    }
+    assertTestMode("UsageTracker._resetForTests");
     this.lastTool = null;
     this.profile = null;
     this.dirty = false;

--- a/tests/rate-limit.test.js
+++ b/tests/rate-limit.test.js
@@ -31,6 +31,7 @@ const {
   getRateLimitStatus,
   _resetRateLimitForTests,
   _resetIpRateLimitForTests,
+  _forceIpBucketStaleForTests,
 } = await import('../dist/shared/rate-limit.js');
 
 beforeEach(() => {
@@ -253,32 +254,49 @@ describe('checkIpRateLimit — HTTP per-IP bucket', () => {
   // env var is read at module load — toggling it inside a single jest
   // worker is not reliable across ESM caches.
 
-  test('pruneStaleIpBuckets evicts buckets older than 2× window', async () => {
-    // Capacity 4, window 60s, 2× = 120s. The simplest way to simulate
-    // staleness without faking time is to mutate lastRefill on a known
-    // bucket. After pruning, a subsequent checkIpRateLimit reissues a
-    // fresh bucket (full capacity), proving the old one was dropped.
-    checkIpRateLimit('stale-ip');
-    checkIpRateLimit('stale-ip');
-    // Expected remaining now: 2 (4 - 2 takes).
-    expect(checkIpRateLimit('stale-ip').remaining).toBe(1);
-
-    // Force the bucket's lastRefill far in the past.
-    const mod = await import('../dist/shared/rate-limit.js');
-    // No public hook — use _resetIpRateLimitForTests to wipe + re-create
-    // staleness scenario via two pollings 0ms apart (prune still works
-    // because we mark cutoff = now - 120s; immediate refill puts it
-    // safely after the cutoff so prune leaves it alone).
-    mod._resetIpRateLimitForTests();
-    // Empty map → prune is a no-op and returns 0.
+  test('pruneStaleIpBuckets is a no-op on an empty map and on fresh buckets', () => {
+    // Empty map → return 0 without iterating.
     expect(pruneStaleIpBuckets()).toBe(0);
 
-    // Build one fresh bucket; prune should not evict it (lastRefill = now).
+    // Fresh bucket (lastRefill = now) survives a prune call.
     checkIpRateLimit('fresh-ip');
     expect(pruneStaleIpBuckets()).toBe(0);
-    // …and the bucket survives, so the next call still sees a partially
-    // depleted bucket (remaining = 3 - 1 = 2).
+    // Bucket still tracked: next call shows partial depletion (3 - 1 = 2).
     expect(checkIpRateLimit('fresh-ip').remaining).toBe(2);
+  });
+
+  test('pruneStaleIpBuckets evicts buckets older than 2× window', () => {
+    // Window = 60s, cutoff = now - 120s. Anything with lastRefill
+    // before that boundary is stale.
+    const now = Date.now();
+
+    // Build three buckets, then mark two of them stale via the
+    // test-only refill rewinder. The third stays fresh.
+    checkIpRateLimit('stale-1');
+    checkIpRateLimit('stale-2');
+    checkIpRateLimit('fresh');
+    _forceIpBucketStaleForTests('stale-1', now - 5 * 60_000); // 5 min old
+    _forceIpBucketStaleForTests('stale-2', now - 3 * 60_000); // 3 min old
+
+    expect(pruneStaleIpBuckets()).toBe(2);
+
+    // 'fresh' bucket survived: remaining is still 3 (one prior take).
+    // 'stale-*' should have been dropped: a new call reissues a full bucket.
+    expect(checkIpRateLimit('fresh').remaining).toBe(2);
+    expect(checkIpRateLimit('stale-1').remaining).toBe(3);
+    expect(checkIpRateLimit('stale-2').remaining).toBe(3);
+  });
+
+  test('pruneStaleIpBuckets keeps buckets just inside the 2× boundary', () => {
+    // Boundary check: cutoff is `now - 2 * window` and the comparison
+    // is strict (`<`). A bucket 1s newer than the cutoff must survive.
+    const now = Date.now();
+    checkIpRateLimit('boundary');
+    _forceIpBucketStaleForTests('boundary', now - 2 * 60_000 + 1_000);
+
+    expect(pruneStaleIpBuckets()).toBe(0);
+    // The original bucket is still tracked; we don't assert remaining
+    // here because refill against the rewound lastRefill changes it.
   });
 
   test('_resetIpRateLimitForTests guard throws outside test mode', () => {
@@ -287,7 +305,7 @@ describe('checkIpRateLimit — HTTP per-IP bucket', () => {
     process.env.NODE_ENV = 'production';
     delete process.env.AIRMCP_TEST_MODE;
     try {
-      expect(() => _resetIpRateLimitForTests()).toThrow(/only callable in test mode/);
+      expect(() => _resetIpRateLimitForTests()).toThrow(/only callable when NODE_ENV=test/);
     } finally {
       process.env.NODE_ENV = origNodeEnv;
       if (origTestMode !== undefined) process.env.AIRMCP_TEST_MODE = origTestMode;

--- a/tests/usage-tracker.test.js
+++ b/tests/usage-tracker.test.js
@@ -234,7 +234,7 @@ describe('UsageTracker — _resetForTests guard', () => {
     process.env.NODE_ENV = 'production';
     delete process.env.AIRMCP_TEST_MODE;
     try {
-      expect(() => usageTracker._resetForTests()).toThrow(/only callable in test mode/);
+      expect(() => usageTracker._resetForTests()).toThrow(/only callable when NODE_ENV=test/);
     } finally {
       process.env.NODE_ENV = origNodeEnv;
       if (origTestMode !== undefined) process.env.AIRMCP_TEST_MODE = origTestMode;


### PR DESCRIPTION
Findings from /simplify pass over PRs #160 / #162:

## 1. Test-mode guard duplication
The same `NODE_ENV` / `AIRMCP_TEST_MODE` check was inlined in four reset helpers (`rate-limit.ts` ×2, `usage-tracker.ts`, `pollers.ts`) even though `shared/errors.ts` already exports `assertTestMode` for exactly this purpose. Replaced the four copies with `assertTestMode` calls. Two existing test regexes that asserted on the old throw message updated to match the shared one (`/only callable when NODE_ENV=test/`).

## 2. pruneStaleIpBuckets coverage
The PR #162 test only exercised the empty-map and fresh-bucket paths — the actual stale-eviction loop ran without coverage. Added `_forceIpBucketStaleForTests` (test-mode guarded) so tests can rewind a bucket's `lastRefill` without faking the system clock. Two new cases:
- two stale + one fresh → asserts only the stale pair gets evicted
- a bucket 1s inside the 2× window is kept (boundary case)

## Test plan
- [x] `npm run typecheck` — clean
- [x] `npm test` — 100 suites / 1612 tests pass (rate-limit suite: 18 → 20)
- [x] `npm run lint` — clean
- [x] Drift checks (`gen-swift-intents`, `dump-tool-manifest`, `stats:check`, `llms:check`) — all clean