### PR TITLE
refactor(rfc0001): migrate location + tv to typed error helpers

### DIFF
--- a/src/location/tools.ts
+++ b/src/location/tools.ts
@@ -1,6 +1,6 @@
 import type { McpServer } from "../shared/mcp.js";
 import type { AirMcpConfig } from "../shared/config.js";
-import { ok, okUntrusted, toolError } from "../shared/result.js";
+import { ok, okUntrusted, errSwift } from "../shared/result.js";
 import { runSwift } from "../shared/swift.js";
 
 interface LocationResult {
@@ -37,7 +37,8 @@ export function registerLocationTools(server: McpServer, _config: AirMcpConfig):
       try {
         return okUntrusted(await runSwift<LocationResult>("get-location", "{}"));
       } catch (e) {
-        return toolError("get current location", e);
+        const msg = e instanceof Error ? e.message : String(e);
+        return errSwift(`Failed to get current location: ${msg}`);
       }
     },
   );
@@ -61,7 +62,8 @@ export function registerLocationTools(server: McpServer, _config: AirMcpConfig):
       try {
         return ok(await runSwift<LocationPermissionResult>("location-permission", "{}"));
       } catch (e) {
-        return toolError("get location permission", e);
+        const msg = e instanceof Error ? e.message : String(e);
+        return errSwift(`Failed to get location permission: ${msg}`);
       }
     },
   );

--- a/src/tv/tools.ts
+++ b/src/tv/tools.ts
@@ -2,7 +2,7 @@ import type { McpServer } from "../shared/mcp.js";
 import { z } from "zod";
 import { runJxa } from "../shared/jxa.js";
 import type { AirMcpConfig } from "../shared/config.js";
-import { ok, okUntrusted, toolError } from "../shared/result.js";
+import { ok, okUntrusted, errJxa } from "../shared/result.js";
 import {
   listPlaylistsScript,
   listTracksScript,
@@ -25,7 +25,8 @@ export function registerTvTools(server: McpServer, _config: AirMcpConfig): void 
       try {
         return okUntrusted(await runJxa(listPlaylistsScript()));
       } catch (e) {
-        return toolError("list TV playlists", e);
+        const msg = e instanceof Error ? e.message : String(e);
+        return errJxa(`Failed to list TV playlists: ${msg}`);
       }
     },
   );
@@ -45,7 +46,8 @@ export function registerTvTools(server: McpServer, _config: AirMcpConfig): void 
       try {
         return okUntrusted(await runJxa(listTracksScript(playlist, limit)));
       } catch (e) {
-        return toolError("list TV tracks", e);
+        const msg = e instanceof Error ? e.message : String(e);
+        return errJxa(`Failed to list TV tracks: ${msg}`);
       }
     },
   );
@@ -62,7 +64,8 @@ export function registerTvTools(server: McpServer, _config: AirMcpConfig): void 
       try {
         return okUntrusted(await runJxa(nowPlayingScript()));
       } catch (e) {
-        return toolError("get TV now playing", e);
+        const msg = e instanceof Error ? e.message : String(e);
+        return errJxa(`Failed to get TV now playing: ${msg}`);
       }
     },
   );
@@ -81,7 +84,8 @@ export function registerTvTools(server: McpServer, _config: AirMcpConfig): void 
       try {
         return ok(await runJxa(playbackControlScript(action)));
       } catch (e) {
-        return toolError("control TV playback", e);
+        const msg = e instanceof Error ? e.message : String(e);
+        return errJxa(`Failed to control TV playback: ${msg}`);
       }
     },
   );
@@ -101,7 +105,8 @@ export function registerTvTools(server: McpServer, _config: AirMcpConfig): void 
       try {
         return okUntrusted(await runJxa(searchTracksScript(query, limit)));
       } catch (e) {
-        return toolError("search TV", e);
+        const msg = e instanceof Error ? e.message : String(e);
+        return errJxa(`Failed to search TV: ${msg}`);
       }
     },
   );
@@ -120,7 +125,8 @@ export function registerTvTools(server: McpServer, _config: AirMcpConfig): void 
       try {
         return ok(await runJxa(playTrackScript(name)));
       } catch (e) {
-        return toolError("play TV content", e);
+        const msg = e instanceof Error ? e.message : String(e);
+        return errJxa(`Failed to play TV content: ${msg}`);
       }
     },
   );


### PR DESCRIPTION
Continues the RFC 0001 envelope rollout. Two more modules off the \`toolError()\` classification fallback.

## Changes
- **`location/tools.ts`** (2 catches): `toolError` → `errSwift`
  - Both tools dispatch via `runSwift` to the AirMCPKit bridge. `errSwift` sets `cause.origin = "swift"` so audit + UI can distinguish bridge failures from JXA / HTTP / fs errors.

- **`tv/tools.ts`** (6 catches): `toolError` → `errJxa`
  - All six tools dispatch via `runJxa` against the Apple TV scripting dictionary. `errJxa` carries `cause.origin = "jxa"` for the same audit / UI diagnostics path.

## Adoption
11 → 13 of 32 `tools.ts` files on the typed helpers.

## Test plan
- [x] `npm run typecheck` — clean
- [x] `npm test` — 101 suites / 1626 tests pass (no behavior change)
- [x] `npm run lint` — clean