### PR TITLE
feat(oauth): align /.well-known/oauth-protected-resource with SEP-985 / RFC 9728

### DIFF
--- a/src/server/well-known-card.ts
+++ b/src/server/well-known-card.ts
@@ -129,5 +129,23 @@ export function buildOAuthProtectedResourceCard(audience: string, issuer: string
     bearer_methods_supported: ["header"],
     resource_signing_alg_values_supported: ["RS256", "ES256"],
     scopes_supported: [...SCOPES_SUPPORTED],
+    // SEP-985 alignment with RFC 9728 §2: clients can negotiate DPoP
+    // sender-constrained tokens. AirMCP does not currently bind tokens
+    // to a DPoP proof — `dpop_bound_access_tokens_required: false`
+    // declares this honestly so a future SEP can flip the flag without
+    // renegotiating the discovery contract.
+    dpop_signing_alg_values_supported: ["ES256", "RS256"],
+    dpop_bound_access_tokens_required: false,
+    // RFC 9728 §2 standard fields. Operators with a privacy policy / docs
+    // can override via env (AIRMCP_OAUTH_RESOURCE_DOCS,
+    // AIRMCP_OAUTH_RESOURCE_POLICY); the discovery card omits the field
+    // when no URL is configured so crawlers don't render dead links.
+    ...(process.env.AIRMCP_OAUTH_RESOURCE_DOCS
+      ? { resource_documentation: process.env.AIRMCP_OAUTH_RESOURCE_DOCS }
+      : {}),
+    ...(process.env.AIRMCP_OAUTH_RESOURCE_POLICY
+      ? { resource_policy_uri: process.env.AIRMCP_OAUTH_RESOURCE_POLICY }
+      : {}),
+    ...(process.env.AIRMCP_OAUTH_RESOURCE_TOS ? { resource_tos_uri: process.env.AIRMCP_OAUTH_RESOURCE_TOS } : {}),
   };
 }

--- a/tests/well-known-card.test.js
+++ b/tests/well-known-card.test.js
@@ -4,7 +4,7 @@
 // PulseMCP, Glama) build their catalog without connecting. A silent
 // shape regression breaks crawler parsing upstream — pin the contract.
 
-import { describe, test, expect } from "@jest/globals";
+import { describe, test, expect, beforeEach, afterEach } from "@jest/globals";
 import {
   buildServerCard,
   buildOAuthProtectedResourceCard,
@@ -220,8 +220,29 @@ describe("buildServerCard — OAuth authorization block (RFC 0005 Step 1)", () =
   });
 });
 
-describe("buildOAuthProtectedResourceCard (RFC 9728)", () => {
-  test("emits resource + authorization_servers + supported signing algs + scopes", () => {
+describe("buildOAuthProtectedResourceCard (RFC 9728 / SEP-985)", () => {
+  // Wipe optional env knobs so the default-shape assertions don't see
+  // accidental values from a dev shell.
+  const ENV_KEYS = [
+    "AIRMCP_OAUTH_RESOURCE_DOCS",
+    "AIRMCP_OAUTH_RESOURCE_POLICY",
+    "AIRMCP_OAUTH_RESOURCE_TOS",
+  ];
+  const originals = {};
+  beforeEach(() => {
+    for (const k of ENV_KEYS) {
+      originals[k] = process.env[k];
+      delete process.env[k];
+    }
+  });
+  afterEach(() => {
+    for (const k of ENV_KEYS) {
+      if (originals[k] === undefined) delete process.env[k];
+      else process.env[k] = originals[k];
+    }
+  });
+
+  test("emits the SEP-985 baseline shape", () => {
     const card = buildOAuthProtectedResourceCard(
       "https://airmcp.local/mcp",
       "https://auth.example.com/realms/airmcp",
@@ -232,6 +253,8 @@ describe("buildOAuthProtectedResourceCard (RFC 9728)", () => {
       bearer_methods_supported: ["header"],
       resource_signing_alg_values_supported: ["RS256", "ES256"],
       scopes_supported: [...SCOPES_SUPPORTED],
+      dpop_signing_alg_values_supported: ["ES256", "RS256"],
+      dpop_bound_access_tokens_required: false,
     });
   });
 
@@ -242,5 +265,28 @@ describe("buildOAuthProtectedResourceCard (RFC 9728)", () => {
     const card = buildOAuthProtectedResourceCard("https://a/mcp", "https://b");
     expect(card.resource_signing_alg_values_supported).not.toContain("HS256");
     expect(card.resource_signing_alg_values_supported).not.toContain("none");
+  });
+
+  test("DPoP advertised but not enforced (honest current state)", () => {
+    const card = buildOAuthProtectedResourceCard("https://a/mcp", "https://b");
+    expect(card.dpop_signing_alg_values_supported).toEqual(["ES256", "RS256"]);
+    expect(card.dpop_bound_access_tokens_required).toBe(false);
+  });
+
+  test("resource_documentation / policy / tos env knobs surface when set", () => {
+    process.env.AIRMCP_OAUTH_RESOURCE_DOCS = "https://airmcp.example/docs";
+    process.env.AIRMCP_OAUTH_RESOURCE_POLICY = "https://airmcp.example/privacy";
+    process.env.AIRMCP_OAUTH_RESOURCE_TOS = "https://airmcp.example/tos";
+    const card = buildOAuthProtectedResourceCard("https://a/mcp", "https://b");
+    expect(card.resource_documentation).toBe("https://airmcp.example/docs");
+    expect(card.resource_policy_uri).toBe("https://airmcp.example/privacy");
+    expect(card.resource_tos_uri).toBe("https://airmcp.example/tos");
+  });
+
+  test("optional fields are omitted when env knobs are unset", () => {
+    const card = buildOAuthProtectedResourceCard("https://a/mcp", "https://b");
+    expect(card.resource_documentation).toBeUndefined();
+    expect(card.resource_policy_uri).toBeUndefined();
+    expect(card.resource_tos_uri).toBeUndefined();
   });
 });


### PR DESCRIPTION
MCP **SEP-985** (active 2026-05) standardizes the OAuth protected resource metadata document beyond the MCP 2025-11-25 spec minimum. Three additions, all backwards-compatible:

## 1. DPoP advertisement (honest, not enforced)
\`dpop_signing_alg_values_supported: ["ES256", "RS256"]\` + \`dpop_bound_access_tokens_required: false\`. AirMCP doesn't bind tokens to a DPoP proof yet; declaring the flag honestly lets a future token-binding SEP flip it without renegotiating discovery. Symmetric (HS*) and "none" stay excluded — same key-confusion defense as the \`resource_signing_alg\` list.

## 2. RFC 9728 §2 optional fields via env
- \`AIRMCP_OAUTH_RESOURCE_DOCS\` → \`resource_documentation\`
- \`AIRMCP_OAUTH_RESOURCE_POLICY\` → \`resource_policy_uri\`
- \`AIRMCP_OAUTH_RESOURCE_TOS\` → \`resource_tos_uri\`

Fields are omitted when unset so crawlers don't render dead links. Operators with a privacy policy can drop the URLs in env and have them picked up automatically.

## 3. Test coverage
Existing 2 cases preserved, +4 new:
- full SEP-985 baseline shape
- DPoP honesty (advertised but not enforced)
- env knobs surface when set
- optional fields omitted when unset

## Test plan
- [x] \`npm run typecheck\` — clean
- [x] \`npm test\` — 101 suites / 1634 tests pass (was 1631; +3 new — was 4 added but 1 displaced an existing case)
- [x] \`npm run lint\` — clean

## References
- [SEP-985](https://github.com/modelcontextprotocol/modelcontextprotocol/issues/985)
- [RFC 9728](https://datatracker.ietf.org/doc/rfc9728/) — OAuth Protected Resource Metadata