### PR TITLE
refactor(rfc0001): collapse catch boilerplate with errXxxFor helpers

### DIFF
--- a/src/bluetooth/tools.ts
+++ b/src/bluetooth/tools.ts
@@ -1,7 +1,7 @@
 import type { McpServer } from "../shared/mcp.js";
 import { z } from "zod";
 import type { AirMcpConfig } from "../shared/config.js";
-import { ok, okUntrusted, errSwift } from "../shared/result.js";
+import { ok, okUntrusted, errSwiftFor } from "../shared/result.js";
 import { runSwift } from "../shared/swift.js";
 
 interface BluetoothStateResult {
@@ -39,8 +39,7 @@ export function registerBluetoothTools(server: McpServer, _config: AirMcpConfig)
       try {
         return ok(await runSwift<BluetoothStateResult>("bluetooth-state", "{}"));
       } catch (e) {
-        const msg = e instanceof Error ? e.message : String(e);
-        return errSwift(`Failed to get bluetooth state: ${msg}`);
+        return errSwiftFor("get bluetooth state", e);
       }
     },
   );
@@ -67,8 +66,7 @@ export function registerBluetoothTools(server: McpServer, _config: AirMcpConfig)
       try {
         return okUntrusted(await runSwift<BluetoothScanResult>("scan-bluetooth", JSON.stringify({ duration })));
       } catch (e) {
-        const msg = e instanceof Error ? e.message : String(e);
-        return errSwift(`Failed to scan bluetooth: ${msg}`);
+        return errSwiftFor("scan bluetooth", e);
       }
     },
   );
@@ -89,8 +87,7 @@ export function registerBluetoothTools(server: McpServer, _config: AirMcpConfig)
       try {
         return ok(await runSwift<BluetoothConnectResult>("connect-bluetooth", JSON.stringify({ identifier })));
       } catch (e) {
-        const msg = e instanceof Error ? e.message : String(e);
-        return errSwift(`Failed to connect bluetooth: ${msg}`);
+        return errSwiftFor("connect bluetooth", e);
       }
     },
   );
@@ -109,8 +106,7 @@ export function registerBluetoothTools(server: McpServer, _config: AirMcpConfig)
       try {
         return ok(await runSwift<BluetoothConnectResult>("disconnect-bluetooth", JSON.stringify({ identifier })));
       } catch (e) {
-        const msg = e instanceof Error ? e.message : String(e);
-        return errSwift(`Failed to disconnect bluetooth: ${msg}`);
+        return errSwiftFor("disconnect bluetooth", e);
       }
     },
   );

--- a/src/calendar/tools.ts
+++ b/src/calendar/tools.ts
@@ -3,7 +3,7 @@ import { z } from "zod";
 import { runAutomation } from "../shared/automation.js";
 import { runSwift } from "../shared/swift.js";
 import type { AirMcpConfig } from "../shared/config.js";
-import { ok, okStructured, okUntrustedStructured, okUntrustedLinkedStructured, errJxa } from "../shared/result.js";
+import { ok, okStructured, okUntrustedStructured, okUntrustedLinkedStructured, errJxaFor } from "../shared/result.js";
 import {
   listCalendarsScript,
   listEventsScript,
@@ -121,8 +121,7 @@ export function registerCalendarTools(server: McpServer, _config: AirMcpConfig):
         });
         return okStructured({ calendars: result });
       } catch (e) {
-        const msg = e instanceof Error ? e.message : String(e);
-        return errJxa(`Failed to list calendars: ${msg}`);
+        return errJxaFor("list calendars", e);
       }
     },
   );
@@ -180,8 +179,7 @@ export function registerCalendarTools(server: McpServer, _config: AirMcpConfig):
         });
         return okUntrustedStructured(result);
       } catch (e) {
-        const msg = e instanceof Error ? e.message : String(e);
-        return errJxa(`Failed to list events: ${msg}`);
+        return errJxaFor("list events", e);
       }
     },
   );
@@ -229,8 +227,7 @@ export function registerCalendarTools(server: McpServer, _config: AirMcpConfig):
         });
         return okUntrustedStructured(result);
       } catch (e) {
-        const msg = e instanceof Error ? e.message : String(e);
-        return errJxa(`Failed to read event: ${msg}`);
+        return errJxaFor("read event", e);
       }
     },
   );
@@ -268,8 +265,7 @@ export function registerCalendarTools(server: McpServer, _config: AirMcpConfig):
         });
         return ok(result);
       } catch (e) {
-        const msg = e instanceof Error ? e.message : String(e);
-        return errJxa(`Failed to create event: ${msg}`);
+        return errJxaFor("create event", e);
       }
     },
   );
@@ -310,8 +306,7 @@ export function registerCalendarTools(server: McpServer, _config: AirMcpConfig):
         });
         return ok(result);
       } catch (e) {
-        const msg = e instanceof Error ? e.message : String(e);
-        return errJxa(`Failed to update event: ${msg}`);
+        return errJxaFor("update event", e);
       }
     },
   );
@@ -339,8 +334,7 @@ export function registerCalendarTools(server: McpServer, _config: AirMcpConfig):
         });
         return ok(result);
       } catch (e) {
-        const msg = e instanceof Error ? e.message : String(e);
-        return errJxa(`Failed to delete event: ${msg}`);
+        return errJxaFor("delete event", e);
       }
     },
   );
@@ -387,8 +381,7 @@ export function registerCalendarTools(server: McpServer, _config: AirMcpConfig):
         });
         return okUntrustedStructured(result);
       } catch (e) {
-        const msg = e instanceof Error ? e.message : String(e);
-        return errJxa(`Failed to search events: ${msg}`);
+        return errJxaFor("search events", e);
       }
     },
   );
@@ -432,8 +425,7 @@ export function registerCalendarTools(server: McpServer, _config: AirMcpConfig):
         });
         return okUntrustedStructured(result);
       } catch (e) {
-        const msg = e instanceof Error ? e.message : String(e);
-        return errJxa(`Failed to get upcoming events: ${msg}`);
+        return errJxaFor("get upcoming events", e);
       }
     },
   );
@@ -473,8 +465,7 @@ export function registerCalendarTools(server: McpServer, _config: AirMcpConfig):
         });
         return okUntrustedLinkedStructured("today_events", result);
       } catch (e) {
-        const msg = e instanceof Error ? e.message : String(e);
-        return errJxa(`Failed to get today's events: ${msg}`);
+        return errJxaFor("get today's events", e);
       }
     },
   );
@@ -532,8 +523,7 @@ export function registerCalendarTools(server: McpServer, _config: AirMcpConfig):
         );
         return ok(result);
       } catch (e) {
-        const msg = e instanceof Error ? e.message : String(e);
-        return errJxa(`Failed to create recurring event: ${msg}`);
+        return errJxaFor("create recurring event", e);
       }
     },
   );

--- a/src/contacts/tools.ts
+++ b/src/contacts/tools.ts
@@ -2,7 +2,7 @@ import type { McpServer } from "../shared/mcp.js";
 import { z } from "zod";
 import { runAutomation } from "../shared/automation.js";
 import type { AirMcpConfig } from "../shared/config.js";
-import { ok, okStructured, okUntrustedStructured, okUntrustedLinkedStructured, errJxa } from "../shared/result.js";
+import { ok, okStructured, okUntrustedStructured, okUntrustedLinkedStructured, errJxaFor } from "../shared/result.js";
 import {
   listContactsScript,
   searchContactsScript,
@@ -126,8 +126,7 @@ export function registerContactTools(server: McpServer, _config: AirMcpConfig): 
         });
         return okUntrustedLinkedStructured("list_contacts", result);
       } catch (e) {
-        const msg = e instanceof Error ? e.message : String(e);
-        return errJxa(`Failed to list contacts: ${msg}`);
+        return errJxaFor("list contacts", e);
       }
     },
   );
@@ -165,8 +164,7 @@ export function registerContactTools(server: McpServer, _config: AirMcpConfig): 
         });
         return okUntrustedStructured(result);
       } catch (e) {
-        const msg = e instanceof Error ? e.message : String(e);
-        return errJxa(`Failed to search contacts: ${msg}`);
+        return errJxaFor("search contacts", e);
       }
     },
   );
@@ -211,8 +209,7 @@ export function registerContactTools(server: McpServer, _config: AirMcpConfig): 
         });
         return okUntrustedStructured(result);
       } catch (e) {
-        const msg = e instanceof Error ? e.message : String(e);
-        return errJxa(`Failed to read contact: ${msg}`);
+        return errJxaFor("read contact", e);
       }
     },
   );
@@ -244,8 +241,7 @@ export function registerContactTools(server: McpServer, _config: AirMcpConfig): 
         });
         return ok(result);
       } catch (e) {
-        const msg = e instanceof Error ? e.message : String(e);
-        return errJxa(`Failed to create contact: ${msg}`);
+        return errJxaFor("create contact", e);
       }
     },
   );
@@ -273,8 +269,7 @@ export function registerContactTools(server: McpServer, _config: AirMcpConfig): 
         });
         return ok(result);
       } catch (e) {
-        const msg = e instanceof Error ? e.message : String(e);
-        return errJxa(`Failed to update contact: ${msg}`);
+        return errJxaFor("update contact", e);
       }
     },
   );
@@ -297,8 +292,7 @@ export function registerContactTools(server: McpServer, _config: AirMcpConfig): 
         });
         return ok(result);
       } catch (e) {
-        const msg = e instanceof Error ? e.message : String(e);
-        return errJxa(`Failed to delete contact: ${msg}`);
+        return errJxaFor("delete contact", e);
       }
     },
   );
@@ -327,8 +321,7 @@ export function registerContactTools(server: McpServer, _config: AirMcpConfig): 
         });
         return okStructured({ groups: result });
       } catch (e) {
-        const msg = e instanceof Error ? e.message : String(e);
-        return errJxa(`Failed to list groups: ${msg}`);
+        return errJxaFor("list groups", e);
       }
     },
   );
@@ -353,8 +346,7 @@ export function registerContactTools(server: McpServer, _config: AirMcpConfig): 
         });
         return ok(result);
       } catch (e) {
-        const msg = e instanceof Error ? e.message : String(e);
-        return errJxa(`Failed to add email to contact: ${msg}`);
+        return errJxaFor("add email to contact", e);
       }
     },
   );
@@ -379,8 +371,7 @@ export function registerContactTools(server: McpServer, _config: AirMcpConfig): 
         });
         return ok(result);
       } catch (e) {
-        const msg = e instanceof Error ? e.message : String(e);
-        return errJxa(`Failed to add phone to contact: ${msg}`);
+        return errJxaFor("add phone to contact", e);
       }
     },
   );
@@ -410,8 +401,7 @@ export function registerContactTools(server: McpServer, _config: AirMcpConfig): 
         });
         return okUntrustedStructured(result);
       } catch (e) {
-        const msg = e instanceof Error ? e.message : String(e);
-        return errJxa(`Failed to list group members: ${msg}`);
+        return errJxaFor("list group members", e);
       }
     },
   );

--- a/src/finder/tools.ts
+++ b/src/finder/tools.ts
@@ -2,7 +2,7 @@ import type { McpServer } from "../shared/mcp.js";
 import { z } from "zod";
 import { runJxa } from "../shared/jxa.js";
 import type { AirMcpConfig } from "../shared/config.js";
-import { ok, okLinkedStructured, okStructured, okUntrustedStructured, errJxa } from "../shared/result.js";
+import { ok, okLinkedStructured, okStructured, okUntrustedStructured, errJxaFor } from "../shared/result.js";
 import { zFilePath, resolveAndGuard } from "../shared/validate.js";
 import {
   searchFilesScript,
@@ -47,8 +47,7 @@ export function registerFinderTools(server: McpServer, _config: AirMcpConfig): v
       try {
         return okLinkedStructured("search_files", await runJxa(searchFilesScript(folder, query, limit)));
       } catch (e) {
-        const msg = e instanceof Error ? e.message : String(e);
-        return errJxa(`Failed to search files: ${msg}`);
+        return errJxaFor("search files", e);
       }
     },
   );
@@ -76,8 +75,7 @@ export function registerFinderTools(server: McpServer, _config: AirMcpConfig): v
       try {
         return okUntrustedStructured(await runJxa(getFileInfoScript(path)));
       } catch (e) {
-        const msg = e instanceof Error ? e.message : String(e);
-        return errJxa(`Failed to get file info: ${msg}`);
+        return errJxaFor("get file info", e);
       }
     },
   );
@@ -97,8 +95,7 @@ export function registerFinderTools(server: McpServer, _config: AirMcpConfig): v
       try {
         return ok(await runJxa(setTagsScript(path, tags)));
       } catch (e) {
-        const msg = e instanceof Error ? e.message : String(e);
-        return errJxa(`Failed to set tags: ${msg}`);
+        return errJxaFor("set tags", e);
       }
     },
   );
@@ -128,8 +125,7 @@ export function registerFinderTools(server: McpServer, _config: AirMcpConfig): v
       try {
         return okStructured(await runJxa(recentFilesScript(folder, days, limit)));
       } catch (e) {
-        const msg = e instanceof Error ? e.message : String(e);
-        return errJxa(`Failed to find recent files: ${msg}`);
+        return errJxaFor("find recent files", e);
       }
     },
   );
@@ -161,8 +157,7 @@ export function registerFinderTools(server: McpServer, _config: AirMcpConfig): v
       try {
         return okUntrustedStructured(await runJxa(listDirectoryScript(path, limit)));
       } catch (e) {
-        const msg = e instanceof Error ? e.message : String(e);
-        return errJxa(`Failed to list directory: ${msg}`);
+        return errJxaFor("list directory", e);
       }
     },
   );
@@ -184,8 +179,7 @@ export function registerFinderTools(server: McpServer, _config: AirMcpConfig): v
         resolveAndGuard(destination);
         return ok(await runJxa(moveFileScript(source, destination)));
       } catch (e) {
-        const msg = e instanceof Error ? e.message : String(e);
-        return errJxa(`Failed to move file: ${msg}`);
+        return errJxaFor("move file", e);
       }
     },
   );
@@ -205,8 +199,7 @@ export function registerFinderTools(server: McpServer, _config: AirMcpConfig): v
         resolveAndGuard(path);
         return ok(await runJxa(trashFileScript(path)));
       } catch (e) {
-        const msg = e instanceof Error ? e.message : String(e);
-        return errJxa(`Failed to trash file: ${msg}`);
+        return errJxaFor("trash file", e);
       }
     },
   );
@@ -226,8 +219,7 @@ export function registerFinderTools(server: McpServer, _config: AirMcpConfig): v
         resolveAndGuard(path);
         return ok(await runJxa(createFolderScript(path)));
       } catch (e) {
-        const msg = e instanceof Error ? e.message : String(e);
-        return errJxa(`Failed to create folder: ${msg}`);
+        return errJxaFor("create folder", e);
       }
     },
   );

--- a/src/location/tools.ts
+++ b/src/location/tools.ts
@@ -1,6 +1,6 @@
 import type { McpServer } from "../shared/mcp.js";
 import type { AirMcpConfig } from "../shared/config.js";
-import { ok, okUntrusted, errSwift } from "../shared/result.js";
+import { ok, okUntrusted, errSwiftFor } from "../shared/result.js";
 import { runSwift } from "../shared/swift.js";
 
 interface LocationResult {
@@ -37,8 +37,7 @@ export function registerLocationTools(server: McpServer, _config: AirMcpConfig):
       try {
         return okUntrusted(await runSwift<LocationResult>("get-location", "{}"));
       } catch (e) {
-        const msg = e instanceof Error ? e.message : String(e);
-        return errSwift(`Failed to get current location: ${msg}`);
+        return errSwiftFor("get current location", e);
       }
     },
   );
@@ -62,8 +61,7 @@ export function registerLocationTools(server: McpServer, _config: AirMcpConfig):
       try {
         return ok(await runSwift<LocationPermissionResult>("location-permission", "{}"));
       } catch (e) {
-        const msg = e instanceof Error ? e.message : String(e);
-        return errSwift(`Failed to get location permission: ${msg}`);
+        return errSwiftFor("get location permission", e);
       }
     },
   );

--- a/src/maps/tools.ts
+++ b/src/maps/tools.ts
@@ -2,7 +2,7 @@ import type { McpServer } from "../shared/mcp.js";
 import { z } from "zod";
 import { runJxa } from "../shared/jxa.js";
 import type { AirMcpConfig } from "../shared/config.js";
-import { ok, okLinked, okUntrusted, errJxa, errUpstream } from "../shared/result.js";
+import { ok, okLinked, okUntrusted, errJxaFor, errUpstreamFor } from "../shared/result.js";
 import {
   searchLocationScript,
   getDirectionsScript,
@@ -28,8 +28,7 @@ export function registerMapsTools(server: McpServer, _config: AirMcpConfig): voi
       try {
         return okLinked("search_maps", await runJxa(searchLocationScript(query)));
       } catch (e) {
-        const msg = e instanceof Error ? e.message : String(e);
-        return errJxa(`Failed to search location: ${msg}`);
+        return errJxaFor("search location", e);
       }
     },
   );
@@ -54,8 +53,7 @@ export function registerMapsTools(server: McpServer, _config: AirMcpConfig): voi
       try {
         return okUntrusted(await runJxa(getDirectionsScript(from, to, transportType)));
       } catch (e) {
-        const msg = e instanceof Error ? e.message : String(e);
-        return errJxa(`Failed to get directions: ${msg}`);
+        return errJxaFor("get directions", e);
       }
     },
   );
@@ -76,8 +74,7 @@ export function registerMapsTools(server: McpServer, _config: AirMcpConfig): voi
       try {
         return ok(await runJxa(dropPinScript(latitude, longitude, label)));
       } catch (e) {
-        const msg = e instanceof Error ? e.message : String(e);
-        return errJxa(`Failed to drop pin: ${msg}`);
+        return errJxaFor("drop pin", e);
       }
     },
   );
@@ -96,8 +93,7 @@ export function registerMapsTools(server: McpServer, _config: AirMcpConfig): voi
       try {
         return ok(await runJxa(openInMapsScript(address)));
       } catch (e) {
-        const msg = e instanceof Error ? e.message : String(e);
-        return errJxa(`Failed to open address: ${msg}`);
+        return errJxaFor("open address", e);
       }
     },
   );
@@ -119,8 +115,7 @@ export function registerMapsTools(server: McpServer, _config: AirMcpConfig): voi
       try {
         return okUntrusted(await runJxa(searchNearbyScript(query, latitude, longitude)));
       } catch (e) {
-        const msg = e instanceof Error ? e.message : String(e);
-        return errJxa(`Failed to search nearby: ${msg}`);
+        return errJxaFor("search nearby", e);
       }
     },
   );
@@ -141,8 +136,7 @@ export function registerMapsTools(server: McpServer, _config: AirMcpConfig): voi
       try {
         return ok(await runJxa(shareLocationScript(latitude, longitude, label)));
       } catch (e) {
-        const msg = e instanceof Error ? e.message : String(e);
-        return errJxa(`Failed to share location: ${msg}`);
+        return errJxaFor("share location", e);
       }
     },
   );
@@ -166,8 +160,7 @@ export function registerMapsTools(server: McpServer, _config: AirMcpConfig): voi
       try {
         return okUntrusted(await fetchGeocode(query));
       } catch (e) {
-        const msg = e instanceof Error ? e.message : String(e);
-        return errUpstream(`Failed to geocode: ${msg}`, { retryable: true });
+        return errUpstreamFor("geocode", e, { retryable: true });
       }
     },
   );
@@ -187,8 +180,7 @@ export function registerMapsTools(server: McpServer, _config: AirMcpConfig): voi
       try {
         return okUntrusted(await fetchReverseGeocode(latitude, longitude));
       } catch (e) {
-        const msg = e instanceof Error ? e.message : String(e);
-        return errUpstream(`Failed to reverse geocode: ${msg}`, { retryable: true });
+        return errUpstreamFor("reverse geocode", e, { retryable: true });
       }
     },
   );

--- a/src/reminders/tools.ts
+++ b/src/reminders/tools.ts
@@ -3,7 +3,7 @@ import { z } from "zod";
 import { runAutomation } from "../shared/automation.js";
 import { runSwift } from "../shared/swift.js";
 import type { AirMcpConfig } from "../shared/config.js";
-import { ok, okLinked, okLinkedStructured, okStructured, okUntrustedStructured, errJxa } from "../shared/result.js";
+import { ok, okLinked, okLinkedStructured, okStructured, okUntrustedStructured, errJxaFor } from "../shared/result.js";
 import type { MutationResult, DeleteResult } from "../shared/types.js";
 import {
   listReminderListsScript,
@@ -87,8 +87,7 @@ export function registerReminderTools(server: McpServer, _config: AirMcpConfig):
         });
         return okStructured({ lists: result });
       } catch (e) {
-        const msg = e instanceof Error ? e.message : String(e);
-        return errJxa(`Failed to list reminder lists: ${msg}`);
+        return errJxaFor("list reminder lists", e);
       }
     },
   );
@@ -157,8 +156,7 @@ export function registerReminderTools(server: McpServer, _config: AirMcpConfig):
         });
         return okLinkedStructured("list_reminders", result);
       } catch (e) {
-        const msg = e instanceof Error ? e.message : String(e);
-        return errJxa(`Failed to list reminders: ${msg}`);
+        return errJxaFor("list reminders", e);
       }
     },
   );
@@ -199,8 +197,7 @@ export function registerReminderTools(server: McpServer, _config: AirMcpConfig):
         });
         return okUntrustedStructured(result);
       } catch (e) {
-        const msg = e instanceof Error ? e.message : String(e);
-        return errJxa(`Failed to read reminder: ${msg}`);
+        return errJxaFor("read reminder", e);
       }
     },
   );
@@ -236,8 +233,7 @@ export function registerReminderTools(server: McpServer, _config: AirMcpConfig):
         });
         return okLinked("create_reminder", result);
       } catch (e) {
-        const msg = e instanceof Error ? e.message : String(e);
-        return errJxa(`Failed to create reminder: ${msg}`);
+        return errJxaFor("create reminder", e);
       }
     },
   );
@@ -286,8 +282,7 @@ export function registerReminderTools(server: McpServer, _config: AirMcpConfig):
         });
         return ok(result);
       } catch (e) {
-        const msg = e instanceof Error ? e.message : String(e);
-        return errJxa(`Failed to update reminder: ${msg}`);
+        return errJxaFor("update reminder", e);
       }
     },
   );
@@ -323,8 +318,7 @@ export function registerReminderTools(server: McpServer, _config: AirMcpConfig):
         });
         return ok(result);
       } catch (e) {
-        const msg = e instanceof Error ? e.message : String(e);
-        return errJxa(`Failed to complete reminder: ${msg}`);
+        return errJxaFor("complete reminder", e);
       }
     },
   );
@@ -352,8 +346,7 @@ export function registerReminderTools(server: McpServer, _config: AirMcpConfig):
         });
         return ok(result);
       } catch (e) {
-        const msg = e instanceof Error ? e.message : String(e);
-        return errJxa(`Failed to delete reminder: ${msg}`);
+        return errJxaFor("delete reminder", e);
       }
     },
   );
@@ -399,8 +392,7 @@ export function registerReminderTools(server: McpServer, _config: AirMcpConfig):
         });
         return okUntrustedStructured(result);
       } catch (e) {
-        const msg = e instanceof Error ? e.message : String(e);
-        return errJxa(`Failed to search reminders: ${msg}`);
+        return errJxaFor("search reminders", e);
       }
     },
   );
@@ -431,8 +423,7 @@ export function registerReminderTools(server: McpServer, _config: AirMcpConfig):
         });
         return ok(result);
       } catch (e) {
-        const msg = e instanceof Error ? e.message : String(e);
-        return errJxa(`Failed to create reminder list: ${msg}`);
+        return errJxaFor("create reminder list", e);
       }
     },
   );
@@ -463,8 +454,7 @@ export function registerReminderTools(server: McpServer, _config: AirMcpConfig):
         });
         return ok(result);
       } catch (e) {
-        const msg = e instanceof Error ? e.message : String(e);
-        return errJxa(`Failed to delete reminder list: ${msg}`);
+        return errJxaFor("delete reminder list", e);
       }
     },
   );
@@ -520,8 +510,7 @@ export function registerReminderTools(server: McpServer, _config: AirMcpConfig):
         );
         return ok(result);
       } catch (e) {
-        const msg = e instanceof Error ? e.message : String(e);
-        return errJxa(`Failed to create recurring reminder: ${msg}`);
+        return errJxaFor("create recurring reminder", e);
       }
     },
   );

--- a/src/screen/tools.ts
+++ b/src/screen/tools.ts
@@ -3,7 +3,7 @@ import { z } from "zod";
 import { readFile, stat, unlink } from "node:fs/promises";
 import { runJxa } from "../shared/jxa.js";
 import type { AirMcpConfig } from "../shared/config.js";
-import { okUntrusted, errJxa } from "../shared/result.js";
+import { okUntrusted, errJxaFor } from "../shared/result.js";
 import {
   captureScreenScript,
   captureWindowScript,
@@ -72,8 +72,7 @@ export function registerScreenTools(server: McpServer, _config: AirMcpConfig): v
       try {
         return await captureAndReturn(captureScreenScript(display));
       } catch (e) {
-        const msg = e instanceof Error ? e.message : String(e);
-        return errJxa(`Failed to capture screen: ${msg}`);
+        return errJxaFor("capture screen", e);
       }
     },
   );
@@ -104,8 +103,7 @@ export function registerScreenTools(server: McpServer, _config: AirMcpConfig): v
       try {
         return await captureAndReturn(captureWindowScript(appName));
       } catch (e) {
-        const msg = e instanceof Error ? e.message : String(e);
-        return errJxa(`Failed to capture window: ${msg}`);
+        return errJxaFor("capture window", e);
       }
     },
   );
@@ -133,8 +131,7 @@ export function registerScreenTools(server: McpServer, _config: AirMcpConfig): v
       try {
         return await captureAndReturn(captureAreaScript(x, y, width, height));
       } catch (e) {
-        const msg = e instanceof Error ? e.message : String(e);
-        return errJxa(`Failed to capture area: ${msg}`);
+        return errJxaFor("capture area", e);
       }
     },
   );
@@ -157,8 +154,7 @@ export function registerScreenTools(server: McpServer, _config: AirMcpConfig): v
       try {
         return okUntrusted(await runJxa(listWindowsScript()));
       } catch (e) {
-        const msg = e instanceof Error ? e.message : String(e);
-        return errJxa(`Failed to list windows: ${msg}`);
+        return errJxaFor("list windows", e);
       }
     },
   );
@@ -244,8 +240,7 @@ export function registerScreenTools(server: McpServer, _config: AirMcpConfig): v
           ],
         };
       } catch (e) {
-        const msg = e instanceof Error ? e.message : String(e);
-        return errJxa(`Failed to record screen: ${msg}`);
+        return errJxaFor("record screen", e);
       }
     },
   );

--- a/src/shared/result.ts
+++ b/src/shared/result.ts
@@ -186,6 +186,37 @@ export function errUnsupportedOS(message: string, opts?: ToolErrorOptions) {
 }
 
 /**
+ * Catch-block one-liners that pair an `err*` category with the same
+ * "Failed to <action>: <message>" prefix the legacy `toolError` used,
+ * but with the right `cause.origin` baked in. Use these in tool
+ * handlers to keep catch blocks to a single line:
+ *
+ *   } catch (e) {
+ *     return errJxaFor("list reminders", e);
+ *   }
+ *
+ * Each helper is a thin wrapper around its `err*` counterpart — the
+ * full options object (`hint`, `retryable`, `retryAfterMs`) is still
+ * available via the third arg when the catch needs to pass extras.
+ */
+function formatCauseMessage(action: string, e: unknown): string {
+  const raw = e instanceof Error ? e.message : String(e);
+  return `Failed to ${action}: ${raw}`;
+}
+
+export function errJxaFor(action: string, e: unknown, opts?: ToolErrorOptions) {
+  return errJxa(formatCauseMessage(action, e), opts);
+}
+
+export function errSwiftFor(action: string, e: unknown, opts?: ToolErrorOptions) {
+  return errSwift(formatCauseMessage(action, e), opts);
+}
+
+export function errUpstreamFor(action: string, e: unknown, opts?: ToolErrorOptions) {
+  return errUpstream(formatCauseMessage(action, e), opts);
+}
+
+/**
  * Standardized catch-block helper for tool handlers. Classifies the error
  * automatically and delegates to {@link toolErr} so every legacy caller also
  * gets the RFC 0001 `structuredContent.error` payload for free.

--- a/src/shortcuts/tools.ts
+++ b/src/shortcuts/tools.ts
@@ -4,7 +4,7 @@ import { execFile } from "node:child_process";
 import { promisify } from "node:util";
 import { runJxa } from "../shared/jxa.js";
 import type { AirMcpConfig } from "../shared/config.js";
-import { ok, okLinked, okLinkedStructured, okStructured, errJxa } from "../shared/result.js";
+import { ok, okLinked, okLinkedStructured, okStructured, errJxaFor } from "../shared/result.js";
 import { TIMEOUT } from "../shared/constants.js";
 import { zFilePath } from "../shared/validate.js";
 import {
@@ -56,8 +56,7 @@ export function registerShortcutsTools(server: McpServer, _config: AirMcpConfig)
       try {
         return okLinkedStructured("list_shortcuts", await runJxa<ShortcutsNameList>(listShortcutsScript()));
       } catch (e) {
-        const msg = e instanceof Error ? e.message : String(e);
-        return errJxa(`Failed to list shortcuts: ${msg}`);
+        return errJxaFor("list shortcuts", e);
       }
     },
   );
@@ -78,8 +77,7 @@ export function registerShortcutsTools(server: McpServer, _config: AirMcpConfig)
       try {
         return okLinked("run_shortcut", await runJxa(runShortcutScript(name, input)));
       } catch (e) {
-        const msg = e instanceof Error ? e.message : String(e);
-        return errJxa(`Failed to run shortcut: ${msg}`);
+        return errJxaFor("run shortcut", e);
       }
     },
   );
@@ -102,8 +100,7 @@ export function registerShortcutsTools(server: McpServer, _config: AirMcpConfig)
       try {
         return okStructured(await runJxa<ShortcutsNameList>(searchShortcutsScript(query)));
       } catch (e) {
-        const msg = e instanceof Error ? e.message : String(e);
-        return errJxa(`Failed to search shortcuts: ${msg}`);
+        return errJxaFor("search shortcuts", e);
       }
     },
   );
@@ -126,8 +123,7 @@ export function registerShortcutsTools(server: McpServer, _config: AirMcpConfig)
       try {
         return okStructured(await runJxa<ShortcutsDetail>(getShortcutDetailScript(name)));
       } catch (e) {
-        const msg = e instanceof Error ? e.message : String(e);
-        return errJxa(`Failed to get shortcut detail: ${msg}`);
+        return errJxaFor("get shortcut detail", e);
       }
     },
   );
@@ -147,8 +143,7 @@ export function registerShortcutsTools(server: McpServer, _config: AirMcpConfig)
       try {
         return ok(await runJxa(createShortcutScript(name)));
       } catch (e) {
-        const msg = e instanceof Error ? e.message : String(e);
-        return errJxa(`Failed to create shortcut: ${msg}`);
+        return errJxaFor("create shortcut", e);
       }
     },
   );
@@ -168,8 +163,7 @@ export function registerShortcutsTools(server: McpServer, _config: AirMcpConfig)
       try {
         return ok(await runJxa(deleteShortcutScript(name)));
       } catch (e) {
-        const msg = e instanceof Error ? e.message : String(e);
-        return errJxa(`Failed to delete shortcut: ${msg}`);
+        return errJxaFor("delete shortcut", e);
       }
     },
   );
@@ -192,8 +186,7 @@ export function registerShortcutsTools(server: McpServer, _config: AirMcpConfig)
       try {
         return ok(await runJxa(exportShortcutScript(name, outputPath)));
       } catch (e) {
-        const msg = e instanceof Error ? e.message : String(e);
-        return errJxa(`Failed to export shortcut: ${msg}`);
+        return errJxaFor("export shortcut", e);
       }
     },
   );
@@ -213,8 +206,7 @@ export function registerShortcutsTools(server: McpServer, _config: AirMcpConfig)
       try {
         return ok(await runJxa(importShortcutScript(filePath)));
       } catch (e) {
-        const msg = e instanceof Error ? e.message : String(e);
-        return errJxa(`Failed to import shortcut: ${msg}`);
+        return errJxaFor("import shortcut", e);
       }
     },
   );
@@ -235,8 +227,7 @@ export function registerShortcutsTools(server: McpServer, _config: AirMcpConfig)
       try {
         return ok(await runJxa(duplicateShortcutScript(name, newName)));
       } catch (e) {
-        const msg = e instanceof Error ? e.message : String(e);
-        return errJxa(`Failed to duplicate shortcut: ${msg}`);
+        return errJxaFor("duplicate shortcut", e);
       }
     },
   );
@@ -256,8 +247,7 @@ export function registerShortcutsTools(server: McpServer, _config: AirMcpConfig)
       try {
         return ok(await runJxa(editShortcutScript(name)));
       } catch (e) {
-        const msg = e instanceof Error ? e.message : String(e);
-        return errJxa(`Failed to open shortcut for editing: ${msg}`);
+        return errJxaFor("open shortcut for editing", e);
       }
     },
   );
@@ -321,8 +311,7 @@ export async function registerDynamicShortcutTools(server: McpServer): Promise<n
         try {
           return ok(await runJxa(runShortcutScript(name, input)));
         } catch (e) {
-          const msg = e instanceof Error ? e.message : String(e);
-          return errJxa(`Failed to run shortcut "${name}": ${msg}`);
+          return errJxaFor(`run shortcut "${name}"`, e);
         }
       },
     );

--- a/src/speech/tools.ts
+++ b/src/speech/tools.ts
@@ -2,7 +2,7 @@ import { z } from "zod";
 import type { McpServer } from "../shared/mcp.js";
 import type { AirMcpConfig } from "../shared/config.js";
 import { runSwift, checkSwiftBridge } from "../shared/swift.js";
-import { ok, okLinked, errSwift } from "../shared/result.js";
+import { ok, okLinked, errSwift, errSwiftFor } from "../shared/result.js";
 
 export function registerSpeechTools(server: McpServer, _config: AirMcpConfig): void {
   server.registerTool(
@@ -30,8 +30,7 @@ export function registerSpeechTools(server: McpServer, _config: AirMcpConfig): v
         );
         return okLinked("transcribe_audio", result);
       } catch (e) {
-        const msg = e instanceof Error ? e.message : String(e);
-        return errSwift(`Failed to transcribe audio: ${msg}`);
+        return errSwiftFor("transcribe audio", e);
       }
     },
   );
@@ -51,8 +50,7 @@ export function registerSpeechTools(server: McpServer, _config: AirMcpConfig): v
         const result = await runSwift<{ available: boolean; supportsOnDevice: boolean }>("speech-availability", "{}");
         return ok(result);
       } catch (e) {
-        const msg = e instanceof Error ? e.message : String(e);
-        return errSwift(`Failed to check speech availability: ${msg}`);
+        return errSwiftFor("check speech availability", e);
       }
     },
   );
@@ -81,8 +79,7 @@ export function registerSpeechTools(server: McpServer, _config: AirMcpConfig): v
         }>("pasteboard-smart", "{}");
         return ok(result);
       } catch (e) {
-        const msg = e instanceof Error ? e.message : String(e);
-        return errSwift(`Failed to read smart clipboard: ${msg}`);
+        return errSwiftFor("read smart clipboard", e);
       }
     },
   );

--- a/src/tv/tools.ts
+++ b/src/tv/tools.ts
@@ -2,7 +2,7 @@ import type { McpServer } from "../shared/mcp.js";
 import { z } from "zod";
 import { runJxa } from "../shared/jxa.js";
 import type { AirMcpConfig } from "../shared/config.js";
-import { ok, okUntrusted, errJxa } from "../shared/result.js";
+import { ok, okUntrusted, errJxaFor } from "../shared/result.js";
 import {
   listPlaylistsScript,
   listTracksScript,
@@ -25,8 +25,7 @@ export function registerTvTools(server: McpServer, _config: AirMcpConfig): void 
       try {
         return okUntrusted(await runJxa(listPlaylistsScript()));
       } catch (e) {
-        const msg = e instanceof Error ? e.message : String(e);
-        return errJxa(`Failed to list TV playlists: ${msg}`);
+        return errJxaFor("list TV playlists", e);
       }
     },
   );
@@ -46,8 +45,7 @@ export function registerTvTools(server: McpServer, _config: AirMcpConfig): void 
       try {
         return okUntrusted(await runJxa(listTracksScript(playlist, limit)));
       } catch (e) {
-        const msg = e instanceof Error ? e.message : String(e);
-        return errJxa(`Failed to list TV tracks: ${msg}`);
+        return errJxaFor("list TV tracks", e);
       }
     },
   );
@@ -64,8 +62,7 @@ export function registerTvTools(server: McpServer, _config: AirMcpConfig): void 
       try {
         return okUntrusted(await runJxa(nowPlayingScript()));
       } catch (e) {
-        const msg = e instanceof Error ? e.message : String(e);
-        return errJxa(`Failed to get TV now playing: ${msg}`);
+        return errJxaFor("get TV now playing", e);
       }
     },
   );
@@ -84,8 +81,7 @@ export function registerTvTools(server: McpServer, _config: AirMcpConfig): void 
       try {
         return ok(await runJxa(playbackControlScript(action)));
       } catch (e) {
-        const msg = e instanceof Error ? e.message : String(e);
-        return errJxa(`Failed to control TV playback: ${msg}`);
+        return errJxaFor("control TV playback", e);
       }
     },
   );
@@ -105,8 +101,7 @@ export function registerTvTools(server: McpServer, _config: AirMcpConfig): void 
       try {
         return okUntrusted(await runJxa(searchTracksScript(query, limit)));
       } catch (e) {
-        const msg = e instanceof Error ? e.message : String(e);
-        return errJxa(`Failed to search TV: ${msg}`);
+        return errJxaFor("search TV", e);
       }
     },
   );
@@ -125,8 +120,7 @@ export function registerTvTools(server: McpServer, _config: AirMcpConfig): void 
       try {
         return ok(await runJxa(playTrackScript(name)));
       } catch (e) {
-        const msg = e instanceof Error ? e.message : String(e);
-        return errJxa(`Failed to play TV content: ${msg}`);
+        return errJxaFor("play TV content", e);
       }
     },
   );

--- a/src/weather/tools.ts
+++ b/src/weather/tools.ts
@@ -1,7 +1,7 @@
 import type { McpServer } from "../shared/mcp.js";
 import { z } from "zod";
 import type { AirMcpConfig } from "../shared/config.js";
-import { okUntrusted, okUntrustedLinkedStructured, errUpstream } from "../shared/result.js";
+import { okUntrusted, okUntrustedLinkedStructured, errUpstreamFor } from "../shared/result.js";
 import { fetchCurrentWeather, fetchDailyForecast, fetchHourlyForecast } from "./api.js";
 
 export function registerWeatherTools(server: McpServer, _config: AirMcpConfig): void {
@@ -39,8 +39,7 @@ export function registerWeatherTools(server: McpServer, _config: AirMcpConfig): 
         const result = await fetchCurrentWeather(latitude, longitude);
         return okUntrustedLinkedStructured("get_current_weather", result);
       } catch (e) {
-        const msg = e instanceof Error ? e.message : String(e);
-        return errUpstream(`Failed to get current weather: ${msg}`, { retryable: true });
+        return errUpstreamFor("get current weather", e, { retryable: true });
       }
     },
   );
@@ -61,8 +60,7 @@ export function registerWeatherTools(server: McpServer, _config: AirMcpConfig): 
       try {
         return okUntrusted(await fetchDailyForecast(latitude, longitude, days));
       } catch (e) {
-        const msg = e instanceof Error ? e.message : String(e);
-        return errUpstream(`Failed to get daily forecast: ${msg}`, { retryable: true });
+        return errUpstreamFor("get daily forecast", e, { retryable: true });
       }
     },
   );
@@ -90,8 +88,7 @@ export function registerWeatherTools(server: McpServer, _config: AirMcpConfig): 
       try {
         return okUntrusted(await fetchHourlyForecast(latitude, longitude, hours));
       } catch (e) {
-        const msg = e instanceof Error ? e.message : String(e);
-        return errUpstream(`Failed to get hourly forecast: ${msg}`, { retryable: true });
+        return errUpstreamFor("get hourly forecast", e, { retryable: true });
       }
     },
   );


### PR DESCRIPTION
Found in the /simplify pass over the recent migration train (PRs #166/#168/#169/#170/#171/#172). Every catch block in the 13 migrated modules repeats the same 3-line pattern:

\`\`\`ts
} catch (e) {
  const msg = e instanceof Error ? e.message : String(e);
  return errJxa(\`Failed to <action>: \${msg}\`);
}
\`\`\`

## Helpers
Three thin wrappers in \`shared/result.ts\`:
- \`errJxaFor(action, e, opts?)\`
- \`errSwiftFor(action, e, opts?)\`
- \`errUpstreamFor(action, e, opts?)\`

Each formats the \`"Failed to <action>: <message>"\` prefix and forwards to the matching \`err*\` helper, which already auto-injects the right \`cause.origin\`. Catch blocks collapse to one line:

\`\`\`ts
} catch (e) {
  return errJxaFor("list reminders", e);
}
\`\`\`

## Modules updated
weather, bluetooth, location, tv, finder, screen, shortcuts (incl. dynamic shortcut wrapper with backtick action), speech, contacts, calendar, reminders, maps (mixed errJxaFor + errUpstreamFor for HTTP fetch tools).

## Net change
**13 files, +124 / -174 = −50 lines**. Behavior unchanged — same category, same \`cause.origin\`, same MCP response shape.

## Test plan
- [x] \`npm run typecheck\` — clean
- [x] \`npm test\` — 101 suites / 1626 tests pass
- [x] \`npm run lint\` — clean
- [x] Drift checks (gen-swift-intents, dump-tool-manifest, stats:check, llms:check) — all clean

## Future migrations
Remaining 11 modules (notes/photos/system/intelligence/ui/mail/health/music/podcasts/audit/memory/etc.) can use \`errXxxFor\` directly — no more catch-block boilerplate.