### PR TITLE
test: replace tautological assertions with real invariants

### DIFF
--- a/tests/rate-limit.test.js
+++ b/tests/rate-limit.test.js
@@ -113,10 +113,14 @@ describe('emergency stop file', () => {
 
 describe('getRateLimitStatus', () => {
   test('reports remaining tokens + emergency state', () => {
+    // Fresh default-tenant bucket has not been touched yet — both
+    // counters should report the configured capacity exactly. (The
+    // earlier `>= 0` assertion was tautologically true because both
+    // counters are non-negative integers.)
     const status = getRateLimitStatus();
     expect(status.enabled).toBe(true);
-    expect(status.globalRemaining).toBeGreaterThanOrEqual(0);
-    expect(status.destructiveRemaining).toBeGreaterThanOrEqual(0);
+    expect(status.globalRemaining).toBe(3); // AIRMCP_MAX_TOOL_CALLS_PER_MINUTE
+    expect(status.destructiveRemaining).toBe(2); // AIRMCP_MAX_DESTRUCTIVE_PER_HOUR
     expect(status.emergencyStop).toBe(false);
     expect(status.emergencyStopPath).toBe(STOP_FILE);
   });

--- a/tests/request-context.test.js
+++ b/tests/request-context.test.js
@@ -118,25 +118,28 @@ describe('request-context — isolation', () => {
     const inner = baseClaims({ subject: 'inner' });
 
     runWithRequestContext({ oauth: outer }, () => {
-      expect(getOAuthClaims()?.subject).toBe('outer');
+      expect(getOAuthClaims()).toBe(outer);
       runWithRequestContext({ oauth: inner }, () => {
-        expect(getOAuthClaims()?.subject).toBe('inner');
+        expect(getOAuthClaims()).toBe(inner);
       });
-      // After the nested run unwinds we see the outer store again.
-      expect(getOAuthClaims()?.subject).toBe('outer');
+      // After the nested run unwinds we see the outer store again,
+      // including object identity (not just the same subject string).
+      expect(getOAuthClaims()).toBe(outer);
     });
   });
 
   test('nested context with a different shape (no oauth) hides outer claims', () => {
-    runWithRequestContext({ oauth: baseClaims() }, () => {
-      expect(getOAuthClaims()).toBeDefined();
+    const outer = baseClaims({ subject: 'outer' });
+    runWithRequestContext({ oauth: outer }, () => {
+      expect(getOAuthClaims()).toBe(outer);
       runWithRequestContext({}, () => {
         // The nested store has no oauth field; helper must return
         // undefined so downstream gates short-circuit instead of
         // surfacing stale claims from the outer scope.
         expect(getOAuthClaims()).toBeUndefined();
       });
-      expect(getOAuthClaims()).toBeDefined();
+      // Outer store restored after the nested run unwinds.
+      expect(getOAuthClaims()).toBe(outer);
     });
   });
 });

--- a/tests/usage-tracker.test.js
+++ b/tests/usage-tracker.test.js
@@ -116,23 +116,49 @@ describe('UsageTracker — sequences', () => {
     expect(usageTracker.getNextTools('never_called')).toEqual([]);
   });
 
-  test('sequence pruning kicks in once the table grows past 1.2x cap', () => {
-    // MAX_SEQUENCE_ENTRIES = 500. The prune branch only fires when
-    // Object.keys(sequences).length > 600 — so build 650 distinct
-    // sequences and expect the table to be trimmed back to <= 500.
-    // Strategy: record alternating "anchor_i" → "tail_i" pairs so each
-    // pair creates exactly one new sequence key.
+  test('sequence pruning kicks in once the table grows past 1.2× cap', async () => {
+    // MAX_SEQUENCE_ENTRIES = 500. The prune branch fires when
+    // Object.keys(sequences).length > 600. We record 650 distinct
+    // anchor_i → tail_i transitions so each pair adds exactly one new
+    // sequence key, then assert the table was trimmed back to the cap.
+    //
+    // The internal sequences map isn't exposed; flush to disk and read
+    // the JSON file (already pointed at a tmp path via env) to inspect
+    // it. getStats().topSequences won't do — it always slices to 10
+    // regardless of map size, so the assertion would pass even if no
+    // pruning happened. (That's how this test got missed in PR #160.)
     for (let i = 0; i < 650; i++) {
       usageTracker.record(`anchor_${i}`);
       usageTracker.record(`tail_${i}`);
     }
-    const stats = usageTracker.getStats();
-    // After pruning: count should be at most MAX_SEQUENCE_ENTRIES (500).
-    expect(stats.topSequences.length).toBeLessThanOrEqual(10); // topK = 10
-    // The full sequences table is internal; we infer pruning happened
-    // via the lack of unbounded growth. Verify by calling getNextTools
-    // for one of the earliest pairs — those should be the ones evicted
-    // (they had count 1 vs survivors that we'll bump now).
+    await usageTracker.flush();
+    const onDisk = JSON.parse(readFileSync(PROFILE, 'utf-8'));
+    const seqCount = Object.keys(onDisk.sequences).length;
+    // Invariant: size is bounded by the 1.2× high-water trigger (600).
+    // Prune fires the moment the table exceeds that threshold and trims
+    // the bottom (least-used) keys down toward MAX_SEQUENCE_ENTRIES.
+    // Across a 650-pair burst the size oscillates within [500, 600];
+    // we don't pin a precise post-trim count because record-by-record
+    // re-trigger ordering is sensitive to sort tie-breaks.
+    expect(seqCount).toBeLessThanOrEqual(600);
+    // …and well below the count we'd see with no pruning at all
+    // (650 anchor→tail + 649 tail→next-anchor ≈ 1299 sequences).
+    expect(seqCount).toBeLessThan(1000);
+
+    // Spot-check: a heavily-reinforced key after pruning must survive a
+    // subsequent prune cycle. Bump anchor_649 → tail_649 a few more
+    // times so its count dominates the table tail; the next prune
+    // pass keeps high-count keys.
+    usageTracker.record('anchor_649');
+    usageTracker.record('tail_649');
+    usageTracker.record('anchor_649');
+    usageTracker.record('tail_649');
+    await usageTracker.flush();
+    const afterBump = JSON.parse(readFileSync(PROFILE, 'utf-8'));
+    expect(afterBump.sequences['anchor_649 → tail_649']).toBeGreaterThanOrEqual(3);
+    // Sanity: the table is still bounded (no leak after additional
+    // records).
+    expect(Object.keys(afterBump.sequences).length).toBeLessThanOrEqual(600);
   });
 });
 


### PR DESCRIPTION
Self-audit pass over the recent test additions (PRs #160, #162, #163, #164) found three places where the assertion was either tautologically true or didn't pin the invariant the test claimed to cover. None caught a real bug, but none would've caught a future regression either.

## `tests/usage-tracker.test.js` — sequence pruning
**Was**: \`expect(stats.topSequences.length).toBeLessThanOrEqual(10)\`. But \`getStats()\` always \`slice(0, 10)\`s, so the check passed even if the prune loop was a no-op.

**Now**: flushes the profile to disk and reads \`Object.keys(sequences).length\`, asserting:
- ≤ 600 (1.2× high-water trigger — the bounded invariant)
- < 1000 (well below the ~1299 sequences a 650-pair burst would create with no pruning)
- a heavily-reinforced key survives a follow-up prune cycle, with the size still bounded.

## `tests/rate-limit.test.js` — `getRateLimitStatus`
**Was**: \`globalRemaining >= 0\` / \`destructiveRemaining >= 0\` — both counters are non-negative integers, so trivially true.

**Now**: pins the exact starting capacity from the env-driven test config (3 / 2).

## `tests/request-context.test.js` — nested context shadowing
**Was**: \`.subject\` equality + \`.toBeDefined()\` on restore. A regression that cloned the store on restore (instead of restoring it verbatim) would still pass.

**Now**: object identity (\`toBe\`) — covers both subject equality *and* identity preservation.

## Test plan
- [x] \`npm test\` — 101 suites / 1626 tests pass
- [x] \`npm run lint\` — clean
- [x] All three previously-tautological tests now fail when their invariant is broken (verified by reverting the prune loop / capping the buckets to 0 / cloning the store on restore — each surfaces a clear failure).