### PR TITLE
docs(rfc): add 0008 elicitation + 0009 iwork-depth drafts

### DIFF
--- a/docs/rfc/0008-elicitation.md
+++ b/docs/rfc/0008-elicitation.md
@@ -1,0 +1,107 @@
+# RFC 0008 — MCP Elicitation for destructive tools
+
+- **Status**: Draft (May 2026)
+- **Author**: heznpc + Claude
+- **Created**: 2026-05-07
+- **Target**: v2.13.0 (Phase 1 — confirmation prompts) · v3.0.0 (Phase 2 — form/URL elicit)
+- **Related**: [`@modelcontextprotocol/sdk` 1.29.0 elicitInput API](https://github.com/modelcontextprotocol/typescript-sdk),
+  [MCP Elicitation spec (draft)](https://modelcontextprotocol.io/specification/draft/client/elicitation),
+  [GitHub Copilot blog — MCP elicitation](https://github.blog/ai-and-ml/github-copilot/building-smarter-interactions-with-mcp-elicitation-from-clunky-tool-calls-to-seamless-user-experiences/),
+  RFC 0001 (error categories), RFC 0007 (App Intent bridge — destructive HITL)
+
+---
+
+## 1. Motivation
+
+Destructive AirMCP tools (`delete_*`, `bulk_move_*`, `send_*`, `quit_app`, `system_power`) currently fall back to one of two patterns:
+
+1. **HITL guard via macOS confirmation dialog** (`requestConfirmation` from RFC 0007 §A.3). Works inside Apple App Intents / Shortcuts / Siri but invisible to plain MCP clients (Claude Desktop, Cursor, Windsurf).
+2. **No prompt at all** — the model has to decide "should I delete?" on its own. With OAuth `mcp:destructive` scope (RFC 0005) and rate-limit buckets (PR #159) we cap blast radius, but the per-call decision is still on the LLM.
+
+MCP Elicitation (June 2025 spec, mature in 2026) standardizes a **server-driven, mid-tool-call user prompt**. The server pauses, sends `elicitation/create` to the client, the client renders the form, the user responds, the server resumes. Effectively the same UX HITL gives App Intents, but over the MCP wire so Claude Desktop / Cursor / etc. can render it natively.
+
+Result of the existing `iwork_mcp` survey + Anthropic SDK 1.29.0 inspection:
+- Server SDK already exposes `server.elicitInput(params, options)` returning an `ElicitResult`.
+- Two modes: **form** (schema-described inputs) and **URL** (out-of-band browser flow).
+- Client capability advertised in the `initialize` handshake — clients that don't support elicitation reject the request with a known error code.
+
+## 2. Goal
+
+Wrap every tool whose `annotations.destructiveHint = true` with a **confirmation elicit** that fires automatically when the client supports elicitation, falls back to the existing HITL guard when it doesn't, and never blocks tools that aren't destructive.
+
+### Non-goals (Phase 1)
+
+- Form-based parameter capture (e.g. "ask the user for the new note title before creating it"). Kept for Phase 2 — Phase 1 is binary confirm / cancel only.
+- URL-based elicitation (OAuth-style consent flows). Out of scope until a tool actually needs it.
+- Custom elicitation surfaces inside App Intents (Apple's `requestConfirmation` already covers that path; keep RFC 0007 §A.3 verbatim).
+
+## 3. Design
+
+### 3.1 Wrapper placement
+
+```
+ToolRegistry.wrapHandler
+  ├── usage tracker
+  ├── correlation-id stamp           (PR #190)
+  ├── OAuth scope gate                (RFC 0005 §3.4)
+  ├── rate-limit gate                 (per-tenant, PR #159)
+  ├── ⭑ elicitation gate (NEW)        ── Phase 1 ──
+  ├── HITL guard (App Intents only)   (RFC 0007 §A.3)
+  └── execute(handler)
+```
+
+The elicit gate runs **after** OAuth + rate-limit (so a denied call doesn't surface a UI prompt) and **before** the handler (so a cancellation prevents side effects).
+
+### 3.2 Capability detection
+
+```ts
+// At handler entry, peek at the active server's negotiated capabilities.
+const supportsElicit = server.getClientCapabilities()?.elicitation != null;
+if (entry?.destructive && supportsElicit) {
+  const decision = await server.elicitInput({
+    mode: "form",
+    title: `Confirm: ${entry.title ?? name}`,
+    schema: { type: "boolean", description: `Run \`${name}\` with the supplied arguments?` },
+    elicitationId: getCorrelationId() ?? randomUUID(),
+  });
+  if (decision.kind === "cancel" || decision.value !== true) {
+    auditLog({ tool: name, status: "error", correlationId: getCorrelationId(), args: { _hitl_cancelled: true } });
+    throw new Error(`[hitl_cancelled] User declined ${name}`);
+  }
+}
+```
+
+Cancellation = audit "error" + RFC 0001 `hitl_timeout` category (re-purposed: same shape, different cause).
+
+### 3.3 Backwards compatibility
+
+| Client capability | macOS surface | Behavior |
+|--|--|--|
+| Elicitation supported | Any | New elicit prompt before call |
+| Elicitation **not** supported | App Intents (Shortcuts/Siri/Spotlight) | RFC 0007 §A.3 `requestConfirmation` (existing) |
+| Elicitation **not** supported | HTTP / stdio | No prompt — rate-limit + scope gate are the only safety net (today's behavior) |
+
+`AIRMCP_ELICITATION_DISABLE=true` env opt-out for users who script destructive tools end-to-end and don't want UI prompts.
+
+### 3.4 Audit + correlation-id
+
+Every elicit decision logs an audit entry threaded by the call's `correlationId` (from PR #190): the original tool call entry, the elicit decision, and any error all carry the same ID so log analysis is one `grep`.
+
+## 4. Phase 2 (deferred to v3.0.0)
+
+- **Form mode** — capture missing required params instead of returning an `errInvalidInput`. Useful for `create_event(summary)` when the LLM forgot to supply `summary`.
+- **URL mode** — OAuth-style consent flows for tools that touch personal data (e.g. `health_*` requesting fresh authorization).
+- **Capability-driven affordances** — surface "this tool will ask for confirmation" in `tools/list` so the model knows ahead of time. Requires a new field in the MCP tool description SEP.
+
+## 5. Open questions
+
+1. **Should the prompt show the args?** Defaults to "yes, sanitized via `sanitizeArgs`" — same path the audit log uses. Skipping args risks the user approving the wrong action.
+2. **Should AppIntent calls also route through the elicit gate?** Currently no — App Intents have native confirmations. Doubling up creates dialog fatigue. Re-evaluate when Apple ships system MCP and the `requestConfirmation` API may merge with elicitation.
+3. **Cancellation taxonomy** — do we need a distinct `cancelled` category in RFC 0001, separate from `hitl_timeout`? Probably yes; user cancel is a different signal than client-side timeout.
+
+## 6. Rollout plan
+
+1. **Phase 1.0** — `elicitInput` wrapper for destructive tools, capability-gated, env-opt-out. Unit tests against an in-process MCP test client that supports elicitation.
+2. **Phase 1.1** — Audit log integration (correlationId thread).
+3. **Phase 1.2** — Doctor / `audit_summary` surfaces "elicit cancelled" stats.
+4. **Phase 2** — Form/URL modes (separate RFC, post-v3.0.0).

--- a/docs/rfc/0009-iwork-depth.md
+++ b/docs/rfc/0009-iwork-depth.md
@@ -1,0 +1,89 @@
+# RFC 0009 — iWork (Pages / Numbers / Keynote) coverage depth
+
+- **Status**: Draft (May 2026)
+- **Author**: heznpc + Claude
+- **Created**: 2026-05-07
+- **Target**: v2.13.0 (Phase 1 — read + structured edit) · v3.0.0 (Phase 2 — formula / template / chart codegen)
+- **Related**: [`reichenbach/iwork_mcp` — 113 tools reference](https://github.com/reichenbach/iwork_mcp),
+  [`easychen/keynote-mcp`](https://github.com/easychen/keynote-mcp),
+  AirMCP `src/pages/`, `src/numbers/`, `src/keynote/`, RFC 0001 (error categories), RFC 0006 (Swift schema dump)
+
+---
+
+## 1. Motivation
+
+May 2026 competitive scan found `reichenbach/iwork_mcp` shipping **113 tools** for Pages / Numbers / Keynote with charts, master slides, formula injection, batch ops, template discovery. AirMCP's iWork modules cover the basics (open / list / read / write title-and-body) but stop well short of "knowledge worker can actually replace their iWork workflow with MCP."
+
+Three tiers of friction the gap creates:
+
+1. **iWork power users will pick the specialist** for any task that touches structured data — Numbers cell formulas, Keynote master slide propagation, Pages section/style manipulation. AirMCP's "30+ Apple apps" pitch loses on depth.
+2. **Apple Intelligence / Foundation Models on-device LLMs** can't drive iWork from natural language without rich tool affordances. The whole RFC 0007 "AppIntent bridge" thesis assumes the underlying tools cover the operations the user verbalizes.
+3. **`iwork_mcp` is Python-based** — a TypeScript / JXA-native AirMCP equivalent is a real differentiator (no separate runtime, plugs into the existing audit / OAuth / rate-limit infrastructure).
+
+## 2. Goal
+
+Bring iWork coverage to **competitive parity** with `iwork_mcp` (~80% of its tool surface) within v2.13.0, then exceed it on the structured-edit + Apple Intelligence integration axis in v3.0.0.
+
+### Non-goals
+
+- Pages / Numbers / Keynote **rendering** (PDF / HTML preview). The Apple apps already render natively — AirMCP shouldn't reimplement.
+- Cloud iWork (iCloud-only sync, browser editor). JXA can't reach those; out of scope.
+- Replacing the iWork apps. AirMCP scripts the local apps; users still see the canonical UI.
+
+## 3. Current state (May 2026)
+
+| Module | Tool count | Coverage notes |
+|--|--|--|
+| `pages/` | TBD (audit at PR-time) | Open + read + likely body-set |
+| `numbers/` | TBD | Open + table / cell minimal |
+| `keynote/` | TBD | Open + slide list / append minimal |
+| `iwork_mcp` (reference) | 113 | Tables, charts, formulas, master slides, batch ops, templates |
+
+A pre-implementation audit (separate task) needs to count exactly what AirMCP ships today and produce a tool-by-tool gap matrix.
+
+## 4. Phase 1 — read + structured edit (v2.13.0)
+
+Targets **40-50 new tools** spanning the high-value workflows. Each module gets a focused sprint.
+
+### 4.1 Numbers (highest demand)
+- **Read**: `numbers_list_sheets`, `numbers_list_tables`, `numbers_read_cell_range`, `numbers_get_formula`, `numbers_list_charts`
+- **Edit**: `numbers_set_cell`, `numbers_set_range` (CSV / 2D-array input), `numbers_set_formula`, `numbers_insert_row`, `numbers_insert_column`, `numbers_delete_row`, `numbers_delete_column`, `numbers_rename_sheet`
+- **Structure**: `numbers_create_sheet`, `numbers_duplicate_sheet`, `numbers_create_table`, `numbers_resize_table`
+
+### 4.2 Pages
+- **Read**: `pages_get_section_count`, `pages_read_section`, `pages_list_styles`, `pages_get_word_count`, `pages_list_links`
+- **Edit**: `pages_insert_section`, `pages_apply_style`, `pages_replace_text`, `pages_insert_image_at`, `pages_insert_table_at`
+- **Structure**: `pages_set_page_break`, `pages_set_header`, `pages_set_footer`
+
+### 4.3 Keynote
+- **Read**: `keynote_list_master_slides`, `keynote_get_slide_layout`, `keynote_get_presenter_notes`, `keynote_list_transitions`
+- **Edit**: `keynote_insert_slide_at`, `keynote_apply_master`, `keynote_set_slide_layout`, `keynote_set_presenter_notes`, `keynote_reorder_slides`, `keynote_duplicate_slide`
+- **Structure**: `keynote_set_theme`, `keynote_set_slide_size`
+
+### 4.4 Cross-cutting
+- All new tools use the RFC 0001 typed error helpers (`errJxaFor`) — established in PR #173.
+- Every tool registers an `outputSchema` for drift guards (Wave 5+ pattern from PR #158, #185).
+- Per-app pollers for unsaved-state detection (Pages "modified" indicator) folded into the existing `pollers.ts` infrastructure.
+
+## 5. Phase 2 — Formula codegen / template introspection (v3.0.0)
+
+- **Numbers formula generation** — natural-language → Numbers formula compiler. Hooks into Apple Intelligence Foundation Models for on-device translation.
+- **Keynote master propagation** — apply a layout / theme change across every slide that uses a given master. Requires walking the master-detail relationship via JXA.
+- **Pages template introspection** — list Apple-bundled templates + extract style / layout metadata so a user can clone style without copy-paste.
+- **Chart manipulation** — read / set chart data, type, series labels. Highest JXA complexity; deferred behind everything else.
+
+## 6. Risks
+
+1. **JXA scripting dictionary inconsistency** — Apple's iWork apps have notoriously partial AppleScript dictionaries. Each tool needs a JXA reachability probe in `airmcp doctor`.
+2. **Performance on large spreadsheets** — `numbers_read_cell_range` on a 10K-row table via JXA is slow. Phase 1 caps range size at 1000 cells; Phase 2 might need a Swift bridge fast path via `iWorkKit` if Apple ever exposes one.
+3. **Discoverability bloat** — adding 40+ tools doubles the iWork manifest. Compact descriptions (RFC 0007 §A.0) + tool grouping in `discover_tools` already mitigate; will need to re-run `npm run tokens` (PR #165) to confirm context budget.
+
+## 7. Rollout plan
+
+1. **Audit PR** — count current `pages/`, `numbers/`, `keynote/` tools; produce a gap matrix versus `iwork_mcp`.
+2. **Numbers sprint** — 17 new tools (§4.1) in 3-4 PRs grouped by surface (read / edit / structure).
+3. **Pages sprint** — 13 new tools (§4.2).
+4. **Keynote sprint** — 13 new tools (§4.3).
+5. **Phase 2 RFC** — separate document once Phase 1 lands and we've measured token-budget impact.
+
+Each sprint follows the established AirMCP pattern: feature flag → RFC 0001 typed errors → outputSchema drift guards → audit / OAuth / rate-limit gates inherit automatically.

--- a/docs/rfc/README.md
+++ b/docs/rfc/README.md
@@ -90,6 +90,8 @@ Draft ──► Proposed ──► Accepted ──► Implemented
 | [0005](./0005-oauth-resource-indicators.md) | OAuth 2.1 + Resource Indicators (MCP 2025-06-18 spec)         | Draft  | v2.11.0                                            |
 | [0006](./0006-swift-bridge-schema-dump.md)  | Swift Bridge `--dump-example-output` for True Schema Contract | Draft  | v2.12.0                                            |
 | [0007](./0007-app-intent-bridge.md)         | MCP Tool ↔ App Intent Auto-Bridge (2-phase)                   | Draft  | v2.13.0+ (Phase A) · Apple-API-dependent (Phase B) |
+| [0008](./0008-elicitation.md)               | MCP Elicitation for destructive tools                         | Draft  | v2.13.0 (Phase 1) · v3.0.0 (Phase 2)               |
+| [0009](./0009-iwork-depth.md)               | iWork (Pages / Numbers / Keynote) coverage depth              | Draft  | v2.13.0 (Phase 1) · v3.0.0 (Phase 2)               |
 
 ## 관련 문서
 


### PR DESCRIPTION
Two design drafts captured from the May 2026 competitive scan to scope upcoming work without committing implementation in this PR.

## RFC 0008 — MCP Elicitation for destructive tools

- \`@modelcontextprotocol/sdk\` 1.29.0 already exposes \`server.elicitInput()\` — verified by inspecting node_modules
- **Phase 1**: confirmation-only elicit wrapper for \`destructiveHint=true\` tools. Capability-gated (only when client advertises \`elicitation\`), env-opt-out (\`AIRMCP_ELICITATION_DISABLE=true\`), threads through \`correlationId\` (PR #190) for the audit trail
- **Phase 2** deferred: form-mode parameter capture, URL-mode consent flows, capability-driven \"this tool will prompt\" hint in \`tools/list\`

Backwards compatibility matrix:
- Elicitation client → new prompt
- App Intents → existing \`requestConfirmation\` (RFC 0007 §A.3)
- Plain HTTP/stdio without elicit → today's behavior (rate-limit + scope gate)

## RFC 0009 — iWork (Pages / Numbers / Keynote) coverage depth

- Pre-implementation gap audit vs \`iwork_mcp\` (113-tool reference)
- **Phase 1** (~40 new tools): Numbers cell/range/formula CRUD, Pages section/style ops, Keynote master/layout/transitions
- **Phase 2** deferred: NL→formula codegen via Foundation Models, master propagation, chart manipulation
- **Risks** captured: JXA dictionary inconsistency, large-spreadsheet performance, context-budget bloat (re-run \`npm run tokens\` after Phase 1)

## Test plan
- [x] docs-only PR — no code, no test changes
- [x] RFC index updated (\`docs/rfc/README.md\`) with both new entries