### PR TITLE
refactor: simplify pass over prs #198/#199

### DIFF
--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -329,10 +329,11 @@ export async function runDoctor(): Promise<void> {
   }
 
   // ── Deep checks (opt-in) ──────────────────────────────────────────
-  // `--deep` runs slower live probes that aren't safe in the default
-  // doctor run: audit-log HMAC chain integrity, Swift bridge round-trip,
-  // module registry boot. Used in user-reported troubleshooting.
-  if (process.argv.includes("--deep")) {
+  // `--deep` runs slower live probes useful for user-reported triage:
+  // audit-log HMAC chain integrity, Swift bridge round-trip, module
+  // registry boot.
+  const deepFlag = process.argv.includes("--deep");
+  if (deepFlag) {
     console.log(heading("Deep checks (--deep)"));
 
     // 1. Audit log HMAC chain — single-line tampering probe.
@@ -347,7 +348,11 @@ export async function runDoctor(): Promise<void> {
         ok("Audit HMAC chain", `verified across ${summary.scannedFiles} file(s), ${summary.total} entries`);
       } else if (summary.verifiedFirstBreak) {
         const b = summary.verifiedFirstBreak;
-        bad("Audit HMAC chain", `break at ${b.file}:${b.lineIndex} (${b.reason}) — possible tampering or corruption`);
+        bad(
+          "Audit HMAC chain",
+          `break at ${b.file}:${b.lineIndex} (${b.reason}) — possible tampering or corruption. ` +
+            `Inspect the surrounding lines, then call audit_summary to see the full break window.`,
+        );
       } else {
         meh("Audit HMAC chain", "no chained entries on disk yet");
       }
@@ -410,7 +415,7 @@ export async function runDoctor(): Promise<void> {
   } else {
     console.log(`\n  ${GREEN}${BOLD}  All checks passed. AirMCP is ready.${RESET}`);
   }
-  if (!process.argv.includes("--deep")) {
+  if (!deepFlag) {
     console.log(
       `  ${DIM}Run \`npx airmcp doctor --deep\` for audit chain + Swift bridge + module registry probes.${RESET}`,
     );

--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -233,6 +233,50 @@ const I18N: Record<string, Record<LangCode, string>> = {
     de: "N\u00E4chste Schritte",
     pt: "Pr\u00F3ximos passos",
   },
+  try_asking: {
+    en: "Try asking your AI:",
+    ko: "AI\uC5D0\uAC8C \uBB3C\uC5B4\uBCF4\uC138\uC694:",
+    ja: "AI\u306B\u8A66\u3057\u306B\u805E\u3044\u3066\u307F\u3066:",
+    "zh-CN": "\u8BD5\u8BD5\u95EE\u4F60\u7684 AI:",
+    "zh-TW": "\u8A66\u8A66\u554F\u4F60\u7684 AI:",
+    es: "Prueba preguntando a tu IA:",
+    fr: "Essayez de demander \u00E0 votre IA :",
+    de: "Frage deine KI:",
+    pt: "Experimente perguntar \u00E0 sua IA:",
+  },
+  prompt_calendar_today: {
+    en: "What's on my calendar today?",
+    ko: "\uC624\uB298 \uC77C\uC815\uC774 \uBB34\uC5C7\uC778\uAC00\uC694?",
+    ja: "\u4ECA\u65E5\u306E\u30B9\u30B1\u30B8\u30E5\u30FC\u30EB\u306F\uFF1F",
+    "zh-CN": "\u6211\u4ECA\u5929\u7684\u65E5\u7A0B\u5B89\u6392\u5982\u4F55\uFF1F",
+    "zh-TW": "\u6211\u4ECA\u5929\u7684\u884C\u7A0B\u5B89\u6392\u5982\u4F55\uFF1F",
+    es: "\u00BFQu\u00E9 hay en mi calendario hoy?",
+    fr: "Qu\u2019y a-t-il \u00E0 mon agenda aujourd\u2019hui ?",
+    de: "Was steht heute in meinem Kalender?",
+    pt: "O que tenho na agenda hoje?",
+  },
+  prompt_summarize_notes: {
+    en: "Read my latest notes and summarize them",
+    ko: "\uCD5C\uADFC \uBA54\uBAA8\uB97C \uC77D\uACE0 \uC694\uC57D\uD574\uC8FC\uC138\uC694",
+    ja: "\u6700\u8FD1\u306E\u30E1\u30E2\u3092\u8AAD\u3093\u3067\u8981\u7D04\u3057\u3066\u304F\u3060\u3055\u3044",
+    "zh-CN": "\u9605\u8BFB\u6700\u8FD1\u7684\u7B14\u8BB0\u5E76\u603B\u7ED3",
+    "zh-TW": "\u95B1\u8B80\u6700\u8FD1\u7684\u7B46\u8A18\u4E26\u7E3D\u7D50",
+    es: "Lee mis \u00FAltimas notas y res\u00FAmelas",
+    fr: "Lis mes derni\u00E8res notes et r\u00E9sume-les",
+    de: "Lies meine letzten Notizen und fasse sie zusammen",
+    pt: "Leia minhas notas recentes e resuma-as",
+  },
+  prompt_overdue_reminders: {
+    en: "Show overdue reminders and reschedule them to tomorrow",
+    ko: "\uC9C0\uB09C \uB9AC\uB9C8\uC778\uB354\uB97C \uBCF4\uC5EC\uC8FC\uACE0 \uB0B4\uC77C\uB85C \uC62E\uACA8\uC8FC\uC138\uC694",
+    ja: "\u671F\u9650\u5207\u308C\u306E\u30EA\u30DE\u30A4\u30F3\u30C0\u30FC\u3092\u660E\u65E5\u306B\u518D\u30B9\u30B1\u30B8\u30E5\u30FC\u30EB",
+    "zh-CN": "\u663E\u793A\u8FC7\u671F\u63D0\u9192\u5E76\u91CD\u65B0\u5B89\u6392\u5230\u660E\u5929",
+    "zh-TW": "\u986F\u793A\u903E\u671F\u63D0\u9192\u4E26\u91CD\u65B0\u5B89\u6392\u5230\u660E\u5929",
+    es: "Muestra recordatorios atrasados y reprogr\u00E1malos para ma\u00F1ana",
+    fr: "Affiche les rappels en retard et reprogramme-les \u00E0 demain",
+    de: "Zeige \u00FCberf\u00E4llige Erinnerungen und verschiebe sie auf morgen",
+    pt: "Mostre lembretes atrasados e reagende-os para amanh\u00E3",
+  },
 };
 
 function t(key: string, lang: LangCode): string {
@@ -477,9 +521,9 @@ export async function runInit(): Promise<void> {
   console.log(`    ${DIM}\u2022${RESET} Re-run ${BOLD}npx airmcp init${RESET} anytime to change modules`);
   console.log(`    ${DIM}\u2022${RESET} Use ${BOLD}npx airmcp --full${RESET} to enable all modules temporarily`);
   console.log("");
-  console.log(`  ${DIM}Try asking your AI:${RESET}`);
-  console.log(`    ${DIM}\u201c${RESET}What's on my calendar today?${DIM}\u201d${RESET}`);
-  console.log(`    ${DIM}\u201c${RESET}Read my latest notes and summarize them${DIM}\u201d${RESET}`);
-  console.log(`    ${DIM}\u201c${RESET}Show overdue reminders and reschedule them to tomorrow${DIM}\u201d${RESET}`);
+  console.log(`  ${DIM}${t("try_asking", lang)}${RESET}`);
+  console.log(`    ${DIM}\u201c${RESET}${t("prompt_calendar_today", lang)}${DIM}\u201d${RESET}`);
+  console.log(`    ${DIM}\u201c${RESET}${t("prompt_summarize_notes", lang)}${DIM}\u201d${RESET}`);
+  console.log(`    ${DIM}\u201c${RESET}${t("prompt_overdue_reminders", lang)}${DIM}\u201d${RESET}`);
   console.log("");
 }

--- a/src/shared/result.ts
+++ b/src/shared/result.ts
@@ -169,18 +169,18 @@ export function errNotFound(message: string, opts?: ToolErrorOptions) {
  *  didn't supply a more specific one. Points the user at the macOS
  *  Privacy & Security pane, which is the canonical fix for the JXA /
  *  Automation / Accessibility / Screen Recording denials AirMCP hits.
- *  Operators on non-darwin (CI runners, Linux clones) get a generic
- *  hint instead. */
-const PERMISSION_HINT_MACOS =
-  "Open System Settings → Privacy & Security and grant the requested permission, then re-run the tool.";
+ *  Empty on non-darwin (CI runners, Linux clones) — there's no
+ *  equivalent settings pane to advertise. */
+const DEFAULT_PERMISSION_HINT =
+  process.platform === "darwin"
+    ? "Open System Settings → Privacy & Security and grant the requested permission, then re-run the tool."
+    : "";
 
 export function errPermission(message: string, opts?: ToolErrorOptions) {
-  // Auto-attach the macOS Settings deep-link as a hint when the caller
-  // didn't supply one. Honors any caller-provided hint verbatim.
-  const withHint: ToolErrorOptions = opts?.hint
-    ? opts
-    : { ...opts, hint: process.platform === "darwin" ? PERMISSION_HINT_MACOS : (opts?.hint ?? "") };
-  return toolErr("permission_denied", message, withHint);
+  // Caller-supplied hint wins. Fall through to the platform default
+  // when the caller doesn't supply one.
+  const hint = opts?.hint || DEFAULT_PERMISSION_HINT;
+  return toolErr("permission_denied", message, { ...opts, hint });
 }
 
 export function errUpstream(message: string, opts?: ToolErrorOptions) {


### PR DESCRIPTION
Three findings from \`/simplify\` on the \`doctor --deep\` + correlation-id + init-prompts work that just landed.

## 1. \`result.ts\` \`errPermission\` — collapse dead-code hint composition
The previous \`opts?.hint ?? ''\` branch could only ever produce \`''\` (it was the \`!opts?.hint\` case). Hoisted the platform check to a module-level \`DEFAULT_PERMISSION_HINT\` const (resolved once at load instead of every error) and use a plain \`||\` fallback at call sites. Functionally identical, three lines shorter, no per-call platform string compare.

## 2. \`doctor.ts\` \`deepFlag\` variable + audit-chain actionable hint
Pulled \`process.argv.includes('--deep')\` into a single local const and reused for both the deep-checks block AND the trailing footer hint. Also widened the audit-chain bad message to include actionable follow-up: *"Inspect the surrounding lines, then call audit_summary to see the full break window."*

## 3. \`init.ts\` example prompts — i18n
Was: three English strings hardcoded in \`console.log\` even when the wizard ran in another locale (the bullets immediately above already routed through \`t()\`). Now goes through the existing \`t()\` helper with four new keys (\`try_asking\`, \`prompt_calendar_today\`, \`prompt_summarize_notes\`, \`prompt_overdue_reminders\`) translated across all 9 locales the wizard already supports.

## Skipped (false positives)
- **\`Trace:\` line backwards compat** — RFC 0001 envelope already specifies multi-line text content; existing \`Hint:\` line precedent.
- **doctor --deep block narrative comments** — section labels are intentional, not redundant.
- **Module-level \`PERMISSION_HINT_MACOS\` const placement** — fine inline; keeping it in \`result.ts\` mirrors the existing local-const style for \`SIZE_HINT_THRESHOLD\` etc.

## Test plan
- [x] \`npm run typecheck\` — clean
- [x] \`npm test\` — 101 suites / 1640 tests pass (no behavior change)
- [x] \`npm run lint\` — clean