### PR TITLE
docs(rfc): add 0010 progressive-disclosure stub + 0011 post-wwdc placeholder

### DIFF
--- a/docs/rfc/0010-progressive-disclosure.md
+++ b/docs/rfc/0010-progressive-disclosure.md
@@ -1,0 +1,80 @@
+# RFC 0010 — Progressive tool disclosure (SEP-1888 alignment)
+
+- **Status**: Stub (May 2026)
+- **Author**: heznpc + Claude
+- **Created**: 2026-05-07
+- **Target**: v3.0.0 (after SEP-1888 lands)
+- **Related**: [SEP-1888 — Progressive Disclosure](https://github.com/modelcontextprotocol/modelcontextprotocol/issues/1888),
+  [Skills-over-MCP charter](https://modelcontextprotocol.io/community/skills-over-mcp/charter),
+  RFC 0007 (App Intent bridge), `npm run tokens` (PR #165), `discover_tools`, `compactDescription`
+
+---
+
+## 1. Motivation
+
+AirMCP eagerly registers **269 tools** at session start. `npm run tokens` (PR #165) measured the description budget at ~3.8K tokens after `compactDescription` — already a 50% reduction over the raw 7.5K. The post-compaction number still puts a meaningful chunk of every model context into "things you might call" rather than "the thing the user asked for."
+
+SEP-1888 (active May 2026) replaces "register N narrow tools" with a **progressive disclosure** pattern: the server exposes a small set of **library / namespace** tools with `searchTools` + `getTypes` operations. The model loads narrow tools on demand instead of seeing everything upfront. The Anthropic Skills-over-MCP charter calls out the same pattern as the long-term direction.
+
+Why now (stub-only):
+- SEP-1888 is **active** but not ratified. The exact tool shape may shift before GA.
+- AirMCP's existing `discover_tools` already does most of the work — the gap is the discoverability *contract* (what the spec calls a "library tool"), not the search engine.
+- Migrating 269 tools without a stable spec risks renaming the public surface twice.
+
+This RFC parks the design space until SEP-1888 lands.
+
+## 2. Goal
+
+Reduce the **eager** tool surface to a single `airmcp.searchTools` library tool plus the destructive / always-relevant subset, deferring discovery of the rest to model-driven `searchTools` calls. Keep the existing `discover_tools` semantic search wiring as the implementation backend so search quality doesn't regress.
+
+### Non-goals
+
+- **Hide tools from `tools/list`.** Until SEP-1888 mandates a discovery shape, keeping eager exposure preserves compatibility with clients that don't speak progressive disclosure.
+- **Re-architect the registry.** The internal `ToolRegistry` (PR #150 onwards) keeps every tool registered; only the *advertised* surface contracts.
+- **Force-enable on all clients.** Capability-gated rollout — clients that advertise progressive-disclosure support get the slim surface; everyone else sees the full eager list.
+
+## 3. Sketch
+
+```
+client capability advertises:
+  capabilities.tools = { progressive: { version: "1.0" } }
+
+→ server response to tools/list:
+  [
+    { name: "airmcp.searchTools",  description: "Find an AirMCP tool by intent." },
+    { name: "airmcp.runTool",      description: "Run a tool returned from searchTools." },
+    { name: "ai_agent",            description: "..." }     // always-relevant
+    { name: "audit_log",           description: "..." }     // always-relevant (reflective)
+    { name: "audit_summary",       description: "..." }
+    // …~5-10 always-relevant tools, total
+  ]
+```
+
+Inside `airmcp.searchTools`:
+- Wraps the existing `discover_tools` semantic search
+- Returns `{ name, description, inputSchema }` triples for the top-K matches
+- Model then calls `airmcp.runTool({ name, args })` to invoke
+
+Inside `airmcp.runTool`:
+- Looks up via `ToolRegistry.callTool` (already exists for the skill executor)
+- Routes through the same audit / OAuth / rate-limit / correlation-id wrapper
+
+## 4. Open questions
+
+1. **Where does the "always-relevant" boundary live?** Probably a per-tool `annotations.alwaysVisible: true` opt-in, defaulting false. Tools the model will always need (HITL helpers, reflection, ai_agent meta-tool) opt in.
+2. **How does `tools/list` track when a session is in progressive mode?** Cache the negotiated capability per `Server` instance and pick the slim list at registration time. Re-running with `progressive: false` should reproduce today's behavior exactly.
+3. **Schema versioning.** SEP-1888 may pin a wire format for the search result; align with that once stable.
+4. **App Intents bridge (RFC 0007).** AppIntents are codegenerated from the eager manifest — Apple Spotlight / Siri don't read MCP, so they keep the full surface regardless of MCP-side progressive mode. No change needed.
+
+## 5. Rollout plan (when SEP-1888 ratifies)
+
+1. Implement `airmcp.searchTools` + `airmcp.runTool` library tools as zero-disruption opt-in (env: `AIRMCP_PROGRESSIVE_DISCLOSURE=true`)
+2. Add `alwaysVisible` annotation to ~10 reflective / meta tools
+3. Capability-gate the slim `tools/list` response
+4. Re-run `npm run tokens` to quantify the eager-surface savings
+5. Default-enable in v3.0.0 once two MCP clients (Claude Desktop + Cursor) negotiate the capability
+
+## 6. Risk
+
+- **Two-tool indirection cost.** Each tool call now becomes search → run, doubling round-trips for the model. Mitigation: cache search results client-side (model self-caching) and keep popular tools always-visible.
+- **`discover_tools` quality regressions** become user-visible since search now drives every tool call instead of being optional. Existing semantic search test coverage needs strengthening before flipping the default.

--- a/docs/rfc/0011-post-wwdc-2026.md
+++ b/docs/rfc/0011-post-wwdc-2026.md
@@ -1,0 +1,41 @@
+# RFC 0011 — Post-WWDC 2026 positioning (placeholder)
+
+- **Status**: Placeholder — to be filled in after WWDC 2026 keynote (June 8–12)
+- **Author**: heznpc + Claude
+- **Created**: 2026-05-07
+- **Target**: TBD (depends on Apple announcements)
+
+---
+
+## 1. Why this exists pre-conference
+
+Multiple credible WWDC 2026 leaks signal a structural shift in Apple's AI strategy:
+- **"Snow Leopard year"** — refinement-focused release cycle
+- **Siri 2.0 with third-party AI extensions** — direct routing to Claude / Gemini for queries Siri can't answer ([geeky-gadgets](https://www.geeky-gadgets.com/wwdc-2026-5-new-leaks/), [TechCrunch](https://techcrunch.com/2026/03/23/apple-wwdc-june-8-12-ai-advancements-siri-developers-conference/))
+- **Possible system MCP** — the developer-visible contract may finally land beyond AppIntents (RFC 0007 §1)
+
+Any of those individually has a measurable AirMCP impact; together they could redraw the competitive map.
+
+## 2. What this RFC will cover (to be written after the keynote)
+
+- **System MCP API shape** — if Apple ships a first-party MCP surface, how does AirMCP coexist? Defensive options:
+  - Become the "tools provider" the system MCP host consumes
+  - Refocus on cross-app workflow / Skills DSL / audit (areas Apple won't ship in v1)
+  - Track the new API as a transport target alongside stdio / HTTP
+- **Siri AI Extensions** — Claude routing through Siri overlaps AirMCP's "talk to your Mac" pitch:
+  - AirMCP's deep tool surface vs Siri's single-query handoff
+  - Migration path for users who'd otherwise use Siri → Claude → MCP
+- **AppIntents API additions** — any new fields (especially `requestConfirmation` API surface, MCP-specific keys) may unblock RFC 0007 Phase B
+- **iOS 27 / macOS 27 SDK gates** — minimum-OS bumps and what they mean for AirMCP's compat matrix (RFC 0004)
+
+## 3. Action items (post-keynote, day-of)
+
+1. Watch the Platforms State of the Union for AppIntents / FoundationModels / system MCP slides
+2. Read the relevant developer documentation diffs against the May 2026 baseline
+3. Draft this RFC's actual content within 48h of the keynote so the post-WWDC sprint starts on the same week
+4. Decide whether RFC 0009 (iWork depth) should accelerate, decelerate, or pivot based on Apple's iWork-side announcements
+
+## 4. Pre-keynote prohibition
+
+- **Do not pivot AirMCP architecture before June 9.** This stub exists to ensure post-WWDC work has a place to land, not to telegraph a course change.
+- **Do not pre-emptively rebrand or reposition** based on leaks. Wait for the actual API and developer docs.

--- a/docs/rfc/README.md
+++ b/docs/rfc/README.md
@@ -90,6 +90,8 @@ Draft ──► Proposed ──► Accepted ──► Implemented
 | [0005](./0005-oauth-resource-indicators.md) | OAuth 2.1 + Resource Indicators (MCP 2025-06-18 spec)         | Draft  | v2.11.0                                            |
 | [0006](./0006-swift-bridge-schema-dump.md)  | Swift Bridge `--dump-example-output` for True Schema Contract | Draft  | v2.12.0                                            |
 | [0007](./0007-app-intent-bridge.md)         | MCP Tool ↔ App Intent Auto-Bridge (2-phase)                   | Draft  | v2.13.0+ (Phase A) · Apple-API-dependent (Phase B) |
+| [0010](./0010-progressive-disclosure.md)    | Progressive tool disclosure (SEP-1888 alignment)              | Stub   | v3.0.0 (after SEP-1888 ratifies)                    |
+| [0011](./0011-post-wwdc-2026.md)            | Post-WWDC 2026 positioning (placeholder)                      | Placeholder | TBD (post June 8-12 WWDC keynote)              |
 | [0008](./0008-elicitation.md)               | MCP Elicitation for destructive tools                         | Draft  | v2.13.0 (Phase 1) · v3.0.0 (Phase 2)               |
 | [0009](./0009-iwork-depth.md)               | iWork (Pages / Numbers / Keynote) coverage depth              | Draft  | v2.13.0 (Phase 1) · v3.0.0 (Phase 2)               |
 


### PR DESCRIPTION
Two future-direction documents from the **May 2026 external scan**.

## RFC 0010 — Progressive tool disclosure (SEP-1888 alignment)

AirMCP advertises **269 tools eagerly**; \`npm run tokens\` (PR #165) measured the description budget at ~3.8K tokens after \`compactDescription\` — already a 50% reduction, but a meaningful chunk of every model context still goes to "things you might call."

[**SEP-1888**](https://github.com/modelcontextprotocol/modelcontextprotocol/issues/1888) (active May 2026) replaces "register N narrow tools" with **library tool + \`searchTools\`** progressive disclosure. The Anthropic [Skills-over-MCP](https://modelcontextprotocol.io/community/skills-over-mcp/charter) charter calls out the same direction.

**Stub-only because**: the SEP shape isn't ratified yet — premature migration would rename the public surface twice. AirMCP's existing \`discover_tools\` already handles the search backend; the gap is the discoverability *contract*, not the implementation.

## RFC 0011 — Post-WWDC 2026 positioning (placeholder)

**WWDC 2026 keynote June 8–12** has credible leaks for:
- Siri 2.0 with third-party AI extensions ([geeky-gadgets](https://www.geeky-gadgets.com/wwdc-2026-5-new-leaks/), [TechCrunch](https://techcrunch.com/2026/03/23/apple-wwdc-june-8-12-ai-advancements-siri-developers-conference/))
- Possible Apple-blessed system MCP API
- "Snow Leopard year" — refinement focus

Any individually has a measurable AirMCP impact; together they could redraw the competitive map.

**Placeholder is intentionally light** — pre-keynote prohibition on pivots, just a guaranteed landing spot for the post-WWDC sprint with action items for the day-of and following 48h.

## Test plan
- [x] Docs-only PR
- [x] RFC index updated