### PR TITLE
refactor(rfc0001): document runAutomation error invariant + migrate contacts

### DIFF
--- a/src/contacts/tools.ts
+++ b/src/contacts/tools.ts
@@ -2,7 +2,7 @@ import type { McpServer } from "../shared/mcp.js";
 import { z } from "zod";
 import { runAutomation } from "../shared/automation.js";
 import type { AirMcpConfig } from "../shared/config.js";
-import { ok, okStructured, okUntrustedStructured, okUntrustedLinkedStructured, toolError } from "../shared/result.js";
+import { ok, okStructured, okUntrustedStructured, okUntrustedLinkedStructured, errJxa } from "../shared/result.js";
 import {
   listContactsScript,
   searchContactsScript,
@@ -126,7 +126,8 @@ export function registerContactTools(server: McpServer, _config: AirMcpConfig): 
         });
         return okUntrustedLinkedStructured("list_contacts", result);
       } catch (e) {
-        return toolError("list contacts", e);
+        const msg = e instanceof Error ? e.message : String(e);
+        return errJxa(`Failed to list contacts: ${msg}`);
       }
     },
   );
@@ -164,7 +165,8 @@ export function registerContactTools(server: McpServer, _config: AirMcpConfig): 
         });
         return okUntrustedStructured(result);
       } catch (e) {
-        return toolError("search contacts", e);
+        const msg = e instanceof Error ? e.message : String(e);
+        return errJxa(`Failed to search contacts: ${msg}`);
       }
     },
   );
@@ -209,7 +211,8 @@ export function registerContactTools(server: McpServer, _config: AirMcpConfig): 
         });
         return okUntrustedStructured(result);
       } catch (e) {
-        return toolError("read contact", e);
+        const msg = e instanceof Error ? e.message : String(e);
+        return errJxa(`Failed to read contact: ${msg}`);
       }
     },
   );
@@ -241,7 +244,8 @@ export function registerContactTools(server: McpServer, _config: AirMcpConfig): 
         });
         return ok(result);
       } catch (e) {
-        return toolError("create contact", e);
+        const msg = e instanceof Error ? e.message : String(e);
+        return errJxa(`Failed to create contact: ${msg}`);
       }
     },
   );
@@ -269,7 +273,8 @@ export function registerContactTools(server: McpServer, _config: AirMcpConfig): 
         });
         return ok(result);
       } catch (e) {
-        return toolError("update contact", e);
+        const msg = e instanceof Error ? e.message : String(e);
+        return errJxa(`Failed to update contact: ${msg}`);
       }
     },
   );
@@ -292,7 +297,8 @@ export function registerContactTools(server: McpServer, _config: AirMcpConfig): 
         });
         return ok(result);
       } catch (e) {
-        return toolError("delete contact", e);
+        const msg = e instanceof Error ? e.message : String(e);
+        return errJxa(`Failed to delete contact: ${msg}`);
       }
     },
   );
@@ -321,7 +327,8 @@ export function registerContactTools(server: McpServer, _config: AirMcpConfig): 
         });
         return okStructured({ groups: result });
       } catch (e) {
-        return toolError("list groups", e);
+        const msg = e instanceof Error ? e.message : String(e);
+        return errJxa(`Failed to list groups: ${msg}`);
       }
     },
   );
@@ -346,7 +353,8 @@ export function registerContactTools(server: McpServer, _config: AirMcpConfig): 
         });
         return ok(result);
       } catch (e) {
-        return toolError("add email to contact", e);
+        const msg = e instanceof Error ? e.message : String(e);
+        return errJxa(`Failed to add email to contact: ${msg}`);
       }
     },
   );
@@ -371,7 +379,8 @@ export function registerContactTools(server: McpServer, _config: AirMcpConfig): 
         });
         return ok(result);
       } catch (e) {
-        return toolError("add phone to contact", e);
+        const msg = e instanceof Error ? e.message : String(e);
+        return errJxa(`Failed to add phone to contact: ${msg}`);
       }
     },
   );
@@ -401,7 +410,8 @@ export function registerContactTools(server: McpServer, _config: AirMcpConfig): 
         });
         return okUntrustedStructured(result);
       } catch (e) {
-        return toolError("list group members", e);
+        const msg = e instanceof Error ? e.message : String(e);
+        return errJxa(`Failed to list group members: ${msg}`);
       }
     },
   );

--- a/src/shared/automation.ts
+++ b/src/shared/automation.ts
@@ -6,6 +6,14 @@ import { runJxa } from "./jxa.js";
  * Falls back to JXA if the Swift bridge is not built, the command is
  * not implemented in Swift, or the Swift call fails.
  *
+ * Error origin invariant (callers can rely on this for RFC 0001
+ * categorization):
+ *   Every error thrown by this function comes from the JXA path.
+ *   The Swift branch always falls through to `runJxa()` on failure,
+ *   so the only error that can reach the caller is the JXA one. This
+ *   means tools wrapping `runAutomation` can use `errJxa()` for their
+ *   catch blocks without needing a separate "automation" origin.
+ *
  * @param options.swift.command  The Swift bridge command name (e.g. "get-clipboard")
  * @param options.swift.input    Optional input payload (will be JSON-serialized)
  * @param options.jxa            Lazy JXA script generator (only called if needed)


### PR DESCRIPTION
Hybrid (Swift+JXA) modules looked like they needed a new \`errAutomation\` helper for \`cause.origin\` attribution. A closer look at \`runAutomation\` shows the question is moot.

## The invariant
\`\`\`
hasSwiftCommand=true  → Swift try → fail → stderr log → JXA fallback → fail → throw [JXA origin]
hasSwiftCommand=true  → Swift try → ok                                       → return (no throw)
hasSwiftCommand=false → JXA only  → fail                                     → throw [JXA origin]
hasSwiftCommand=false → JXA only  → ok                                       → return (no throw)
\`\`\`
The Swift catch only logs to stderr and continues — Swift-only failures never escape. **Every error that reaches the caller is from the JXA path.** Tools wrapping \`runAutomation\` can use \`errJxa()\` directly and the \`cause.origin\` is correct.

## Changes
1. **\`shared/automation.ts\`** — add the invariant to the doc-comment so future readers don't repeat the analysis. No code change.
2. **\`contacts/tools.ts\`** (10 catches): \`toolError\` → \`errJxa\`. First user of the documented pattern.

## Adoption
19 → 19 of 32 \`tools.ts\` files on the typed helpers (PR #170 brought it from 18 → 19, this PR adds 1 more). Remaining four \`runAutomation\` users (calendar, reminders, photos, system) follow the same pattern and can be migrated next.

## Test plan
- [x] \`npm run typecheck\` — clean
- [x] \`npm test\` — 101 suites / 1626 tests pass (no behavior change)
- [x] \`npm run lint\` — clean