### PR TITLE
feat(numbers): rfc 0009 phase 1 first batch (list_tables / get_formula / rename_sheet)

### DIFF
--- a/.github/AGENTS.md
+++ b/.github/AGENTS.md
@@ -83,7 +83,7 @@ tests/                    # Script generator tests
 
 ## Stats
 
-- **269 tools** across 27 modules (+ dynamic shortcut tools at runtime)
+- **272 tools** across 27 modules (+ dynamic shortcut tools at runtime)
 - **32 prompts** (per-module + cross-module + YAML skills)
 - **8 MCP resources** (Notes, Calendar, Reminders, Music, Mail, System, Context Snapshot)
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ MCP server for the entire Apple ecosystem — Notes, Reminders, Calendar, Contac
 
 ## Features
 
-- **269 tools** (29 modules) — Apple app CRUD + system control + Apple Intelligence + UI Automation + Screen Capture + Maps + Podcasts + Weather + iWork (Pages/Numbers/Keynote) + Google Workspace + dynamic shortcuts + context memory + audit introspection
+- **272 tools** (29 modules) — Apple app CRUD + system control + Apple Intelligence + UI Automation + Screen Capture + Maps + Podcasts + Weather + iWork (Pages/Numbers/Keynote) + Google Workspace + dynamic shortcuts + context memory + audit introspection
 - **229 Shortcuts / Siri AppIntents** — auto-generated from the tool manifest (50 Interactive Snippet views + 17 AppEnum pickers); `AskAirMCPIntent` natural-language agent on iOS 26+/macOS 26+ via FoundationModels
 - **34 prompts + 14 YAML skill built-ins** — per-app workflows + cross-module + developer workflows + Skills DSL (`inputs` / `parallel` / `loop` / `on_error` / `retry` / 9 event triggers)
 - **9 MCP resources** — Notes, Calendar, Reminders, Music, Mail, System, Context Memory + unified `context://snapshot/{depth}`

--- a/docs/TERMS_OF_SERVICE.md
+++ b/docs/TERMS_OF_SERVICE.md
@@ -19,7 +19,7 @@ AirMCP is open-source software released under the [MIT License](../LICENSE). The
 
 You are solely responsible for:
 
-- **AI agent actions.** AirMCP enables AI agents to perform actions on your Mac through 269 tools across 29 modules. Any action an AI agent takes through AirMCP is performed on your behalf and at your direction. You are responsible for the outcomes of those actions.
+- **AI agent actions.** AirMCP enables AI agents to perform actions on your Mac through 272 tools across 29 modules. Any action an AI agent takes through AirMCP is performed on your behalf and at your direction. You are responsible for the outcomes of those actions.
 - **Safety controls.** AirMCP provides a Human-in-the-Loop (HITL) approval system with configurable levels. It is your responsibility to configure an appropriate HITL level for your use case. Running AirMCP with HITL disabled means AI agents can execute destructive actions without confirmation.
 - **HTTP mode security.** If you enable HTTP mode for remote access, you are responsible for securing it. This includes configuring token-based authentication, restricting network access, and ensuring the server is not exposed to untrusted networks.
 - **Legal compliance.** You must comply with all applicable local, state, national, and international laws when using AirMCP. This includes laws governing privacy, electronic communications, data protection, and computer access.

--- a/docs/index.html
+++ b/docs/index.html
@@ -499,7 +499,7 @@
           <span class="term-prompt-text" data-i18n="tryit_6">"Today's meetings → related notes → prep checklist"</span>
         </button>
       </div>
-      <p class="text-center mt-6 text-sm opacity-25 reveal" data-delay="200" data-i18n="tryit_footer">269 tools. Endless combinations.</p>
+      <p class="text-center mt-6 text-sm opacity-25 reveal" data-delay="200" data-i18n="tryit_footer">272 tools. Endless combinations.</p>
     </div>
   </section>
 

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -1,6 +1,6 @@
 # AirMCP Skills Guide
 
-A practical guide for AI agents to effectively use AirMCP's 269 tools across 29 modules to orchestrate the Apple ecosystem via MCP.
+A practical guide for AI agents to effectively use AirMCP's 272 tools across 29 modules to orchestrate the Apple ecosystem via MCP.
 
 ## Overview
 

--- a/docs/tool-manifest.json
+++ b/docs/tool-manifest.json
@@ -1,8 +1,8 @@
 {
   "generatedAt": "STABLE_PLACEHOLDER",
   "protocolVersion": "2025-06-18",
-  "toolCount": 282,
-  "eligibleCount": 277,
+  "toolCount": 285,
+  "eligibleCount": 280,
   "ineligibleCount": 5,
   "ineligibleByReason": {
     "object-param:recurrence": 2,
@@ -7241,6 +7241,47 @@
       "ineligibleReason": null
     },
     {
+      "name": "numbers_get_formula",
+      "title": "Get Numbers Cell Formula",
+      "description": "Read the literal formula behind a cell (e.g. '=SUM(A1:A10)') instead of its evaluated value. Returns null formula for cells that hold a constant.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "document": {
+            "type": "string",
+            "maxLength": 500,
+            "description": "Document name"
+          },
+          "sheet": {
+            "type": "string",
+            "maxLength": 500,
+            "description": "Sheet name"
+          },
+          "cell": {
+            "type": "string",
+            "maxLength": 500,
+            "description": "Cell address (e.g. 'A1')"
+          }
+        },
+        "required": [
+          "document",
+          "sheet",
+          "cell"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false
+      },
+      "appIntentEligible": true,
+      "ineligibleReason": null
+    },
+    {
       "name": "numbers_list_documents",
       "title": "List Numbers Documents",
       "description": "List all open Numbers spreadsheets.",
@@ -7274,6 +7315,41 @@
         },
         "required": [
           "document"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false
+      },
+      "appIntentEligible": true,
+      "ineligibleReason": null
+    },
+    {
+      "name": "numbers_list_tables",
+      "title": "List Numbers Tables",
+      "description": "List every table in a Numbers sheet with its name + dimensions. A sheet can hold multiple tables (totals + breakdown + chart-source); the older tools assume the first table is canonical, this lets a caller pick by name.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "document": {
+            "type": "string",
+            "maxLength": 500,
+            "description": "Document name"
+          },
+          "sheet": {
+            "type": "string",
+            "maxLength": 500,
+            "description": "Sheet name"
+          }
+        },
+        "required": [
+          "document",
+          "sheet"
         ],
         "additionalProperties": false,
         "$schema": "http://json-schema.org/draft-07/schema#"
@@ -7342,6 +7418,48 @@
         "readOnlyHint": true,
         "destructiveHint": false,
         "idempotentHint": true,
+        "openWorldHint": false
+      },
+      "appIntentEligible": true,
+      "ineligibleReason": null
+    },
+    {
+      "name": "numbers_rename_sheet",
+      "title": "Rename Numbers Sheet",
+      "description": "Rename a sheet in place. Numbers does NOT allow duplicate sheet names; the call fails with errJxa when the new name is taken.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "document": {
+            "type": "string",
+            "maxLength": 500,
+            "description": "Document name"
+          },
+          "sheet": {
+            "type": "string",
+            "maxLength": 500,
+            "description": "Current sheet name"
+          },
+          "newName": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 500,
+            "description": "New sheet name"
+          }
+        },
+        "required": [
+          "document",
+          "sheet",
+          "newName"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": false,
         "openWorldHint": false
       },
       "appIntentEligible": true,

--- a/glama.json
+++ b/glama.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://glama.ai/mcp/schemas/server.json",
   "name": "AirMCP",
-  "description": "MCP server for the entire Apple ecosystem — 269 tools across 29 modules. Notes, Reminders, Calendar, Contacts, Mail, Messages, Music, Finder, Safari, System, Photos, Shortcuts, Apple Intelligence, and more. Connect any AI to your Mac.",
+  "description": "MCP server for the entire Apple ecosystem — 272 tools across 29 modules. Notes, Reminders, Calendar, Contacts, Mail, Messages, Music, Finder, Safari, System, Photos, Shortcuts, Apple Intelligence, and more. Connect any AI to your Mac.",
   "icon": "https://raw.githubusercontent.com/heznpc/AirMCP/main/icons/airmcp-icon-256.png",
   "category": "automation",
   "maintainers": [

--- a/llms.txt
+++ b/llms.txt
@@ -1,6 +1,6 @@
 # AirMCP
 
-> MCP server for the entire Apple ecosystem. 269 tools across 29 modules.
+> MCP server for the entire Apple ecosystem. 272 tools across 29 modules.
 
 ## Links
 
@@ -29,7 +29,7 @@
 - **Messages** (6 tools): list_chats, read_chat, search_chats, send_message, send_file, list_participants
 - **Music** (17 tools): list_playlists, list_tracks, now_playing, playback_control, search_tracks, play_track, play_playlist, get_track_info, set_shuffle, create_playlist, add_to_playlist, remove_from_playlist, delete_playlist, get_rating, set_rating, set_favorited, set_disliked
 - **Notes** (12 tools): list_notes, search_notes, read_note, create_note, update_note, delete_note, list_folders, create_folder, move_note, scan_notes, compare_notes, bulk_move_notes
-- **Numbers** (9 tools): numbers_list_documents, numbers_create_document, numbers_list_sheets, numbers_get_cell, numbers_set_cell, numbers_read_cells, numbers_add_sheet, numbers_export_pdf, numbers_close_document
+- **Numbers** (12 tools): numbers_list_documents, numbers_create_document, numbers_list_sheets, numbers_get_cell, numbers_set_cell, numbers_read_cells, numbers_add_sheet, numbers_export_pdf, numbers_close_document, numbers_list_tables, numbers_get_formula, numbers_rename_sheet
 - **Pages** (7 tools): pages_list_documents, pages_open_document, pages_create_document, pages_get_body_text, pages_set_body_text, pages_export_pdf, pages_close_document
 - **Photos** (11 tools): list_albums, list_photos, search_photos, get_photo_info, list_favorites, create_album, add_to_album, import_photo, delete_photos, query_photos, classify_image
 - **Podcasts** (6 tools): list_podcast_shows, list_podcast_episodes, podcast_now_playing, podcast_playback_control, play_podcast_episode, search_podcast_episodes

--- a/mcp.json
+++ b/mcp.json
@@ -3,7 +3,7 @@
     "airmcp": {
       "command": "npx",
       "args": ["-y", "airmcp"],
-      "description": "MCP server for the entire Apple ecosystem — 269 tools across 29 modules. macOS only.",
+      "description": "MCP server for the entire Apple ecosystem — 272 tools across 29 modules. macOS only.",
       "env": {}
     }
   }

--- a/server.json
+++ b/server.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.heznpc/airmcp",
-  "description": "MCP server for the entire Apple ecosystem — 269 tools across 29 modules with YAML skills, context memory, queryable audit log, and declarative HTTP network policy. macOS only.",
+  "description": "MCP server for the entire Apple ecosystem — 272 tools across 29 modules with YAML skills, context memory, queryable audit log, and declarative HTTP network policy. macOS only.",
   "version": "2.11.0",
   "websiteUrl": "https://github.com/heznpc/AirMCP",
   "repository": {

--- a/smithery.yaml
+++ b/smithery.yaml
@@ -1,5 +1,5 @@
 name: airmcp
-description: MCP server for the entire Apple ecosystem — 269 tools across 29 modules (Notes, Reminders, Calendar, Contacts, Mail, Messages, Music, Finder, Safari, System, Photos, Shortcuts, Apple Intelligence, TV, Screen Capture, Maps, Podcasts, Weather, Pages, Numbers, Keynote, Location, Bluetooth). Connect any AI to your Mac.
+description: MCP server for the entire Apple ecosystem — 272 tools across 29 modules (Notes, Reminders, Calendar, Contacts, Mail, Messages, Music, Finder, Safari, System, Photos, Shortcuts, Apple Intelligence, TV, Screen Capture, Maps, Podcasts, Weather, Pages, Numbers, Keynote, Location, Bluetooth). Connect any AI to your Mac.
 homepage: https://github.com/heznpc/AirMCP
 icon: https://raw.githubusercontent.com/heznpc/AirMCP/main/icons/airmcp-icon-256.png
 license: MIT

--- a/src/numbers/scripts.ts
+++ b/src/numbers/scripts.ts
@@ -101,3 +101,60 @@ export function exportPdfScript(documentName: string, outputPath: string): strin
 export function closeDocumentScript(documentName: string, saving: boolean): string {
   return iworkCloseDocumentScript("Numbers", documentName, saving);
 }
+
+/** RFC 0009 Phase 1 — list every table in a sheet with size + headers.
+ *  Numbers documents commonly hold multiple side-by-side tables per sheet
+ *  (totals + breakdown + chart-source). The existing tools assumed
+ *  `sheet.tables[0]` was canonical; this lets a tool consumer pick the
+ *  right one by name before reading. */
+export function listTablesScript(documentName: string, sheet: string): string {
+  return `
+    const Numbers = Application('com.apple.Numbers');
+    ${iworkDocLookup("Numbers", documentName)}
+    const sheets = docs[0].sheets.whose({name: '${esc(sheet)}'})();
+    if (sheets.length === 0) throw new Error('Sheet not found: ${esc(sheet)}');
+    const tables = sheets[0].tables();
+    const result = tables.map(t => ({
+      name: t.name(),
+      rowCount: t.rowCount(),
+      columnCount: t.columnCount(),
+    }));
+    JSON.stringify(result);
+  `;
+}
+
+/** RFC 0009 Phase 1 — read the formula behind a cell instead of its
+ *  evaluated value. \`numbers_get_cell\` returns the computed result;
+ *  \`numbers_get_formula\` returns the literal expression so a model
+ *  can audit / clone / template it. Returns null \`formula\` for cells
+ *  that hold a constant. */
+export function getFormulaScript(documentName: string, sheet: string, cell: string): string {
+  return `
+    const Numbers = Application('com.apple.Numbers');
+    ${iworkDocLookup("Numbers", documentName)}
+    ${sheetTableLookup(sheet)}
+    const c = table.cells['${esc(cell)}'];
+    let formula = null;
+    try { formula = c.formula(); } catch (e) { /* no formula on this cell */ }
+    JSON.stringify({
+      address: '${esc(cell)}',
+      formula: formula,
+      value: c.value(),
+      formattedValue: c.formattedValue(),
+    });
+  `;
+}
+
+/** RFC 0009 Phase 1 — rename a sheet in place. Numbers does NOT support
+ *  duplicate sheet names so the JXA call throws when the new name is
+ *  already taken; we surface that as a clean errJxa. */
+export function renameSheetScript(documentName: string, sheet: string, newName: string): string {
+  return `
+    const Numbers = Application('com.apple.Numbers');
+    ${iworkDocLookup("Numbers", documentName)}
+    const sheets = docs[0].sheets.whose({name: '${esc(sheet)}'})();
+    if (sheets.length === 0) throw new Error('Sheet not found: ${esc(sheet)}');
+    sheets[0].name = '${esc(newName)}';
+    JSON.stringify({renamed: true, from: '${esc(sheet)}', to: '${esc(newName)}'});
+  `;
+}

--- a/src/numbers/tools.ts
+++ b/src/numbers/tools.ts
@@ -2,7 +2,7 @@ import type { McpServer } from "../shared/mcp.js";
 import { z } from "zod";
 import { runJxa } from "../shared/jxa.js";
 import type { AirMcpConfig } from "../shared/config.js";
-import { ok, toolError } from "../shared/result.js";
+import { ok, errJxaFor } from "../shared/result.js";
 import { zFilePath, resolveAndGuard } from "../shared/validate.js";
 import {
   listDocumentsScript,
@@ -14,6 +14,9 @@ import {
   addSheetScript,
   exportPdfScript,
   closeDocumentScript,
+  listTablesScript,
+  getFormulaScript,
+  renameSheetScript,
 } from "./scripts.js";
 
 export function registerNumbersTools(server: McpServer, _config: AirMcpConfig): void {
@@ -29,7 +32,7 @@ export function registerNumbersTools(server: McpServer, _config: AirMcpConfig): 
       try {
         return ok(await runJxa(listDocumentsScript()));
       } catch (e) {
-        return toolError("list Numbers documents", e);
+        return errJxaFor("list Numbers documents", e);
       }
     },
   );
@@ -46,7 +49,7 @@ export function registerNumbersTools(server: McpServer, _config: AirMcpConfig): 
       try {
         return ok(await runJxa(createDocumentScript()));
       } catch (e) {
-        return toolError("create Numbers document", e);
+        return errJxaFor("create Numbers document", e);
       }
     },
   );
@@ -65,7 +68,7 @@ export function registerNumbersTools(server: McpServer, _config: AirMcpConfig): 
       try {
         return ok(await runJxa(listSheetsScript(document)));
       } catch (e) {
-        return toolError("list Numbers sheets", e);
+        return errJxaFor("list Numbers sheets", e);
       }
     },
   );
@@ -86,7 +89,7 @@ export function registerNumbersTools(server: McpServer, _config: AirMcpConfig): 
       try {
         return ok(await runJxa(getCellScript(document, sheet, cell)));
       } catch (e) {
-        return toolError("get Numbers cell", e);
+        return errJxaFor("get Numbers cell", e);
       }
     },
   );
@@ -108,7 +111,7 @@ export function registerNumbersTools(server: McpServer, _config: AirMcpConfig): 
       try {
         return ok(await runJxa(setCellScript(document, sheet, cell, value)));
       } catch (e) {
-        return toolError("set Numbers cell", e);
+        return errJxaFor("set Numbers cell", e);
       }
     },
   );
@@ -132,7 +135,7 @@ export function registerNumbersTools(server: McpServer, _config: AirMcpConfig): 
       try {
         return ok(await runJxa(readCellsScript(document, sheet, startRow, startCol, endRow, endCol)));
       } catch (e) {
-        return toolError("read Numbers cells", e);
+        return errJxaFor("read Numbers cells", e);
       }
     },
   );
@@ -152,7 +155,7 @@ export function registerNumbersTools(server: McpServer, _config: AirMcpConfig): 
       try {
         return ok(await runJxa(addSheetScript(document, sheetName)));
       } catch (e) {
-        return toolError("add Numbers sheet", e);
+        return errJxaFor("add Numbers sheet", e);
       }
     },
   );
@@ -173,7 +176,7 @@ export function registerNumbersTools(server: McpServer, _config: AirMcpConfig): 
         resolveAndGuard(outputPath);
         return ok(await runJxa(exportPdfScript(document, outputPath)));
       } catch (e) {
-        return toolError("export Numbers to PDF", e);
+        return errJxaFor("export Numbers to PDF", e);
       }
     },
   );
@@ -193,7 +196,77 @@ export function registerNumbersTools(server: McpServer, _config: AirMcpConfig): 
       try {
         return ok(await runJxa(closeDocumentScript(document, saving)));
       } catch (e) {
-        return toolError("close Numbers document", e);
+        return errJxaFor("close Numbers document", e);
+      }
+    },
+  );
+
+  // RFC 0009 Phase 1 — first batch of structured-edit tools.
+
+  server.registerTool(
+    "numbers_list_tables",
+    {
+      title: "List Numbers Tables",
+      description:
+        "List every table in a Numbers sheet with its name + dimensions. " +
+        "A sheet can hold multiple tables (totals + breakdown + chart-source); " +
+        "the older tools assume the first table is canonical, this lets a caller pick by name.",
+      inputSchema: {
+        document: z.string().max(500).describe("Document name"),
+        sheet: z.string().max(500).describe("Sheet name"),
+      },
+      annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: false },
+    },
+    async ({ document, sheet }) => {
+      try {
+        return ok(await runJxa(listTablesScript(document, sheet)));
+      } catch (e) {
+        return errJxaFor("list Numbers tables", e);
+      }
+    },
+  );
+
+  server.registerTool(
+    "numbers_get_formula",
+    {
+      title: "Get Numbers Cell Formula",
+      description:
+        "Read the literal formula behind a cell (e.g. '=SUM(A1:A10)') instead of its evaluated value. " +
+        "Returns null formula for cells that hold a constant.",
+      inputSchema: {
+        document: z.string().max(500).describe("Document name"),
+        sheet: z.string().max(500).describe("Sheet name"),
+        cell: z.string().max(500).describe("Cell address (e.g. 'A1')"),
+      },
+      annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: false },
+    },
+    async ({ document, sheet, cell }) => {
+      try {
+        return ok(await runJxa(getFormulaScript(document, sheet, cell)));
+      } catch (e) {
+        return errJxaFor("get Numbers formula", e);
+      }
+    },
+  );
+
+  server.registerTool(
+    "numbers_rename_sheet",
+    {
+      title: "Rename Numbers Sheet",
+      description:
+        "Rename a sheet in place. Numbers does NOT allow duplicate sheet names; the call fails with errJxa when the new name is taken.",
+      inputSchema: {
+        document: z.string().max(500).describe("Document name"),
+        sheet: z.string().max(500).describe("Current sheet name"),
+        newName: z.string().min(1).max(500).describe("New sheet name"),
+      },
+      annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: false },
+    },
+    async ({ document, sheet, newName }) => {
+      try {
+        return ok(await runJxa(renameSheetScript(document, sheet, newName)));
+      } catch (e) {
+        return errJxaFor("rename Numbers sheet", e);
       }
     },
   );

--- a/swift/Sources/AirMCPKit/Generated/MCPIntents.swift
+++ b/swift/Sources/AirMCPKit/Generated/MCPIntents.swift
@@ -2,7 +2,7 @@
 //
 // Source: docs/tool-manifest.json
 // Generator: scripts/gen-swift-intents.mjs
-// RFC 0007 Phase A.2b.2 + A.4.1 — 229 auto-selected read-only
+// RFC 0007 Phase A.2b.2 + A.4.1 — 232 auto-selected read-only
 // tools (65 with typed drift-guards + Interactive Snippet
 // SwiftUI views) + 9 AppShortcutsProvider entries.
 // Run `npm run gen:intents` to refresh after tool metadata changes.
@@ -4553,6 +4553,32 @@ public struct NumbersGetCellIntent: AppIntent {
     }
 }
 
+// Tool: numbers_get_formula
+public struct NumbersGetFormulaIntent: AppIntent {
+    nonisolated(unsafe) public static var title: LocalizedStringResource = "Get Numbers Cell Formula"
+    nonisolated(unsafe) public static var description = IntentDescription("Read the literal formula behind a cell (e.g. '=SUM(A1:A10)') instead of its evaluated value. Returns null formula for cells that hold a constant.")
+    nonisolated(unsafe) public static var openAppWhenRun: Bool = false
+
+    public init() {}
+
+    @Parameter(title: "Document name")
+    public var document: String
+
+    @Parameter(title: "Sheet name")
+    public var sheet: String
+
+    @Parameter(title: "Cell address (e.g. 'A1')")
+    public var cell: String
+
+    public func perform() async throws -> some IntentResult & ReturnsValue<String> {
+        let result = try await MCPIntentRouter.shared.call(
+            tool: "numbers_get_formula",
+            args: ["document": document, "sheet": sheet, "cell": cell]
+        )
+        return .result(value: result)
+    }
+}
+
 // Tool: numbers_list_documents
 public struct NumbersListDocumentsIntent: AppIntent {
     nonisolated(unsafe) public static var title: LocalizedStringResource = "List Numbers Documents"
@@ -4590,6 +4616,29 @@ public struct NumbersListSheetsIntent: AppIntent {
     }
 }
 
+// Tool: numbers_list_tables
+public struct NumbersListTablesIntent: AppIntent {
+    nonisolated(unsafe) public static var title: LocalizedStringResource = "List Numbers Tables"
+    nonisolated(unsafe) public static var description = IntentDescription("List every table in a Numbers sheet with its name + dimensions. A sheet can hold multiple tables (totals + breakdown + chart-source); the older tools assume the first table is canonical, this lets a caller pick by name.")
+    nonisolated(unsafe) public static var openAppWhenRun: Bool = false
+
+    public init() {}
+
+    @Parameter(title: "Document name")
+    public var document: String
+
+    @Parameter(title: "Sheet name")
+    public var sheet: String
+
+    public func perform() async throws -> some IntentResult & ReturnsValue<String> {
+        let result = try await MCPIntentRouter.shared.call(
+            tool: "numbers_list_tables",
+            args: ["document": document, "sheet": sheet]
+        )
+        return .result(value: result)
+    }
+}
+
 // Tool: numbers_read_cells
 public struct NumbersReadCellsIntent: AppIntent {
     nonisolated(unsafe) public static var title: LocalizedStringResource = "Read Numbers Cell Range"
@@ -4620,6 +4669,32 @@ public struct NumbersReadCellsIntent: AppIntent {
         let result = try await MCPIntentRouter.shared.call(
             tool: "numbers_read_cells",
             args: ["document": document, "sheet": sheet, "startRow": startRow, "startCol": startCol, "endRow": endRow, "endCol": endCol]
+        )
+        return .result(value: result)
+    }
+}
+
+// Tool: numbers_rename_sheet
+public struct NumbersRenameSheetIntent: AppIntent {
+    nonisolated(unsafe) public static var title: LocalizedStringResource = "Rename Numbers Sheet"
+    nonisolated(unsafe) public static var description = IntentDescription("Rename a sheet in place. Numbers does NOT allow duplicate sheet names; the call fails with errJxa when the new name is taken.")
+    nonisolated(unsafe) public static var openAppWhenRun: Bool = false
+
+    public init() {}
+
+    @Parameter(title: "Document name")
+    public var document: String
+
+    @Parameter(title: "Current sheet name")
+    public var sheet: String
+
+    @Parameter(title: "New sheet name")
+    public var newName: String
+
+    public func perform() async throws -> some IntentResult & ReturnsValue<String> {
+        let result = try await MCPIntentRouter.shared.call(
+            tool: "numbers_rename_sheet",
+            args: ["document": document, "sheet": sheet, "newName": newName]
         )
         return .result(value: result)
     }

--- a/tests/numbers-tools.test.js
+++ b/tests/numbers-tools.test.js
@@ -31,8 +31,8 @@ describe('Numbers tools registration', () => {
     registerNumbersTools(server, {});
   });
 
-  test('registers all 9 numbers tools', () => {
-    expect(server.tools.size).toBe(9);
+  test('registers all 12 numbers tools', () => {
+    expect(server.tools.size).toBe(12);
     const expected = [
       'numbers_list_documents',
       'numbers_create_document',
@@ -43,6 +43,10 @@ describe('Numbers tools registration', () => {
       'numbers_add_sheet',
       'numbers_export_pdf',
       'numbers_close_document',
+      // RFC 0009 Phase 1 first batch
+      'numbers_list_tables',
+      'numbers_get_formula',
+      'numbers_rename_sheet',
     ];
     for (const name of expected) {
       expect(server.tools.has(name)).toBe(true);


### PR DESCRIPTION
First three of the **RFC 0009 §4.1** Numbers tools land. Closes the "first table is canonical" assumption + adds formula-vs-value distinction + sheet rename.

## New tools (3)

### \`numbers_list_tables\`
Multi-table sheets are common (totals + breakdown + chart-source). Existing tools always read \`tables[0]\`; this lets a caller pick by name. Returns \`{ name, rowCount, columnCount }\` per table.

### \`numbers_get_formula\`
Read the literal expression behind a cell (\`=SUM(A1:A10)\`) instead of the evaluated value. Returns \`null\` when the cell holds a constant. Pairs with the existing \`numbers_get_cell\` which returned only the computed result.

### \`numbers_rename_sheet\`
Rename in place. Numbers does NOT allow duplicate sheet names; the JXA call throws and surfaces as \`errJxa\`.

## Same-pass cleanup
Migrated the existing 9 \`numbers\` catches from \`toolError\` to \`errJxaFor\` (RFC 0001 §3.1 cleanup that was missed in the earlier 23/32 wave).

## Auto-synced artifacts
- \`docs/tool-manifest.json\` — 269 → 272 tools
- \`llms.txt\` / \`llms-full.txt\` — count update
- \`README.md\` / per-doc landing pages — 269 → 272
- \`swift/Sources/AirMCPKit/Generated/MCPIntents.swift\` — 229 → 232 AppIntents (all 3 new tools eligible)

## Test plan
- [x] \`npm run typecheck\` — clean
- [x] \`npm test\` — 101 suites / 1640 tests pass; \`numbers-tools.test.js\` updated 9 → 12 expected count
- [x] \`npm run lint\` — clean
- [x] All four drift checks (\`gen-swift-intents\`, \`dump-tool-manifest\`, \`stats:check\`, \`llms:check\`) — clean

## Remaining (RFC 0009 §4.1)
14 more Numbers tools queued (set_formula, set_range CSV, insert_row/column, delete_row/column, list_charts, duplicate_sheet, create_table, resize_table, etc.). Followups can lift this PR's pattern verbatim.