### PR TITLE
docs(readme): audit log mentions correlation id + hmac chain

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ AirMCP runs with access to 269 tools on your machine. A few layers keep a buggy 
 - **HITL approval** — every destructive tool prompts before firing (via MCP Elicitation or a Unix socket fallback). Per-call, per-scope.
 - **Rate limit** — 60 tool calls/minute globally, 10 destructive/hour. Token-bucket so bursts are fine; sustained rate isn't.
 - **Emergency stop** — `touch ~/.config/airmcp/emergency-stop` blocks every destructive tool immediately with a 1-second probe cache. No restart needed. `rm` the file to resume.
-- **Audit log** — every tool call lands in `~/.airmcp/audit.jsonl` with PII-scrubbed args, 0600 perms, 10MB rotation. Query it via `audit_log` / `audit_summary` tools.
+- **Audit log** — every tool call lands in `~/.airmcp/audit.jsonl` with PII-scrubbed args, 0600 perms, 10MB rotation. Query it via `audit_log` / `audit_summary` tools. Each entry carries an HMAC chain (single-line tamper detection — `AIRMCP_AUDIT_HMAC_KEY` for cross-machine integrity) and a **correlation ID** that threads the entry, any thrown error, and the OpenTelemetry span (when enabled) for the same call — so a failing tool can be traced across log lines with one `grep`.
 - **HTTP network policy** (RFC 0002) — `AIRMCP_ALLOW_NETWORK` = `loopback-only` (default) / `with-token` / `with-token+origin` / `unauthenticated`. Startup invariant refuses to boot a misconfigured server. Reverse-proxy header detection warns when a `loopback-only` server sees `X-Forwarded-*` so silently-public deploys get caught.
 - **`npx airmcp doctor`** — runs all the above policy + macOS compatibility + permission checks in one command.
 


### PR DESCRIPTION
PR #190 added per-call correlation IDs to every audit entry, and PR #152 added HMAC chain integrity. The README's **Safety & Operations** bullet hadn't caught up. One sentence expansion so users + integrators see the feature without reading the CHANGELOG.

## Test plan
- [x] Docs-only change