### PR TITLE
feat(hitl): rfc 0008 phase 1 — capability gate + env opt-out for elicitation

### DIFF
--- a/docs/rfc/0008-elicitation.md
+++ b/docs/rfc/0008-elicitation.md
@@ -1,9 +1,11 @@
 # RFC 0008 — MCP Elicitation for destructive tools
 
-- **Status**: Draft (May 2026)
+- **Status**: Phase 1 Implemented (May 2026 — `tryElicitApproval` in `src/shared/hitl-guard.ts`). Phase 2 Draft.
 - **Author**: heznpc + Claude
 - **Created**: 2026-05-07
-- **Target**: v2.13.0 (Phase 1 — confirmation prompts) · v3.0.0 (Phase 2 — form/URL elicit)
+- **Target**: v2.13.0 (Phase 1 — confirmation prompts ✅) · v3.0.0 (Phase 2 — form/URL elicit)
+- **Amendment**:
+  - 2026-05-07 — Phase 1 lands: capability gate + `AIRMCP_ELICITATION_DISABLE` env opt-out folded into the existing HITL guard's elicitation path. The previous draft assumed a fresh wrapper at the tool-registry layer; on review the `installHitlGuard` interceptor was already wiring `inner.elicitInput()` for destructive tools — the gap was just the negotiated-capability check + env switch. No new wrapper layer needed.
 - **Related**: [`@modelcontextprotocol/sdk` 1.29.0 elicitInput API](https://github.com/modelcontextprotocol/typescript-sdk),
   [MCP Elicitation spec (draft)](https://modelcontextprotocol.io/specification/draft/client/elicitation),
   [GitHub Copilot blog — MCP elicitation](https://github.blog/ai-and-ml/github-copilot/building-smarter-interactions-with-mcp-elicitation-from-clunky-tool-calls-to-seamless-user-experiences/),

--- a/docs/rfc/README.md
+++ b/docs/rfc/README.md
@@ -92,7 +92,7 @@ Draft ──► Proposed ──► Accepted ──► Implemented
 | [0007](./0007-app-intent-bridge.md)         | MCP Tool ↔ App Intent Auto-Bridge (2-phase)                   | Draft  | v2.13.0+ (Phase A) · Apple-API-dependent (Phase B) |
 | [0010](./0010-progressive-disclosure.md)    | Progressive tool disclosure (SEP-1888 alignment)              | Stub   | v3.0.0 (after SEP-1888 ratifies)                    |
 | [0011](./0011-post-wwdc-2026.md)            | Post-WWDC 2026 positioning (placeholder)                      | Placeholder | TBD (post June 8-12 WWDC keynote)              |
-| [0008](./0008-elicitation.md)               | MCP Elicitation for destructive tools                         | Draft  | v2.13.0 (Phase 1) · v3.0.0 (Phase 2)               |
+| [0008](./0008-elicitation.md)               | MCP Elicitation for destructive tools                         | Phase 1 Implemented | v2.13.0 (Phase 1 ✅) · v3.0.0 (Phase 2) |
 | [0009](./0009-iwork-depth.md)               | iWork (Pages / Numbers / Keynote) coverage depth              | Draft  | v2.13.0 (Phase 1) · v3.0.0 (Phase 2)               |
 
 ## 관련 문서

--- a/src/shared/hitl-guard.ts
+++ b/src/shared/hitl-guard.ts
@@ -84,9 +84,22 @@ async function tryElicitApproval(
   toolArgs: Record<string, unknown>,
   destructive: boolean,
 ): Promise<boolean | undefined> {
+  // RFC 0008 §3.3 — operator opt-out for end-to-end scripted pipelines
+  // that don't want any user prompt. When set, every call falls through
+  // to the socket HITL channel (or the no-prompt path) just like a
+  // client that doesn't advertise elicitation.
+  if (process.env.AIRMCP_ELICITATION_DISABLE === "true") return undefined;
+
   try {
     const inner = server.server;
     if (!inner?.elicitInput) return undefined;
+
+    // RFC 0008 §3.2 — capability gate. Honoring the negotiated capability
+    // up-front avoids waiting on a doomed request when the client declared
+    // no elicitation support; the try/catch around the call below stays as
+    // a belt-and-suspenders fallback for clients that lie about it.
+    const caps = inner.getClientCapabilities?.();
+    if (caps && !caps.elicitation) return undefined;
 
     const label = destructive ? `⚠️ Destructive: ${toolName}` : `Approve: ${toolName}`;
     const argsSummary = JSON.stringify(toolArgs, null, 2).slice(0, 500);


### PR DESCRIPTION
On review the elicitation path was already wired in \`installHitlGuard\` (\`tryElicitApproval\` calls \`inner.elicitInput\` when the inner Server exposes it — landed earlier as part of the HITL guard rollout). RFC 0008 §3.2 + §3.3 named two gaps the existing draft specified that hadn't landed yet.

## 1. \`AIRMCP_ELICITATION_DISABLE\` env opt-out (RFC 0008 §3.3)
Operator switch for end-to-end scripted destructive pipelines that don't want any user prompt. When set, every call falls through to the socket HITL channel exactly like a client that doesn't advertise elicitation.

## 2. Capability gate (RFC 0008 §3.2)
Explicit \`getClientCapabilities()\` check before issuing the elicit request. Avoids waiting on a doomed call when the client declared no elicitation support; the existing try/catch stays as a belt-and-suspenders fallback for clients that lie about their capabilities.

## RFC 0008 status update
- \`docs/rfc/README.md\` — Status: Draft → **Phase 1 Implemented**
- \`docs/rfc/0008-elicitation.md\` — amendment block records that the existing HITL guard already carried the wiring so no new wrapper layer was needed

## Test plan
- [x] \`npm run typecheck\` — clean
- [x] \`npm test\` — 101 suites / 1640 tests pass (was 1637; +3 from upstream merges)
- [x] \`npm run lint\` — clean