### PR TITLE
feat(observability): correlation id threaded through request-context, tool-registry, audit

### DIFF
--- a/src/shared/audit.ts
+++ b/src/shared/audit.ts
@@ -4,6 +4,7 @@ import { hostname, platform } from "node:os";
 import { createHmac } from "node:crypto";
 import { AUDIT, PATHS } from "./constants.js";
 import { assertTestMode, formatError } from "./errors.js";
+import { getCorrelationId } from "./request-context.js";
 
 const AUDIT_PATH = join(PATHS.VECTOR_STORE, "audit.jsonl");
 const AUDIT_DIR = PATHS.VECTOR_STORE;
@@ -16,6 +17,9 @@ interface AuditEntry {
   args?: Record<string, unknown>;
   status: "ok" | "error";
   durationMs?: number;
+  /** Correlation ID for cross-line tracing. Auto-populated from
+   *  request-context if not set explicitly by the caller. */
+  correlationId?: string;
 }
 
 /**
@@ -93,7 +97,11 @@ export function auditLog(entry: AuditEntry): void {
   } else if (entry.args) {
     sanitized = sanitizeArgs(entry.args);
   }
-  let line = JSON.stringify({ ...entry, args: sanitized });
+  // Auto-attach the active correlation ID when the caller didn't pass
+  // one. Falls through to undefined for synthetic / pre-context callers
+  // (e.g. startup banner, direct test invocations).
+  const correlationId = entry.correlationId ?? getCorrelationId();
+  let line = JSON.stringify({ ...entry, args: sanitized, correlationId });
   if (line.length > AUDIT.MAX_ENTRY_SIZE) {
     line = JSON.stringify({
       ...entry,

--- a/src/shared/request-context.ts
+++ b/src/shared/request-context.ts
@@ -26,6 +26,11 @@ export interface OAuthClaims {
 
 export interface RequestContext {
   oauth?: OAuthClaims;
+  /** Unique ID for the in-flight request / tool-call. Lets audit log
+   *  entries, telemetry traces, and error envelopes thread together
+   *  without manual plumbing through the SDK. Generated lazily by the
+   *  tool-registry wrapper if no upstream middleware set one. */
+  correlationId?: string;
 }
 
 const storage = new AsyncLocalStorage<RequestContext>();
@@ -42,4 +47,11 @@ export function getRequestContext(): RequestContext | undefined {
  *  call stack wasn't entered through an OAuth middleware. */
 export function getOAuthClaims(): OAuthClaims | undefined {
   return storage.getStore()?.oauth;
+}
+
+/** The correlation ID for the active request, or undefined if no
+ *  context has been entered. Audit / telemetry / error builders read
+ *  this so a single failing tool call can be traced across log lines. */
+export function getCorrelationId(): string | undefined {
+  return storage.getStore()?.correlationId;
 }

--- a/src/shared/tool-registry.ts
+++ b/src/shared/tool-registry.ts
@@ -22,7 +22,8 @@ import { withResultSizeHint } from "./result.js";
 import { traceToolCall } from "./telemetry.js";
 import { assertTestMode } from "./errors.js";
 import { checkRateLimit } from "./rate-limit.js";
-import { getOAuthClaims } from "./request-context.js";
+import { getOAuthClaims, getRequestContext, runWithRequestContext } from "./request-context.js";
+import { randomUUID } from "node:crypto";
 import { evaluateScopeGate } from "./oauth-scope.js";
 
 /** Threshold in characters above which we auto-attach a result size hint. */
@@ -235,21 +236,60 @@ class ToolRegistry {
 
         const entry = tools.get(name);
 
-        // OAuth scope gate (RFC 0005 §3.4 — Step 2). Runs BEFORE the
-        // rate-limit bucket so a token missing `mcp:destructive` can't
-        // burn the destructive bucket's budget just to hit a 403.
-        // Absence of claims means we're on a non-OAuth path (stdio,
-        // loopback, legacy Bearer) — skip the gate entirely.
-        const claims = getOAuthClaims();
-        if (claims) {
-          const decision = evaluateScopeGate({
-            toolName: name,
-            isReadOnly: entry?.readOnly === true,
-            isDestructive: entry?.destructive === true,
-            callerScopes: claims.scopes,
-          });
-          if (!decision.allowed) {
-            const msg = `[forbidden] scope ${decision.missing} required for tool "${name}"`;
+        // Stamp a correlation ID on the active context (or open one if
+        // the call came in over stdio with no upstream middleware) so
+        // every audit / telemetry / error line for this tool call shares
+        // an identifier. Honors any ID already set by a transport
+        // middleware so external tracing systems can drive it.
+        const existing = getRequestContext();
+        if (!existing?.correlationId) {
+          const ctx = { ...(existing ?? {}), correlationId: randomUUID() };
+          return runWithRequestContext(ctx, () => runWrapped());
+        }
+        return runWrapped();
+
+        async function runWrapped(): Promise<unknown> {
+          // OAuth scope gate (RFC 0005 §3.4 — Step 2). Runs BEFORE the
+          // rate-limit bucket so a token missing `mcp:destructive` can't
+          // burn the destructive bucket's budget just to hit a 403.
+          // Absence of claims means we're on a non-OAuth path (stdio,
+          // loopback, legacy Bearer) — skip the gate entirely.
+          const claims = getOAuthClaims();
+          if (claims) {
+            const decision = evaluateScopeGate({
+              toolName: name,
+              isReadOnly: entry?.readOnly === true,
+              isDestructive: entry?.destructive === true,
+              callerScopes: claims.scopes,
+            });
+            if (!decision.allowed) {
+              const msg = `[forbidden] scope ${decision.missing} required for tool "${name}"`;
+              if (process.env.AIRMCP_AUDIT_LOG !== "false") {
+                auditLog({
+                  timestamp: new Date().toISOString(),
+                  tool: name,
+                  args: args[0] as Record<string, unknown>,
+                  status: "error",
+                });
+              }
+              throw new Error(msg);
+            }
+          }
+
+          // Rate-limit + emergency-stop gate. Runs before the call reaches
+          // the handler so a runaway agent burning through the bucket can
+          // never touch the filesystem/APIs on the denied call. Denials
+          // throw so the error is captured by audit and surfaces to the
+          // caller with the same shape as any other failure.
+          // Tenant isolation: when OAuth claims are present (HTTP transport),
+          // the bucket is keyed on the JWT subject so one tenant's runaway
+          // agent can't exhaust budget for everyone else. Stdio / loopback
+          // share the default tenant.
+          const gate = checkRateLimit(entry?.destructive === true, claims?.subject);
+          if (!gate.allowed) {
+            const msg = `[rate_limited] ${gate.reason ?? "Rate limit exceeded"}${
+              gate.retryAfterMs ? ` (retry in ~${Math.ceil(gate.retryAfterMs / 1000)}s)` : ""
+            }`;
             if (process.env.AIRMCP_AUDIT_LOG !== "false") {
               auditLog({
                 timestamp: new Date().toISOString(),
@@ -260,67 +300,42 @@ class ToolRegistry {
             }
             throw new Error(msg);
           }
-        }
 
-        // Rate-limit + emergency-stop gate. Runs before the call reaches
-        // the handler so a runaway agent burning through the bucket can
-        // never touch the filesystem/APIs on the denied call. Denials
-        // throw so the error is captured by audit and surfaces to the
-        // caller with the same shape as any other failure.
-        // Tenant isolation: when OAuth claims are present (HTTP transport),
-        // the bucket is keyed on the JWT subject so one tenant's runaway
-        // agent can't exhaust budget for everyone else. Stdio / loopback
-        // share the default tenant.
-        const gate = checkRateLimit(entry?.destructive === true, claims?.subject);
-        if (!gate.allowed) {
-          const msg = `[rate_limited] ${gate.reason ?? "Rate limit exceeded"}${
-            gate.retryAfterMs ? ` (retry in ~${Math.ceil(gate.retryAfterMs / 1000)}s)` : ""
-          }`;
-          if (process.env.AIRMCP_AUDIT_LOG !== "false") {
-            auditLog({
-              timestamp: new Date().toISOString(),
-              tool: name,
-              args: args[0] as Record<string, unknown>,
-              status: "error",
-            });
-          }
-          throw new Error(msg);
-        }
-
-        const execute = async () => {
-          const start = Date.now();
-          try {
-            let result = await handler(...args);
-            if (process.env.AIRMCP_AUDIT_LOG !== "false") {
-              auditLog({
-                timestamp: new Date(start).toISOString(),
-                tool: name,
-                args: args[0] as Record<string, unknown>,
-                status: "ok",
-                durationMs: Date.now() - start,
-              });
+          const execute = async () => {
+            const start = Date.now();
+            try {
+              let result = await handler(...args);
+              if (process.env.AIRMCP_AUDIT_LOG !== "false") {
+                auditLog({
+                  timestamp: new Date(start).toISOString(),
+                  tool: name,
+                  args: args[0] as Record<string, unknown>,
+                  status: "ok",
+                  durationMs: Date.now() - start,
+                });
+              }
+              result = autoSizeHint(result);
+              return result;
+            } catch (e) {
+              if (process.env.AIRMCP_AUDIT_LOG !== "false") {
+                auditLog({
+                  timestamp: new Date(start).toISOString(),
+                  tool: name,
+                  args: args[0] as Record<string, unknown>,
+                  status: "error",
+                  durationMs: Date.now() - start,
+                });
+              }
+              throw e;
             }
-            result = autoSizeHint(result);
-            return result;
-          } catch (e) {
-            if (process.env.AIRMCP_AUDIT_LOG !== "false") {
-              auditLog({
-                timestamp: new Date(start).toISOString(),
-                tool: name,
-                args: args[0] as Record<string, unknown>,
-                status: "error",
-                durationMs: Date.now() - start,
-              });
-            }
-            throw e;
-          }
-        };
+          };
 
-        if (process.env.AIRMCP_TELEMETRY === "true") {
-          const toolArgs = args[0] as Record<string, unknown> | undefined;
-          return traceToolCall(name, toolArgs ? Object.keys(toolArgs).length : 0, execute);
+          if (process.env.AIRMCP_TELEMETRY === "true") {
+            const toolArgs = args[0] as Record<string, unknown> | undefined;
+            return traceToolCall(name, toolArgs ? Object.keys(toolArgs).length : 0, execute);
+          }
+          return execute();
         }
-        return execute();
       }) as AnyFn;
     };
 

--- a/tests/request-context.test.js
+++ b/tests/request-context.test.js
@@ -14,7 +14,7 @@
  */
 import { describe, test, expect } from '@jest/globals';
 
-const { runWithRequestContext, getRequestContext, getOAuthClaims } = await import(
+const { runWithRequestContext, getRequestContext, getOAuthClaims, getCorrelationId } = await import(
   '../dist/shared/request-context.js'
 );
 
@@ -140,6 +140,45 @@ describe('request-context — isolation', () => {
       });
       // Outer store restored after the nested run unwinds.
       expect(getOAuthClaims()).toBe(outer);
+    });
+  });
+});
+
+describe('request-context — correlation ID', () => {
+  test('getCorrelationId is undefined outside a context', () => {
+    expect(getCorrelationId()).toBeUndefined();
+  });
+
+  test('correlationId returned verbatim when set', () => {
+    runWithRequestContext({ correlationId: 'corr-abc-123' }, () => {
+      expect(getCorrelationId()).toBe('corr-abc-123');
+    });
+  });
+
+  test('correlationId persists across an await boundary', async () => {
+    const got = await runWithRequestContext({ correlationId: 'corr-async' }, async () => {
+      await Promise.resolve();
+      return getCorrelationId();
+    });
+    expect(got).toBe('corr-async');
+  });
+
+  test('concurrent contexts do not see each other’s correlation IDs', async () => {
+    const branch = (id, holdMs) =>
+      runWithRequestContext({ correlationId: id }, async () => {
+        await new Promise((r) => setTimeout(r, holdMs));
+        return getCorrelationId();
+      });
+    const [a, b] = await Promise.all([branch('A', 10), branch('B', 1)]);
+    expect(a).toBe('A');
+    expect(b).toBe('B');
+  });
+
+  test('correlationId coexists with oauth claims', () => {
+    const oauth = baseClaims({ subject: 'alice' });
+    runWithRequestContext({ oauth, correlationId: 'corr-and-oauth' }, () => {
+      expect(getCorrelationId()).toBe('corr-and-oauth');
+      expect(getOAuthClaims()).toBe(oauth);
     });
   });
 });


### PR DESCRIPTION
Async tool calls were untraceable across log lines — an audit entry, a telemetry trace, and a thrown error from the same call had no shared identifier so debugging required reconstructing wall-clock timing. Adds a \`correlationId\` field that the tool-registry wrapper stamps once per call (or honors an upstream-provided one from a transport middleware) and that the audit module reads automatically.

## Changes

- **\`shared/request-context.ts\`** — \`RequestContext\` gains \`correlationId\` (optional). New \`getCorrelationId()\` helper.
- **\`shared/tool-registry.ts\`** — wrapper opens a \`runWithRequestContext\` scope on first entry and stamps a \`randomUUID()\` correlation ID. If the call already arrived inside a context with a correlationId set (e.g. an HTTP middleware seeded one for distributed tracing), the existing ID is honored.
- **\`shared/audit.ts\`** — \`auditLog\` auto-attaches the active correlationId to every entry; explicit caller-supplied IDs win. \`AuditEntry\` shape documents the field.

## Tests
+5 cases in \`tests/request-context.test.js\` covering:
- absence (\`getCorrelationId()\` undefined outside context)
- verbatim return when set
- await-boundary persistence
- concurrent isolation (Promise.all branches see only their own ID)
- coexistence with OAuth claims

## Adoption path
- audit log entries already in production keep working — \`correlationId\` is optional in the JSON shape
- HTTP transport middleware can seed an inbound \`Request-Id\` header into the context for distributed tracing systems

## Test plan
- [x] \`npm run typecheck\` — clean
- [x] \`npm test\` — 101 suites / 1631 tests pass (was 1626; +5 new)
- [x] \`npm run lint\` — clean