### PR TITLE
feat(audit): broaden sensitive patterns + correlationId tests + hmac corruption signal

### DIFF
--- a/src/shared/audit.ts
+++ b/src/shared/audit.ts
@@ -62,9 +62,21 @@ let chainResumed = false;
  * even truncated. Matching tool calls get their args replaced with a single
  * `_redacted` marker. The audit log already lives behind 0600 permissions,
  * but defense-in-depth: a single accidental share of audit.jsonl shouldn't
- * leak the user's location coordinates or health metrics.
+ * leak the user's location coordinates, health metrics, or OAuth tokens.
  */
-const SENSITIVE_TOOL_PATTERNS: RegExp[] = [/^get_current_location$/, /^get_location_permission$/, /^health_/];
+const SENSITIVE_TOOL_PATTERNS: RegExp[] = [
+  /^get_current_location$/,
+  /^get_location_permission$/,
+  /^health_/,
+  // OAuth / credential surface (RFC 0005). Tokens, refresh tokens, scope
+  // grants — anything an attacker could replay against an authorization
+  // server. Conservative pattern; tools that legitimately need to log
+  // their args can opt out by living outside this pattern.
+  /^oauth_/,
+  /password/i,
+  /credential/i,
+  /token/i,
+];
 
 function isSensitiveTool(name: string): boolean {
   return SENSITIVE_TOOL_PATTERNS.some((re) => re.test(name));
@@ -158,6 +170,7 @@ async function resumeChainHead(): Promise<void> {
   try {
     const raw = await readFile(AUDIT_PATH, "utf-8");
     const lines = raw.trimEnd().split("\n");
+    let malformedCount = 0;
     for (let i = lines.length - 1; i >= 0; i--) {
       const line = lines[i];
       if (!line) continue;
@@ -165,11 +178,23 @@ async function resumeChainHead(): Promise<void> {
         const parsed = JSON.parse(line) as { _hmac?: string };
         if (parsed._hmac && /^[0-9a-f]{64}$/.test(parsed._hmac)) {
           lastHmac = parsed._hmac;
+          if (malformedCount > 0) {
+            console.error(
+              `[AirMCP Audit] resumed chain at lastHmac=${parsed._hmac.slice(0, 8)}…; skipped ${malformedCount} malformed line(s) — possible tampering or corruption (run audit_summary to verify).`,
+            );
+          }
           return;
         }
       } catch {
-        // skip malformed
+        // Malformed line in the tail. Tracked so an operator notices a
+        // pattern of corruption before it gets buried under fresh entries.
+        malformedCount++;
       }
+    }
+    if (malformedCount > 0) {
+      console.error(
+        `[AirMCP Audit] no chain head found in ${lines.length} on-disk lines (${malformedCount} malformed) — restarting chain from genesis.`,
+      );
     }
   } catch {
     // file missing or unreadable — start from genesis

--- a/tests/audit.test.js
+++ b/tests/audit.test.js
@@ -64,6 +64,72 @@ describe('auditLog()', () => {
     expect(parsed.args).toBeUndefined();
   });
 
+  test('explicit correlationId is preserved verbatim', () => {
+    auditLog({
+      timestamp: 'T1',
+      tool: 'test_tool',
+      status: 'ok',
+      correlationId: 'corr-explicit-abc',
+    });
+    const buf = _testReset();
+    expect(JSON.parse(buf[0]).correlationId).toBe('corr-explicit-abc');
+  });
+
+  test('omitted correlationId stays undefined when no active context', () => {
+    // No runWithRequestContext → getCorrelationId() returns undefined.
+    auditLog({ timestamp: 'T1', tool: 'no_ctx_tool', status: 'ok' });
+    const buf = _testReset();
+    expect(JSON.parse(buf[0]).correlationId).toBeUndefined();
+  });
+
+  test('oauth_* tool name redacts args (RFC 0005 token guard)', () => {
+    auditLog({
+      timestamp: 'T1',
+      tool: 'oauth_authorize',
+      args: { code: 'tok_abc', state: 'xyz' },
+      status: 'ok',
+    });
+    const buf = _testReset();
+    const parsed = JSON.parse(buf[0]);
+    expect(parsed.args).toEqual({ _redacted: 'sensitive_tool' });
+  });
+
+  test('tool name containing "credential" is redacted', () => {
+    auditLog({
+      timestamp: 'T1',
+      tool: 'create_api_credential',
+      args: { secret: 'super-secret' },
+      status: 'ok',
+    });
+    const parsed = JSON.parse(_testReset()[0]);
+    expect(parsed.args).toEqual({ _redacted: 'sensitive_tool' });
+  });
+
+  test('tool name containing "token" is redacted', () => {
+    auditLog({
+      timestamp: 'T1',
+      tool: 'rotate_session_token',
+      args: { value: 'tok_xyz' },
+      status: 'ok',
+    });
+    const parsed = JSON.parse(_testReset()[0]);
+    expect(parsed.args).toEqual({ _redacted: 'sensitive_tool' });
+  });
+
+  test('non-sensitive tool names still flow through sanitizeArgs', () => {
+    // search_notes is not on the sensitive list, so its args go through
+    // sanitizeArgs (which redacts password / token / secret keys, not whole args).
+    auditLog({
+      timestamp: 'T1',
+      tool: 'search_notes',
+      args: { query: 'meeting', password: 'should-be-redacted' },
+      status: 'ok',
+    });
+    const parsed = JSON.parse(_testReset()[0]);
+    expect(parsed.args.query).toBe('meeting');
+    expect(parsed.args.password).toBe('[REDACTED]');
+  });
+
   test('entries exceeding 10KB are truncated', () => {
     // sanitizeArgs truncates individual strings at 500 chars, so we need
     // many fields to push the total JSON size over 10KB.


### PR DESCRIPTION
Three small hardenings on the audit log surface — caught in the May 2026 internal scan after correlation-id (PR #190) and HMAC chain (PR #152) landed.

## 1. \`SENSITIVE_TOOL_PATTERNS\` broadened
\`oauth_*\` / \`password\` / \`credential\` / \`token\` substring patterns added. Catches RFC 0005 OAuth tools (\`oauth_authorize\`, \`oauth_refresh\`, …) plus any future credential-bearing tool name without per-tool opt-in. Defense-in-depth on top of the args-side sanitizer for tools that pack credentials into nested args the per-key sanitizer can miss.

## 2. \`resumeChainHead\` malformed-line counter
Was silently skipping garbage lines while scanning the disk tail for chain resumption. Now logs a one-shot stderr warning with the malformed count + recovery point so an operator notices tampering or corruption before it gets buried under fresh entries. Behavior unchanged; the message is the only delta.

## 3. Audit test gap closed
Six new cases in \`tests/audit.test.js\`:
- explicit \`correlationId\` is preserved verbatim
- omitted \`correlationId\` stays undefined outside an active context
- \`oauth_authorize\` → args replaced with \`_redacted\` marker
- tool name containing \`credential\` → redacted
- tool name containing \`token\` → redacted
- non-sensitive tool flows through \`sanitizeArgs\` unchanged

## Test plan
- [x] \`npm run typecheck\` — clean
- [x] \`npm test\` — 101 suites / 1637 tests pass (was 1631; +6 new)
- [x] \`npm run lint\` — clean