### PR TITLE
fix(eventkit): reset shared store after permission grant — closes #145

### DIFF
--- a/swift/Sources/AirMCPKit/EventKitService.swift
+++ b/swift/Sources/AirMCPKit/EventKitService.swift
@@ -357,6 +357,14 @@ public struct EventKitService: Sendable {
     }
 
     /// Shared authorization logic for EventKit stores.
+    ///
+    /// Issue #145: a freshly-granted `EKEventStore` can return an empty
+    /// `calendars(for:)` array even though the user has calendars
+    /// available — the shared store keeps the pre-authorization snapshot
+    /// of sources and never picks up the now-readable data. `reset()`
+    /// after the grant clears that snapshot so the very next call sees
+    /// the real backing data. Idempotent across subsequent calls because
+    /// `flag` short-circuits.
     private func authorize(
         store: EKEventStore,
         flag: OSAllocatedUnfairLock<Bool>,
@@ -367,6 +375,7 @@ public struct EventKitService: Sendable {
         if !isAuthorized {
             let granted = try await request(store)
             guard granted else { throw AirMCPKitError.permissionDenied(errorMessage) }
+            store.reset()
             flag.withLock { $0 = true }
         }
         return store


### PR DESCRIPTION
Closes #145.

User-reported (@jagaliano): \`list_calendars\` returns an empty array even though Calendar.app shows the user's calendars and the Calendar permission has been granted. Reproduces on macOS 15.7.5 via the Swift bridge.

## Root cause

A freshly-granted \`EKEventStore\` keeps the snapshot it had from *before* authorization. \`calendars(for: .event)\` reads that stale snapshot rather than the now-readable backing data, so it surfaces an empty list. The store needs an explicit \`reset()\` after the grant to drop the cached sources/calendars and pick up the post-auth state.

## Fix

In the shared \`authorize()\` helper (used by both the events and reminders paths in \`EventKitService\`), call \`store.reset()\` between the granted check and flagging the store as authorized. Idempotent across subsequent calls because the flag short-circuits — \`reset()\` only fires the first time through after a grant.

The reporter proposed the same shape via a \`postGrant\` callback per request; consolidating into the helper covers both events + reminders in one place since both share the same authorize() flow.

## Verification

- Issue reporter applied the same patch shape locally and confirmed \`list_calendars\` returned their actual calendars.
- Local \`cd swift && swift build\` passes (Swift 6.2.3 toolchain).
- JXA path is unaffected — Calendar.app scripting reads through Calendar's own data store, not EventKit.

## Test plan
- [x] \`cd swift && swift build\` — clean
- [x] \`npm run typecheck\` — clean (no TS surface change)
- [x] \`npm test\` — 101 suites / 1640 tests pass

Thanks to @jagaliano for the high-quality bug report — clear repro, isolated root cause, and a verified patch shape.