### PR TITLE
refactor(rfc0001): migrate photos + music to errXxxFor helpers

### DIFF
--- a/src/music/tools.ts
+++ b/src/music/tools.ts
@@ -2,7 +2,7 @@ import type { McpServer } from "../shared/mcp.js";
 import { z } from "zod";
 import { runJxa } from "../shared/jxa.js";
 import type { AirMcpConfig } from "../shared/config.js";
-import { ok, okLinkedStructured, okStructured, toolError } from "../shared/result.js";
+import { ok, okLinkedStructured, okStructured, errJxaFor } from "../shared/result.js";
 // Side-effect import: register the now_playing poller with the shared registry
 // at module load time. The poller itself only starts when startPollers() is
 // invoked by the cross/event observer tool.
@@ -54,7 +54,7 @@ export function registerMusicTools(server: McpServer, _config: AirMcpConfig): vo
           );
         return okStructured({ playlists });
       } catch (e) {
-        return toolError("list playlists", e);
+        return errJxaFor("list playlists", e);
       }
     },
   );
@@ -90,7 +90,7 @@ export function registerMusicTools(server: McpServer, _config: AirMcpConfig): vo
       try {
         return okStructured(await runJxa(listTracksScript(playlist, limit)));
       } catch (e) {
-        return toolError("list tracks", e);
+        return errJxaFor("list tracks", e);
       }
     },
   );
@@ -119,7 +119,7 @@ export function registerMusicTools(server: McpServer, _config: AirMcpConfig): vo
       try {
         return okLinkedStructured("now_playing", await runJxa(nowPlayingScript()));
       } catch (e) {
-        return toolError("get now playing", e);
+        return errJxaFor("get now playing", e);
       }
     },
   );
@@ -138,7 +138,7 @@ export function registerMusicTools(server: McpServer, _config: AirMcpConfig): vo
       try {
         return ok(await runJxa(playbackControlScript(action)));
       } catch (e) {
-        return toolError("control playback", e);
+        return errJxaFor("control playback", e);
       }
     },
   );
@@ -158,7 +158,7 @@ export function registerMusicTools(server: McpServer, _config: AirMcpConfig): vo
       try {
         return ok(await runJxa(searchTracksScript(query, limit)));
       } catch (e) {
-        return toolError("search tracks", e);
+        return errJxaFor("search tracks", e);
       }
     },
   );
@@ -178,7 +178,7 @@ export function registerMusicTools(server: McpServer, _config: AirMcpConfig): vo
       try {
         return ok(await runJxa(playTrackScript(trackName, playlist)));
       } catch (e) {
-        return toolError("play track", e);
+        return errJxaFor("play track", e);
       }
     },
   );
@@ -198,7 +198,7 @@ export function registerMusicTools(server: McpServer, _config: AirMcpConfig): vo
       try {
         return ok(await runJxa(playPlaylistScript(name, shuffle)));
       } catch (e) {
-        return toolError("play playlist", e);
+        return errJxaFor("play playlist", e);
       }
     },
   );
@@ -217,7 +217,7 @@ export function registerMusicTools(server: McpServer, _config: AirMcpConfig): vo
       try {
         return ok(await runJxa(getTrackInfoScript(trackName)));
       } catch (e) {
-        return toolError("get track info", e);
+        return errJxaFor("get track info", e);
       }
     },
   );
@@ -237,7 +237,7 @@ export function registerMusicTools(server: McpServer, _config: AirMcpConfig): vo
       try {
         return ok(await runJxa(setShuffleScript(shuffle, songRepeat)));
       } catch (e) {
-        return toolError("set shuffle/repeat", e);
+        return errJxaFor("set shuffle/repeat", e);
       }
     },
   );
@@ -256,7 +256,7 @@ export function registerMusicTools(server: McpServer, _config: AirMcpConfig): vo
       try {
         return ok(await runJxa(createPlaylistScript(name)));
       } catch (e) {
-        return toolError("create playlist", e);
+        return errJxaFor("create playlist", e);
       }
     },
   );
@@ -276,7 +276,7 @@ export function registerMusicTools(server: McpServer, _config: AirMcpConfig): vo
       try {
         return ok(await runJxa(addToPlaylistScript(playlistName, trackName)));
       } catch (e) {
-        return toolError("add to playlist", e);
+        return errJxaFor("add to playlist", e);
       }
     },
   );
@@ -296,7 +296,7 @@ export function registerMusicTools(server: McpServer, _config: AirMcpConfig): vo
       try {
         return ok(await runJxa(removeFromPlaylistScript(playlistName, trackName)));
       } catch (e) {
-        return toolError("remove from playlist", e);
+        return errJxaFor("remove from playlist", e);
       }
     },
   );
@@ -315,7 +315,7 @@ export function registerMusicTools(server: McpServer, _config: AirMcpConfig): vo
       try {
         return ok(await runJxa(deletePlaylistScript(name)));
       } catch (e) {
-        return toolError("delete playlist", e);
+        return errJxaFor("delete playlist", e);
       }
     },
   );
@@ -334,7 +334,7 @@ export function registerMusicTools(server: McpServer, _config: AirMcpConfig): vo
       try {
         return ok(await runJxa(getRatingScript(trackName)));
       } catch (e) {
-        return toolError("get rating", e);
+        return errJxaFor("get rating", e);
       }
     },
   );
@@ -355,7 +355,7 @@ export function registerMusicTools(server: McpServer, _config: AirMcpConfig): vo
       try {
         return ok(await runJxa(setRatingScript(trackName, rating)));
       } catch (e) {
-        return toolError("set rating", e);
+        return errJxaFor("set rating", e);
       }
     },
   );
@@ -375,7 +375,7 @@ export function registerMusicTools(server: McpServer, _config: AirMcpConfig): vo
       try {
         return ok(await runJxa(setFavoritedScript(trackName, favorited)));
       } catch (e) {
-        return toolError("set favorited", e);
+        return errJxaFor("set favorited", e);
       }
     },
   );
@@ -395,7 +395,7 @@ export function registerMusicTools(server: McpServer, _config: AirMcpConfig): vo
       try {
         return ok(await runJxa(setDislikedScript(trackName, disliked)));
       } catch (e) {
-        return toolError("set disliked", e);
+        return errJxaFor("set disliked", e);
       }
     },
   );

--- a/src/photos/tools.ts
+++ b/src/photos/tools.ts
@@ -3,7 +3,14 @@ import { z } from "zod";
 import { runSwift } from "../shared/swift.js";
 import { runAutomation } from "../shared/automation.js";
 import type { AirMcpConfig } from "../shared/config.js";
-import { ok, okUntrusted, okUntrustedLinkedStructured, okUntrustedStructured, toolError } from "../shared/result.js";
+import {
+  ok,
+  okUntrusted,
+  okUntrustedLinkedStructured,
+  okUntrustedStructured,
+  errJxaFor,
+  errSwiftFor,
+} from "../shared/result.js";
 import { zFilePath, resolveAndGuard } from "../shared/validate.js";
 import {
   listAlbumsScript,
@@ -109,7 +116,7 @@ export function registerPhotosTools(server: McpServer, _config: AirMcpConfig): v
         });
         return okUntrusted(result);
       } catch (e) {
-        return toolError("list albums", e);
+        return errJxaFor("list albums", e);
       }
     },
   );
@@ -153,7 +160,7 @@ export function registerPhotosTools(server: McpServer, _config: AirMcpConfig): v
         });
         return okUntrustedLinkedStructured("list_photos", result);
       } catch (e) {
-        return toolError("list photos", e);
+        return errJxaFor("list photos", e);
       }
     },
   );
@@ -193,7 +200,7 @@ export function registerPhotosTools(server: McpServer, _config: AirMcpConfig): v
         });
         return okUntrustedLinkedStructured("search_photos", result);
       } catch (e) {
-        return toolError("search photos", e);
+        return errJxaFor("search photos", e);
       }
     },
   );
@@ -234,7 +241,7 @@ export function registerPhotosTools(server: McpServer, _config: AirMcpConfig): v
         });
         return okUntrustedStructured(result);
       } catch (e) {
-        return toolError("get photo info", e);
+        return errJxaFor("get photo info", e);
       }
     },
   );
@@ -275,7 +282,7 @@ export function registerPhotosTools(server: McpServer, _config: AirMcpConfig): v
         });
         return okUntrustedLinkedStructured("list_favorites", result);
       } catch (e) {
-        return toolError("list favorites", e);
+        return errJxaFor("list favorites", e);
       }
     },
   );
@@ -301,7 +308,7 @@ export function registerPhotosTools(server: McpServer, _config: AirMcpConfig): v
         });
         return ok(result);
       } catch (e) {
-        return toolError("create album", e);
+        return errJxaFor("create album", e);
       }
     },
   );
@@ -328,7 +335,7 @@ export function registerPhotosTools(server: McpServer, _config: AirMcpConfig): v
         });
         return ok(result);
       } catch (e) {
-        return toolError("add photos to album", e);
+        return errJxaFor("add photos to album", e);
       }
     },
   );
@@ -356,7 +363,7 @@ export function registerPhotosTools(server: McpServer, _config: AirMcpConfig): v
         const result = await runSwift<PhotoImportResult>("import-photo", JSON.stringify({ filePath, albumName }));
         return ok(result);
       } catch (e) {
-        return toolError("import photo", e);
+        return errSwiftFor("import photo", e);
       }
     },
   );
@@ -382,7 +389,7 @@ export function registerPhotosTools(server: McpServer, _config: AirMcpConfig): v
         const result = await runSwift<PhotoDeleteResult>("delete-photos", JSON.stringify({ identifiers }));
         return ok(result);
       } catch (e) {
-        return toolError("delete photos", e);
+        return errSwiftFor("delete photos", e);
       }
     },
   );
@@ -413,7 +420,7 @@ export function registerPhotosTools(server: McpServer, _config: AirMcpConfig): v
         );
         return ok(result);
       } catch (e) {
-        return toolError("query photos", e);
+        return errSwiftFor("query photos", e);
       }
     },
   );
@@ -439,7 +446,7 @@ export function registerPhotosTools(server: McpServer, _config: AirMcpConfig): v
         );
         return ok(result);
       } catch (e) {
-        return toolError("classify image", e);
+        return errSwiftFor("classify image", e);
       }
     },
   );


### PR DESCRIPTION
## Changes

### \`photos/tools.ts\` (11 catches): split between transports
- **7 runAutomation tools** → \`errJxaFor\` (list_albums / list_photos / search_photos / get_photo_info / list_favorites / create_album / add_to_album). Per the runAutomation invariant doc-comment from PR #171, every error escapes via the JXA path.
- **4 runSwift tools** → \`errSwiftFor\` (import_photo / delete_photos / query_photos / classify_image). \`cause.origin = "swift"\` since these dispatch directly through the AirMCPKit bridge.

### \`music/tools.ts\` (17 catches): \`toolError\` → \`errJxaFor\`
Every tool dispatches via \`runJxa\` against the Music app scripting dictionary. \`cause.origin = "jxa"\` is correct for the typical failure modes (Music.app not running, scripting permission revoked, rate-limited Apple Music server reply).

## Adoption
21 → 23 of 32 \`tools.ts\` files on the typed helpers.

## Test plan
- [x] \`npm run typecheck\` — clean
- [x] \`npm test\` — 101 suites / 1626 tests pass (no behavior change)
- [x] \`npm run lint\` — clean