### PR TITLE
chore(swift): bump swift-tools-version 6.1 -> 6.3

### DIFF
--- a/app/Package.swift
+++ b/app/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 6.1
+// swift-tools-version: 6.3
 
 import PackageDescription
 

--- a/ios/Package.swift
+++ b/ios/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 6.1
+// swift-tools-version: 6.3
 
 import PackageDescription
 

--- a/swift/Package.swift
+++ b/swift/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 6.1
+// swift-tools-version: 6.3
 
 import PackageDescription
 


### PR DESCRIPTION
Retry the Swift toolchain bump that was reverted in PR #159 (CI runner had Swift 6.1.0 at the time).

## Why now
**Swift 6.3 GA'd 2026-03-24** ([release notes](https://www.swift.org/blog/whats-new-in-swift-april-2026/)) and ships in Xcode 26.4.1. If GitHub's \`macos-latest\` runner picked up that Xcode, the manifest now parses cleanly upstream.

## Changes
- \`swift/Package.swift\`, \`app/Package.swift\`, \`ios/Package.swift\` — \`swift-tools-version: 6.1\` → \`6.3\`

## Local note
Local toolchain is still 6.2.3 (CommandLineTools), so \`swift build\` won't run here — relying on CI for the verdict. TS-side typecheck/build/test pass (the bump is Swift-only).

## Plan if CI fails
Same as PR #159: revert the three Package.swift lines and re-merge. No risk to TS code.

## Test plan
- [x] \`npm run typecheck\` — clean
- [x] \`npm test\` — 101 suites / 1626 tests pass (Swift bump doesn't affect TS)
- [ ] CI Swift build job — this PR's actual gate