### PR TITLE
refactor(rfc0001): migrate calendar + reminders to typed error helpers

### DIFF
--- a/src/calendar/tools.ts
+++ b/src/calendar/tools.ts
@@ -3,7 +3,7 @@ import { z } from "zod";
 import { runAutomation } from "../shared/automation.js";
 import { runSwift } from "../shared/swift.js";
 import type { AirMcpConfig } from "../shared/config.js";
-import { ok, okStructured, okUntrustedStructured, okUntrustedLinkedStructured, toolError } from "../shared/result.js";
+import { ok, okStructured, okUntrustedStructured, okUntrustedLinkedStructured, errJxa } from "../shared/result.js";
 import {
   listCalendarsScript,
   listEventsScript,
@@ -121,7 +121,8 @@ export function registerCalendarTools(server: McpServer, _config: AirMcpConfig):
         });
         return okStructured({ calendars: result });
       } catch (e) {
-        return toolError("list calendars", e);
+        const msg = e instanceof Error ? e.message : String(e);
+        return errJxa(`Failed to list calendars: ${msg}`);
       }
     },
   );
@@ -179,7 +180,8 @@ export function registerCalendarTools(server: McpServer, _config: AirMcpConfig):
         });
         return okUntrustedStructured(result);
       } catch (e) {
-        return toolError("list events", e);
+        const msg = e instanceof Error ? e.message : String(e);
+        return errJxa(`Failed to list events: ${msg}`);
       }
     },
   );
@@ -227,7 +229,8 @@ export function registerCalendarTools(server: McpServer, _config: AirMcpConfig):
         });
         return okUntrustedStructured(result);
       } catch (e) {
-        return toolError("read event", e);
+        const msg = e instanceof Error ? e.message : String(e);
+        return errJxa(`Failed to read event: ${msg}`);
       }
     },
   );
@@ -265,7 +268,8 @@ export function registerCalendarTools(server: McpServer, _config: AirMcpConfig):
         });
         return ok(result);
       } catch (e) {
-        return toolError("create event", e);
+        const msg = e instanceof Error ? e.message : String(e);
+        return errJxa(`Failed to create event: ${msg}`);
       }
     },
   );
@@ -306,7 +310,8 @@ export function registerCalendarTools(server: McpServer, _config: AirMcpConfig):
         });
         return ok(result);
       } catch (e) {
-        return toolError("update event", e);
+        const msg = e instanceof Error ? e.message : String(e);
+        return errJxa(`Failed to update event: ${msg}`);
       }
     },
   );
@@ -334,7 +339,8 @@ export function registerCalendarTools(server: McpServer, _config: AirMcpConfig):
         });
         return ok(result);
       } catch (e) {
-        return toolError("delete event", e);
+        const msg = e instanceof Error ? e.message : String(e);
+        return errJxa(`Failed to delete event: ${msg}`);
       }
     },
   );
@@ -381,7 +387,8 @@ export function registerCalendarTools(server: McpServer, _config: AirMcpConfig):
         });
         return okUntrustedStructured(result);
       } catch (e) {
-        return toolError("search events", e);
+        const msg = e instanceof Error ? e.message : String(e);
+        return errJxa(`Failed to search events: ${msg}`);
       }
     },
   );
@@ -425,7 +432,8 @@ export function registerCalendarTools(server: McpServer, _config: AirMcpConfig):
         });
         return okUntrustedStructured(result);
       } catch (e) {
-        return toolError("get upcoming events", e);
+        const msg = e instanceof Error ? e.message : String(e);
+        return errJxa(`Failed to get upcoming events: ${msg}`);
       }
     },
   );
@@ -465,7 +473,8 @@ export function registerCalendarTools(server: McpServer, _config: AirMcpConfig):
         });
         return okUntrustedLinkedStructured("today_events", result);
       } catch (e) {
-        return toolError("get today's events", e);
+        const msg = e instanceof Error ? e.message : String(e);
+        return errJxa(`Failed to get today's events: ${msg}`);
       }
     },
   );
@@ -523,7 +532,8 @@ export function registerCalendarTools(server: McpServer, _config: AirMcpConfig):
         );
         return ok(result);
       } catch (e) {
-        return toolError("create recurring event", e);
+        const msg = e instanceof Error ? e.message : String(e);
+        return errJxa(`Failed to create recurring event: ${msg}`);
       }
     },
   );

--- a/src/reminders/tools.ts
+++ b/src/reminders/tools.ts
@@ -3,7 +3,7 @@ import { z } from "zod";
 import { runAutomation } from "../shared/automation.js";
 import { runSwift } from "../shared/swift.js";
 import type { AirMcpConfig } from "../shared/config.js";
-import { ok, okLinked, okLinkedStructured, okStructured, okUntrustedStructured, toolError } from "../shared/result.js";
+import { ok, okLinked, okLinkedStructured, okStructured, okUntrustedStructured, errJxa } from "../shared/result.js";
 import type { MutationResult, DeleteResult } from "../shared/types.js";
 import {
   listReminderListsScript,
@@ -87,7 +87,8 @@ export function registerReminderTools(server: McpServer, _config: AirMcpConfig):
         });
         return okStructured({ lists: result });
       } catch (e) {
-        return toolError("list reminder lists", e);
+        const msg = e instanceof Error ? e.message : String(e);
+        return errJxa(`Failed to list reminder lists: ${msg}`);
       }
     },
   );
@@ -156,7 +157,8 @@ export function registerReminderTools(server: McpServer, _config: AirMcpConfig):
         });
         return okLinkedStructured("list_reminders", result);
       } catch (e) {
-        return toolError("list reminders", e);
+        const msg = e instanceof Error ? e.message : String(e);
+        return errJxa(`Failed to list reminders: ${msg}`);
       }
     },
   );
@@ -197,7 +199,8 @@ export function registerReminderTools(server: McpServer, _config: AirMcpConfig):
         });
         return okUntrustedStructured(result);
       } catch (e) {
-        return toolError("read reminder", e);
+        const msg = e instanceof Error ? e.message : String(e);
+        return errJxa(`Failed to read reminder: ${msg}`);
       }
     },
   );
@@ -233,7 +236,8 @@ export function registerReminderTools(server: McpServer, _config: AirMcpConfig):
         });
         return okLinked("create_reminder", result);
       } catch (e) {
-        return toolError("create reminder", e);
+        const msg = e instanceof Error ? e.message : String(e);
+        return errJxa(`Failed to create reminder: ${msg}`);
       }
     },
   );
@@ -282,7 +286,8 @@ export function registerReminderTools(server: McpServer, _config: AirMcpConfig):
         });
         return ok(result);
       } catch (e) {
-        return toolError("update reminder", e);
+        const msg = e instanceof Error ? e.message : String(e);
+        return errJxa(`Failed to update reminder: ${msg}`);
       }
     },
   );
@@ -318,7 +323,8 @@ export function registerReminderTools(server: McpServer, _config: AirMcpConfig):
         });
         return ok(result);
       } catch (e) {
-        return toolError("complete reminder", e);
+        const msg = e instanceof Error ? e.message : String(e);
+        return errJxa(`Failed to complete reminder: ${msg}`);
       }
     },
   );
@@ -346,7 +352,8 @@ export function registerReminderTools(server: McpServer, _config: AirMcpConfig):
         });
         return ok(result);
       } catch (e) {
-        return toolError("delete reminder", e);
+        const msg = e instanceof Error ? e.message : String(e);
+        return errJxa(`Failed to delete reminder: ${msg}`);
       }
     },
   );
@@ -392,7 +399,8 @@ export function registerReminderTools(server: McpServer, _config: AirMcpConfig):
         });
         return okUntrustedStructured(result);
       } catch (e) {
-        return toolError("search reminders", e);
+        const msg = e instanceof Error ? e.message : String(e);
+        return errJxa(`Failed to search reminders: ${msg}`);
       }
     },
   );
@@ -423,7 +431,8 @@ export function registerReminderTools(server: McpServer, _config: AirMcpConfig):
         });
         return ok(result);
       } catch (e) {
-        return toolError("create reminder list", e);
+        const msg = e instanceof Error ? e.message : String(e);
+        return errJxa(`Failed to create reminder list: ${msg}`);
       }
     },
   );
@@ -454,7 +463,8 @@ export function registerReminderTools(server: McpServer, _config: AirMcpConfig):
         });
         return ok(result);
       } catch (e) {
-        return toolError("delete reminder list", e);
+        const msg = e instanceof Error ? e.message : String(e);
+        return errJxa(`Failed to delete reminder list: ${msg}`);
       }
     },
   );
@@ -510,7 +520,8 @@ export function registerReminderTools(server: McpServer, _config: AirMcpConfig):
         );
         return ok(result);
       } catch (e) {
-        return toolError("create recurring reminder", e);
+        const msg = e instanceof Error ? e.message : String(e);
+        return errJxa(`Failed to create recurring reminder: ${msg}`);
       }
     },
   );


### PR DESCRIPTION
Continues the \`runAutomation\`-aware rollout from PR #171. Two more hybrid (Swift + JXA) modules off the \`toolError()\` classification fallback.

## Changes
- **\`calendar/tools.ts\`** (10 catches): \`toolError\` → \`errJxa\`
  - All ten tools wrap \`runAutomation\` calls (list_calendars, list_events, read_event, create/update/delete_event, search_events, get_upcoming_events, today_events, create_recurring_event).
- **\`reminders/tools.ts\`** (11 catches): \`toolError\` → \`errJxa\`
  - All eleven tools wrap \`runAutomation\` calls (lists CRUD + reminders CRUD + complete + search + recurring).

## Invariant
Per the PR #171 doc-comment in \`shared/automation.ts\`: errors that escape \`runAutomation\` always come from the JXA path (Swift failures fall through to JXA fallback, never re-throw). So \`errJxa\` with \`cause.origin = "jxa"\` is correct.

## Adoption
19 → 21 of 32 \`tools.ts\` files on the typed helpers. Two \`runAutomation\` users left (photos, system) plus a few partial migrations (notes, mail, intelligence, ui, health).

## Test plan
- [x] \`npm run typecheck\` — clean
- [x] \`npm test\` — 101 suites / 1626 tests pass (no behavior change)
- [x] \`npm run lint\` — clean