### PR TITLE
feat(quality): doctor --deep + correlation id surfaced in error envelope

### DIFF
--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -328,6 +328,73 @@ export async function runDoctor(): Promise<void> {
     }
   }
 
+  // ── Deep checks (opt-in) ──────────────────────────────────────────
+  // `--deep` runs slower live probes that aren't safe in the default
+  // doctor run: audit-log HMAC chain integrity, Swift bridge round-trip,
+  // module registry boot. Used in user-reported troubleshooting.
+  if (process.argv.includes("--deep")) {
+    console.log(heading("Deep checks (--deep)"));
+
+    // 1. Audit log HMAC chain — single-line tampering probe.
+    const s4 = spinner("Verifying audit log HMAC chain...");
+    try {
+      const auditMod = await import("../shared/audit.js");
+      const summary = await auditMod.summarizeAuditEntries({});
+      s4.succeed("Audit verification complete");
+      if (summary.auditDisabled) {
+        meh("Audit log", "currently disabled (recovery window — re-enables on next call)");
+      } else if (summary.verified) {
+        ok("Audit HMAC chain", `verified across ${summary.scannedFiles} file(s), ${summary.total} entries`);
+      } else if (summary.verifiedFirstBreak) {
+        const b = summary.verifiedFirstBreak;
+        bad("Audit HMAC chain", `break at ${b.file}:${b.lineIndex} (${b.reason}) — possible tampering or corruption`);
+      } else {
+        meh("Audit HMAC chain", "no chained entries on disk yet");
+      }
+    } catch (e) {
+      s4.fail("Audit verification failed");
+      meh("Audit HMAC chain", `error: ${e instanceof Error ? e.message : String(e)}`);
+    }
+
+    // 2. Swift bridge live ping. checkSwiftBridge resolves to null when
+    //    everything is fine, or a string with the human-readable reason.
+    const s5 = spinner("Pinging Swift bridge...");
+    try {
+      const swiftMod = await import("../shared/swift.js");
+      const missing = await swiftMod.checkSwiftBridge();
+      s5.succeed("Swift bridge probe complete");
+      if (!missing) {
+        ok("Swift bridge", "responsive");
+      } else {
+        meh("Swift bridge", missing);
+      }
+    } catch (e) {
+      s5.fail("Swift bridge probe failed");
+      meh("Swift bridge", `error: ${e instanceof Error ? e.message : String(e)}`);
+    }
+
+    // 3. Module registry boot smoke. Loads every module's tools.ts +
+    //    optional prompts.ts the same way the runtime does and reports
+    //    any module that fails to import (typo in a script.ts, missing
+    //    transitive dep, etc.).
+    const s6 = spinner("Loading module registry (boot smoke)...");
+    try {
+      const modulesMod = await import("../shared/modules.js");
+      const registry = await modulesMod.loadModuleRegistry();
+      s6.succeed("Module registry loaded");
+      ok("Module registry", `${registry.length} of ${MODULE_NAMES.length} modules loaded successfully`);
+      if (registry.length < MODULE_NAMES.length) {
+        meh(
+          "Module registry",
+          `${MODULE_NAMES.length - registry.length} module(s) failed — see stderr for the failed names`,
+        );
+      }
+    } catch (e) {
+      s6.fail("Module registry boot failed");
+      bad("Module registry", `import error: ${e instanceof Error ? e.message : String(e)}`);
+    }
+  }
+
   // ── Summary ────────────────────────────────────────────────────────
   console.log("");
   console.log(divider());
@@ -342,6 +409,11 @@ export async function runDoctor(): Promise<void> {
     console.log(`\n  ${DIM}Warnings are optional. AirMCP will work with current setup.${RESET}`);
   } else {
     console.log(`\n  ${GREEN}${BOLD}  All checks passed. AirMCP is ready.${RESET}`);
+  }
+  if (!process.argv.includes("--deep")) {
+    console.log(
+      `  ${DIM}Run \`npx airmcp doctor --deep\` for audit chain + Swift bridge + module registry probes.${RESET}`,
+    );
   }
   console.log("");
 }

--- a/src/shared/error-categories.ts
+++ b/src/shared/error-categories.ts
@@ -59,6 +59,10 @@ export interface ToolErrorPayload {
     code?: string;
     origin?: ErrorOrigin;
   };
+  /** Auto-attached correlation ID for cross-log tracing. Pairs with
+   *  the same field on `audit.jsonl` entries — `grep <id>` joins
+   *  the failed tool result, the audit row, and any HITL prompt. */
+  correlationId?: string;
 }
 
 /**

--- a/src/shared/result.ts
+++ b/src/shared/result.ts
@@ -1,6 +1,7 @@
 import { getToolLinks, withLinks } from "./tool-links.js";
 import { usageTracker } from "./usage-tracker.js";
 import { CATEGORY_RETRYABLE, type ErrorCategory, type ErrorOrigin, type ToolErrorPayload } from "./error-categories.js";
+import { getCorrelationId } from "./request-context.js";
 
 /** Return a successful MCP tool response with JSON-formatted data. */
 export function ok(data: unknown) {
@@ -121,10 +122,15 @@ export interface ToolErrorOptions {
   retryAfterMs?: number;
   hint?: string;
   cause?: { code?: string; origin?: ErrorOrigin };
+  /** Override the auto-attached correlation ID. Useful for tests; in
+   *  production the active request-context value is picked up
+   *  automatically. */
+  correlationId?: string;
 }
 
 export function toolErr(category: ErrorCategory, message: string, opts: ToolErrorOptions = {}) {
   const retryable = opts.retryable ?? (opts.retryAfterMs !== undefined ? true : CATEGORY_RETRYABLE[category]);
+  const correlationId = opts.correlationId ?? getCorrelationId();
 
   const payload: ToolErrorPayload = {
     category,
@@ -133,10 +139,16 @@ export function toolErr(category: ErrorCategory, message: string, opts: ToolErro
     ...(opts.retryAfterMs !== undefined ? { retryAfterMs: opts.retryAfterMs } : {}),
     ...(opts.hint ? { hint: opts.hint } : {}),
     ...(opts.cause ? { cause: opts.cause } : {}),
+    ...(correlationId ? { correlationId } : {}),
   };
 
   const lines = [`[${category}] ${message}`];
   if (opts.hint) lines.push(`Hint: ${opts.hint}`);
+  if (correlationId) {
+    // One-line trace breadcrumb so a user looking at a failed tool call
+    // can grep the audit log directly: `grep <id> ~/.airmcp/audit.jsonl`.
+    lines.push(`Trace: ${correlationId}`);
+  }
 
   return {
     content: [{ type: "text" as const, text: lines.join("\n") }],


### PR DESCRIPTION
Two DX / Ops polish items from the May 2026 quality sweep — top of the "즉시 가능" list (Track A).

## 1. \`npx airmcp doctor --deep\` (\`src/cli/doctor.ts\`)
Default \`doctor\` stays fast. The new flag opts in to slower live probes useful for user-reported troubleshooting:

- **HMAC chain verification** across all on-disk audit JSONL files. Surfaces single-line tampering with the exact file + line number via the existing \`summarizeAuditEntries\` \`verifiedFirstBreak\` field.
- **Swift bridge live ping** (\`checkSwiftBridge\`). Distinguishes "not built" (default doctor) from "built but unresponsive."
- **Module registry boot smoke** — \`loadModuleRegistry\` actually imports every \`tools.ts\` + \`prompts.ts\`. Surfaces typos / missing transitive deps that ride the eager-import path at startup.

Footer of the default \`doctor\` now prints the hint pointing at \`--deep\`.

## 2. Correlation ID in the error envelope (\`src/shared/result.ts\`, \`src/shared/error-categories.ts\`)
\`toolErr()\` now auto-attaches the active context's correlation id to:
- \`structuredContent.error.correlationId\` (machine-readable)
- A trailing \`Trace: <id>\` line in the human-readable text

PR #190 already added the id to every audit row; this closes the loop on the user side so a failed tool call carries the id needed for \`grep <id> ~/.airmcp/audit.jsonl\`. \`ToolErrorOptions\` gains an explicit \`correlationId\` override for tests.

## Test plan
- [x] \`npm run typecheck\` — clean
- [x] \`npm test\` — 101 suites / 1640 tests pass (no behavior change to existing flows)
- [x] \`npm run lint\` — clean
- [x] All drift checks (\`gen-swift-intents\`, \`dump-tool-manifest\`, \`stats:check\`, \`llms:check\`) — clean