### PR TITLE
refactor(rfc0001): migrate maps + finder + screen to typed error helpers

### DIFF
--- a/src/finder/tools.ts
+++ b/src/finder/tools.ts
@@ -2,7 +2,7 @@ import type { McpServer } from "../shared/mcp.js";
 import { z } from "zod";
 import { runJxa } from "../shared/jxa.js";
 import type { AirMcpConfig } from "../shared/config.js";
-import { ok, okLinkedStructured, okStructured, okUntrustedStructured, toolError } from "../shared/result.js";
+import { ok, okLinkedStructured, okStructured, okUntrustedStructured, errJxa } from "../shared/result.js";
 import { zFilePath, resolveAndGuard } from "../shared/validate.js";
 import {
   searchFilesScript,
@@ -47,7 +47,8 @@ export function registerFinderTools(server: McpServer, _config: AirMcpConfig): v
       try {
         return okLinkedStructured("search_files", await runJxa(searchFilesScript(folder, query, limit)));
       } catch (e) {
-        return toolError("search files", e);
+        const msg = e instanceof Error ? e.message : String(e);
+        return errJxa(`Failed to search files: ${msg}`);
       }
     },
   );
@@ -75,7 +76,8 @@ export function registerFinderTools(server: McpServer, _config: AirMcpConfig): v
       try {
         return okUntrustedStructured(await runJxa(getFileInfoScript(path)));
       } catch (e) {
-        return toolError("get file info", e);
+        const msg = e instanceof Error ? e.message : String(e);
+        return errJxa(`Failed to get file info: ${msg}`);
       }
     },
   );
@@ -95,7 +97,8 @@ export function registerFinderTools(server: McpServer, _config: AirMcpConfig): v
       try {
         return ok(await runJxa(setTagsScript(path, tags)));
       } catch (e) {
-        return toolError("set tags", e);
+        const msg = e instanceof Error ? e.message : String(e);
+        return errJxa(`Failed to set tags: ${msg}`);
       }
     },
   );
@@ -125,7 +128,8 @@ export function registerFinderTools(server: McpServer, _config: AirMcpConfig): v
       try {
         return okStructured(await runJxa(recentFilesScript(folder, days, limit)));
       } catch (e) {
-        return toolError("find recent files", e);
+        const msg = e instanceof Error ? e.message : String(e);
+        return errJxa(`Failed to find recent files: ${msg}`);
       }
     },
   );
@@ -157,7 +161,8 @@ export function registerFinderTools(server: McpServer, _config: AirMcpConfig): v
       try {
         return okUntrustedStructured(await runJxa(listDirectoryScript(path, limit)));
       } catch (e) {
-        return toolError("list directory", e);
+        const msg = e instanceof Error ? e.message : String(e);
+        return errJxa(`Failed to list directory: ${msg}`);
       }
     },
   );
@@ -179,7 +184,8 @@ export function registerFinderTools(server: McpServer, _config: AirMcpConfig): v
         resolveAndGuard(destination);
         return ok(await runJxa(moveFileScript(source, destination)));
       } catch (e) {
-        return toolError("move file", e);
+        const msg = e instanceof Error ? e.message : String(e);
+        return errJxa(`Failed to move file: ${msg}`);
       }
     },
   );
@@ -199,7 +205,8 @@ export function registerFinderTools(server: McpServer, _config: AirMcpConfig): v
         resolveAndGuard(path);
         return ok(await runJxa(trashFileScript(path)));
       } catch (e) {
-        return toolError("trash file", e);
+        const msg = e instanceof Error ? e.message : String(e);
+        return errJxa(`Failed to trash file: ${msg}`);
       }
     },
   );
@@ -219,7 +226,8 @@ export function registerFinderTools(server: McpServer, _config: AirMcpConfig): v
         resolveAndGuard(path);
         return ok(await runJxa(createFolderScript(path)));
       } catch (e) {
-        return toolError("create folder", e);
+        const msg = e instanceof Error ? e.message : String(e);
+        return errJxa(`Failed to create folder: ${msg}`);
       }
     },
   );

--- a/src/maps/tools.ts
+++ b/src/maps/tools.ts
@@ -2,7 +2,7 @@ import type { McpServer } from "../shared/mcp.js";
 import { z } from "zod";
 import { runJxa } from "../shared/jxa.js";
 import type { AirMcpConfig } from "../shared/config.js";
-import { ok, okLinked, okUntrusted, toolError } from "../shared/result.js";
+import { ok, okLinked, okUntrusted, errJxa, errUpstream } from "../shared/result.js";
 import {
   searchLocationScript,
   getDirectionsScript,
@@ -28,7 +28,8 @@ export function registerMapsTools(server: McpServer, _config: AirMcpConfig): voi
       try {
         return okLinked("search_maps", await runJxa(searchLocationScript(query)));
       } catch (e) {
-        return toolError("search location", e);
+        const msg = e instanceof Error ? e.message : String(e);
+        return errJxa(`Failed to search location: ${msg}`);
       }
     },
   );
@@ -53,7 +54,8 @@ export function registerMapsTools(server: McpServer, _config: AirMcpConfig): voi
       try {
         return okUntrusted(await runJxa(getDirectionsScript(from, to, transportType)));
       } catch (e) {
-        return toolError("get directions", e);
+        const msg = e instanceof Error ? e.message : String(e);
+        return errJxa(`Failed to get directions: ${msg}`);
       }
     },
   );
@@ -74,7 +76,8 @@ export function registerMapsTools(server: McpServer, _config: AirMcpConfig): voi
       try {
         return ok(await runJxa(dropPinScript(latitude, longitude, label)));
       } catch (e) {
-        return toolError("drop pin", e);
+        const msg = e instanceof Error ? e.message : String(e);
+        return errJxa(`Failed to drop pin: ${msg}`);
       }
     },
   );
@@ -93,7 +96,8 @@ export function registerMapsTools(server: McpServer, _config: AirMcpConfig): voi
       try {
         return ok(await runJxa(openInMapsScript(address)));
       } catch (e) {
-        return toolError("open address", e);
+        const msg = e instanceof Error ? e.message : String(e);
+        return errJxa(`Failed to open address: ${msg}`);
       }
     },
   );
@@ -115,7 +119,8 @@ export function registerMapsTools(server: McpServer, _config: AirMcpConfig): voi
       try {
         return okUntrusted(await runJxa(searchNearbyScript(query, latitude, longitude)));
       } catch (e) {
-        return toolError("search nearby", e);
+        const msg = e instanceof Error ? e.message : String(e);
+        return errJxa(`Failed to search nearby: ${msg}`);
       }
     },
   );
@@ -136,7 +141,8 @@ export function registerMapsTools(server: McpServer, _config: AirMcpConfig): voi
       try {
         return ok(await runJxa(shareLocationScript(latitude, longitude, label)));
       } catch (e) {
-        return toolError("share location", e);
+        const msg = e instanceof Error ? e.message : String(e);
+        return errJxa(`Failed to share location: ${msg}`);
       }
     },
   );
@@ -160,7 +166,8 @@ export function registerMapsTools(server: McpServer, _config: AirMcpConfig): voi
       try {
         return okUntrusted(await fetchGeocode(query));
       } catch (e) {
-        return toolError("geocode", e);
+        const msg = e instanceof Error ? e.message : String(e);
+        return errUpstream(`Failed to geocode: ${msg}`, { retryable: true });
       }
     },
   );
@@ -180,7 +187,8 @@ export function registerMapsTools(server: McpServer, _config: AirMcpConfig): voi
       try {
         return okUntrusted(await fetchReverseGeocode(latitude, longitude));
       } catch (e) {
-        return toolError("reverse geocode", e);
+        const msg = e instanceof Error ? e.message : String(e);
+        return errUpstream(`Failed to reverse geocode: ${msg}`, { retryable: true });
       }
     },
   );

--- a/src/screen/tools.ts
+++ b/src/screen/tools.ts
@@ -3,7 +3,7 @@ import { z } from "zod";
 import { readFile, stat, unlink } from "node:fs/promises";
 import { runJxa } from "../shared/jxa.js";
 import type { AirMcpConfig } from "../shared/config.js";
-import { okUntrusted, toolError } from "../shared/result.js";
+import { okUntrusted, errJxa } from "../shared/result.js";
 import {
   captureScreenScript,
   captureWindowScript,
@@ -72,7 +72,8 @@ export function registerScreenTools(server: McpServer, _config: AirMcpConfig): v
       try {
         return await captureAndReturn(captureScreenScript(display));
       } catch (e) {
-        return toolError("capture screen", e);
+        const msg = e instanceof Error ? e.message : String(e);
+        return errJxa(`Failed to capture screen: ${msg}`);
       }
     },
   );
@@ -103,7 +104,8 @@ export function registerScreenTools(server: McpServer, _config: AirMcpConfig): v
       try {
         return await captureAndReturn(captureWindowScript(appName));
       } catch (e) {
-        return toolError("capture window", e);
+        const msg = e instanceof Error ? e.message : String(e);
+        return errJxa(`Failed to capture window: ${msg}`);
       }
     },
   );
@@ -131,7 +133,8 @@ export function registerScreenTools(server: McpServer, _config: AirMcpConfig): v
       try {
         return await captureAndReturn(captureAreaScript(x, y, width, height));
       } catch (e) {
-        return toolError("capture area", e);
+        const msg = e instanceof Error ? e.message : String(e);
+        return errJxa(`Failed to capture area: ${msg}`);
       }
     },
   );
@@ -154,7 +157,8 @@ export function registerScreenTools(server: McpServer, _config: AirMcpConfig): v
       try {
         return okUntrusted(await runJxa(listWindowsScript()));
       } catch (e) {
-        return toolError("list windows", e);
+        const msg = e instanceof Error ? e.message : String(e);
+        return errJxa(`Failed to list windows: ${msg}`);
       }
     },
   );
@@ -240,7 +244,8 @@ export function registerScreenTools(server: McpServer, _config: AirMcpConfig): v
           ],
         };
       } catch (e) {
-        return toolError("record screen", e);
+        const msg = e instanceof Error ? e.message : String(e);
+        return errJxa(`Failed to record screen: ${msg}`);
       }
     },
   );


### PR DESCRIPTION
Continues the RFC 0001 envelope rollout. Three more modules (21 catches) off the \`toolError()\` classification fallback.

## Changes

### \`maps/tools.ts\` (8 catches): split between transports
- **6 JXA-dispatch tools** → \`errJxa\` (search / directions / dropPin / openAddress / searchNearby / shareLocation)
- **2 HTTP-fetch tools** → \`errUpstream\` with \`retryable: true\` — geocode / reverse_geocode hit Open-Meteo and Nominatim, so timeouts and non-2xx responses are advertised as retryable

### \`finder/tools.ts\` (8 catches): \`toolError\` → \`errJxa\`
All eight tools dispatch via \`runJxa\` for Spotlight + Finder operations. \`resolveAndGuard\` validation throws stay categorized as \`errJxa\` for now; a future pass can split them into \`errInvalidInput\` if the path-traversal guard message becomes worth surfacing distinctly.

### \`screen/tools.ts\` (5 catches): \`toolError\` → \`errJxa\`
All five tools dispatch via \`runJxa\` for screencapture + window enumeration. \`errJxa\` sets \`cause.origin = "jxa"\` so audit / UI distinguishes these from Swift bridge / fs failures.

## Adoption
13 → 16 of 32 \`tools.ts\` files on the typed helpers.

## Test plan
- [x] \`npm run typecheck\` — clean
- [x] \`npm test\` — 101 suites / 1626 tests pass (no behavior change)
- [x] \`npm run lint\` — clean