### PR TITLE
feat(numbers): rfc 0009 phase 1 batch 2 — list_charts / set_formula / set_range / resize_table

### DIFF
--- a/.github/AGENTS.md
+++ b/.github/AGENTS.md
@@ -83,7 +83,7 @@ tests/                    # Script generator tests
 
 ## Stats
 
-- **272 tools** across 27 modules (+ dynamic shortcut tools at runtime)
+- **276 tools** across 27 modules (+ dynamic shortcut tools at runtime)
 - **32 prompts** (per-module + cross-module + YAML skills)
 - **8 MCP resources** (Notes, Calendar, Reminders, Music, Mail, System, Context Snapshot)
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ MCP server for the entire Apple ecosystem — Notes, Reminders, Calendar, Contac
 
 ## Features
 
-- **272 tools** (29 modules) — Apple app CRUD + system control + Apple Intelligence + UI Automation + Screen Capture + Maps + Podcasts + Weather + iWork (Pages/Numbers/Keynote) + Google Workspace + dynamic shortcuts + context memory + audit introspection
+- **276 tools** (29 modules) — Apple app CRUD + system control + Apple Intelligence + UI Automation + Screen Capture + Maps + Podcasts + Weather + iWork (Pages/Numbers/Keynote) + Google Workspace + dynamic shortcuts + context memory + audit introspection
 - **229 Shortcuts / Siri AppIntents** — auto-generated from the tool manifest (50 Interactive Snippet views + 17 AppEnum pickers); `AskAirMCPIntent` natural-language agent on iOS 26+/macOS 26+ via FoundationModels
 - **34 prompts + 14 YAML skill built-ins** — per-app workflows + cross-module + developer workflows + Skills DSL (`inputs` / `parallel` / `loop` / `on_error` / `retry` / 9 event triggers)
 - **9 MCP resources** — Notes, Calendar, Reminders, Music, Mail, System, Context Memory + unified `context://snapshot/{depth}`

--- a/docs/TERMS_OF_SERVICE.md
+++ b/docs/TERMS_OF_SERVICE.md
@@ -19,7 +19,7 @@ AirMCP is open-source software released under the [MIT License](../LICENSE). The
 
 You are solely responsible for:
 
-- **AI agent actions.** AirMCP enables AI agents to perform actions on your Mac through 272 tools across 29 modules. Any action an AI agent takes through AirMCP is performed on your behalf and at your direction. You are responsible for the outcomes of those actions.
+- **AI agent actions.** AirMCP enables AI agents to perform actions on your Mac through 276 tools across 29 modules. Any action an AI agent takes through AirMCP is performed on your behalf and at your direction. You are responsible for the outcomes of those actions.
 - **Safety controls.** AirMCP provides a Human-in-the-Loop (HITL) approval system with configurable levels. It is your responsibility to configure an appropriate HITL level for your use case. Running AirMCP with HITL disabled means AI agents can execute destructive actions without confirmation.
 - **HTTP mode security.** If you enable HTTP mode for remote access, you are responsible for securing it. This includes configuring token-based authentication, restricting network access, and ensuring the server is not exposed to untrusted networks.
 - **Legal compliance.** You must comply with all applicable local, state, national, and international laws when using AirMCP. This includes laws governing privacy, electronic communications, data protection, and computer access.

--- a/docs/index.html
+++ b/docs/index.html
@@ -499,7 +499,7 @@
           <span class="term-prompt-text" data-i18n="tryit_6">"Today's meetings → related notes → prep checklist"</span>
         </button>
       </div>
-      <p class="text-center mt-6 text-sm opacity-25 reveal" data-delay="200" data-i18n="tryit_footer">272 tools. Endless combinations.</p>
+      <p class="text-center mt-6 text-sm opacity-25 reveal" data-delay="200" data-i18n="tryit_footer">276 tools. Endless combinations.</p>
     </div>
   </section>
 

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -1,6 +1,6 @@
 # AirMCP Skills Guide
 
-A practical guide for AI agents to effectively use AirMCP's 272 tools across 29 modules to orchestrate the Apple ecosystem via MCP.
+A practical guide for AI agents to effectively use AirMCP's 276 tools across 29 modules to orchestrate the Apple ecosystem via MCP.
 
 ## Overview
 

--- a/docs/tool-manifest.json
+++ b/docs/tool-manifest.json
@@ -1,8 +1,8 @@
 {
   "generatedAt": "STABLE_PLACEHOLDER",
   "protocolVersion": "2025-06-18",
-  "toolCount": 285,
-  "eligibleCount": 280,
+  "toolCount": 289,
+  "eligibleCount": 284,
   "ineligibleCount": 5,
   "ineligibleByReason": {
     "object-param:recurrence": 2,
@@ -7282,6 +7282,41 @@
       "ineligibleReason": null
     },
     {
+      "name": "numbers_list_charts",
+      "title": "List Numbers Charts",
+      "description": "List every chart in a Numbers sheet with its name + chart type. A sheet can carry multiple charts (revenue trend + segment pie + region bar); a model picking which one to interrogate or update needs to enumerate them first. Symmetric to numbers_list_tables.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "document": {
+            "type": "string",
+            "maxLength": 500,
+            "description": "Document name"
+          },
+          "sheet": {
+            "type": "string",
+            "maxLength": 500,
+            "description": "Sheet name"
+          }
+        },
+        "required": [
+          "document",
+          "sheet"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false
+      },
+      "appIntentEligible": true,
+      "ineligibleReason": null
+    },
+    {
       "name": "numbers_list_documents",
       "title": "List Numbers Documents",
       "description": "List all open Numbers spreadsheets.",
@@ -7466,6 +7501,69 @@
       "ineligibleReason": null
     },
     {
+      "name": "numbers_resize_table",
+      "title": "Resize Numbers Table",
+      "description": "Resize a table by setting its rowCount and/or columnCount. Growing appends empty rows/columns on the bottom/right. Shrinking DISCARDS the trailing rows/columns AND THEIR CONTENT — destructive. Pass null for either dimension to leave it unchanged.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "document": {
+            "type": "string",
+            "maxLength": 500,
+            "description": "Document name"
+          },
+          "sheet": {
+            "type": "string",
+            "maxLength": 500,
+            "description": "Sheet name"
+          },
+          "rowCount": {
+            "anyOf": [
+              {
+                "type": "integer",
+                "minimum": 1,
+                "maximum": 100000
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "New row count (null to leave unchanged). Shrinking truncates trailing rows."
+          },
+          "columnCount": {
+            "anyOf": [
+              {
+                "type": "integer",
+                "minimum": 1,
+                "maximum": 1000
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "New column count (null to leave unchanged). Shrinking truncates trailing columns."
+          }
+        },
+        "required": [
+          "document",
+          "sheet",
+          "rowCount",
+          "columnCount"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": true,
+        "idempotentHint": true,
+        "openWorldHint": false
+      },
+      "appIntentEligible": true,
+      "ineligibleReason": null
+    },
+    {
       "name": "numbers_set_cell",
       "title": "Set Numbers Cell",
       "description": "Write a value to a single cell.",
@@ -7498,6 +7596,110 @@
           "sheet",
           "cell",
           "value"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false
+      },
+      "appIntentEligible": true,
+      "ineligibleReason": null
+    },
+    {
+      "name": "numbers_set_formula",
+      "title": "Set Numbers Cell Formula",
+      "description": "Write a formula expression to a cell (e.g. '=SUM(A1:A10)'). The leading '=' is optional — passing 'SUM(A1:A10)' or '=SUM(A1:A10)' both work. Errors in the formula (bad reference, unknown function) surface as errJxa with the Numbers parse message. Symmetric to numbers_get_formula.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "document": {
+            "type": "string",
+            "maxLength": 500,
+            "description": "Document name"
+          },
+          "sheet": {
+            "type": "string",
+            "maxLength": 500,
+            "description": "Sheet name"
+          },
+          "cell": {
+            "type": "string",
+            "maxLength": 500,
+            "description": "Cell address (e.g. 'A1')"
+          },
+          "formula": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 10000,
+            "description": "Formula expression — '=' prefix optional"
+          }
+        },
+        "required": [
+          "document",
+          "sheet",
+          "cell",
+          "formula"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "outputSchema": null,
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false
+      },
+      "appIntentEligible": true,
+      "ineligibleReason": null
+    },
+    {
+      "name": "numbers_set_range",
+      "title": "Set Numbers Cell Range",
+      "description": "Bulk-write a 2D rectangular block of string values starting at a top-left cell address (e.g. 'B2'). Each value is written via the .value setter — values starting with '=' are parsed as formulas (same as numbers_set_cell). Cell addresses use A1 notation; the script auto-extends past Z (AA, AB, …). Returns the count of cells written. Capped at 1000 cells per call to stay within Phase 1's range-size budget (RFC 0009 §6.2).",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "document": {
+            "type": "string",
+            "maxLength": 500,
+            "description": "Document name"
+          },
+          "sheet": {
+            "type": "string",
+            "maxLength": 500,
+            "description": "Sheet name"
+          },
+          "startCell": {
+            "type": "string",
+            "pattern": "^[A-Z]+[0-9]+$",
+            "maxLength": 20,
+            "description": "Top-left cell address in A1 notation (e.g. 'B2')"
+          },
+          "values": {
+            "type": "array",
+            "items": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "maxLength": 10000
+              }
+            },
+            "minItems": 1,
+            "maxItems": 1000,
+            "description": "2D array: outer = rows, inner = columns. Max 1000 cells total."
+          }
+        },
+        "required": [
+          "document",
+          "sheet",
+          "startCell",
+          "values"
         ],
         "additionalProperties": false,
         "$schema": "http://json-schema.org/draft-07/schema#"

--- a/glama.json
+++ b/glama.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://glama.ai/mcp/schemas/server.json",
   "name": "AirMCP",
-  "description": "MCP server for the entire Apple ecosystem — 272 tools across 29 modules. Notes, Reminders, Calendar, Contacts, Mail, Messages, Music, Finder, Safari, System, Photos, Shortcuts, Apple Intelligence, and more. Connect any AI to your Mac.",
+  "description": "MCP server for the entire Apple ecosystem — 276 tools across 29 modules. Notes, Reminders, Calendar, Contacts, Mail, Messages, Music, Finder, Safari, System, Photos, Shortcuts, Apple Intelligence, and more. Connect any AI to your Mac.",
   "icon": "https://raw.githubusercontent.com/heznpc/AirMCP/main/icons/airmcp-icon-256.png",
   "category": "automation",
   "maintainers": [

--- a/llms.txt
+++ b/llms.txt
@@ -1,6 +1,6 @@
 # AirMCP
 
-> MCP server for the entire Apple ecosystem. 272 tools across 29 modules.
+> MCP server for the entire Apple ecosystem. 276 tools across 29 modules.
 
 ## Links
 
@@ -29,7 +29,7 @@
 - **Messages** (6 tools): list_chats, read_chat, search_chats, send_message, send_file, list_participants
 - **Music** (17 tools): list_playlists, list_tracks, now_playing, playback_control, search_tracks, play_track, play_playlist, get_track_info, set_shuffle, create_playlist, add_to_playlist, remove_from_playlist, delete_playlist, get_rating, set_rating, set_favorited, set_disliked
 - **Notes** (12 tools): list_notes, search_notes, read_note, create_note, update_note, delete_note, list_folders, create_folder, move_note, scan_notes, compare_notes, bulk_move_notes
-- **Numbers** (12 tools): numbers_list_documents, numbers_create_document, numbers_list_sheets, numbers_get_cell, numbers_set_cell, numbers_read_cells, numbers_add_sheet, numbers_export_pdf, numbers_close_document, numbers_list_tables, numbers_get_formula, numbers_rename_sheet
+- **Numbers** (16 tools): numbers_list_documents, numbers_create_document, numbers_list_sheets, numbers_get_cell, numbers_set_cell, numbers_read_cells, numbers_add_sheet, numbers_export_pdf, numbers_close_document, numbers_list_tables, numbers_get_formula, numbers_rename_sheet, numbers_list_charts, numbers_set_formula, numbers_set_range, numbers_resize_table
 - **Pages** (7 tools): pages_list_documents, pages_open_document, pages_create_document, pages_get_body_text, pages_set_body_text, pages_export_pdf, pages_close_document
 - **Photos** (11 tools): list_albums, list_photos, search_photos, get_photo_info, list_favorites, create_album, add_to_album, import_photo, delete_photos, query_photos, classify_image
 - **Podcasts** (6 tools): list_podcast_shows, list_podcast_episodes, podcast_now_playing, podcast_playback_control, play_podcast_episode, search_podcast_episodes

--- a/mcp.json
+++ b/mcp.json
@@ -3,7 +3,7 @@
     "airmcp": {
       "command": "npx",
       "args": ["-y", "airmcp"],
-      "description": "MCP server for the entire Apple ecosystem — 272 tools across 29 modules. macOS only.",
+      "description": "MCP server for the entire Apple ecosystem — 276 tools across 29 modules. macOS only.",
       "env": {}
     }
   }

--- a/server.json
+++ b/server.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.heznpc/airmcp",
-  "description": "MCP server for the entire Apple ecosystem — 272 tools across 29 modules with YAML skills, context memory, queryable audit log, and declarative HTTP network policy. macOS only.",
+  "description": "MCP server for the entire Apple ecosystem — 276 tools across 29 modules with YAML skills, context memory, queryable audit log, and declarative HTTP network policy. macOS only.",
   "version": "2.12.0",
   "websiteUrl": "https://github.com/heznpc/AirMCP",
   "repository": {

--- a/smithery.yaml
+++ b/smithery.yaml
@@ -1,5 +1,5 @@
 name: airmcp
-description: MCP server for the entire Apple ecosystem — 272 tools across 29 modules (Notes, Reminders, Calendar, Contacts, Mail, Messages, Music, Finder, Safari, System, Photos, Shortcuts, Apple Intelligence, TV, Screen Capture, Maps, Podcasts, Weather, Pages, Numbers, Keynote, Location, Bluetooth). Connect any AI to your Mac.
+description: MCP server for the entire Apple ecosystem — 276 tools across 29 modules (Notes, Reminders, Calendar, Contacts, Mail, Messages, Music, Finder, Safari, System, Photos, Shortcuts, Apple Intelligence, TV, Screen Capture, Maps, Podcasts, Weather, Pages, Numbers, Keynote, Location, Bluetooth). Connect any AI to your Mac.
 homepage: https://github.com/heznpc/AirMCP
 icon: https://raw.githubusercontent.com/heznpc/AirMCP/main/icons/airmcp-icon-256.png
 license: MIT

--- a/src/numbers/scripts.ts
+++ b/src/numbers/scripts.ts
@@ -158,3 +158,114 @@ export function renameSheetScript(documentName: string, sheet: string, newName: 
     JSON.stringify({renamed: true, from: '${esc(sheet)}', to: '${esc(newName)}'});
   `;
 }
+
+/** RFC 0009 Phase 1 batch 2 — list every chart in a sheet with name + type
+ *  + source range. Symmetric to listTablesScript: a Numbers sheet can
+ *  carry multiple charts (revenue trend + pie of segments + bar of regions),
+ *  so a model picking which one to update needs to enumerate them first. */
+export function listChartsScript(documentName: string, sheet: string): string {
+  return `
+    const Numbers = Application('com.apple.Numbers');
+    ${iworkDocLookup("Numbers", documentName)}
+    const sheets = docs[0].sheets.whose({name: '${esc(sheet)}'})();
+    if (sheets.length === 0) throw new Error('Sheet not found: ${esc(sheet)}');
+    const charts = sheets[0].charts();
+    const result = charts.map(ch => {
+      let chartType = null;
+      try { chartType = ch.chartType(); } catch (e) { /* not exposed on every variant */ }
+      let chartName = null;
+      try { chartName = ch.name(); } catch (e) { /* default-named chart */ }
+      return { name: chartName, chartType: chartType };
+    });
+    JSON.stringify(result);
+  `;
+}
+
+/** RFC 0009 Phase 1 batch 2 — write a literal formula expression to a cell.
+ *  Symmetric to getFormulaScript. Numbers' \`.formula\` setter parses the
+ *  expression on assignment; \`=\` prefix normalised on the TS side so the
+ *  call works whether the model emits "=SUM(A1:A10)" or "SUM(A1:A10)".
+ *  Errors in the formula (bad reference, unknown function) surface as
+ *  errJxa with the Numbers-side parse message. */
+export function setFormulaScript(documentName: string, sheet: string, cell: string, formula: string): string {
+  const normalized = formula.startsWith("=") ? formula : "=" + formula;
+  return `
+    const Numbers = Application('com.apple.Numbers');
+    ${iworkDocLookup("Numbers", documentName)}
+    ${sheetTableLookup(sheet)}
+    table.cells['${esc(cell)}'].formula = '${esc(normalized)}';
+    JSON.stringify({written: true, address: '${esc(cell)}', formula: '${esc(normalized)}'});
+  `;
+}
+
+/** RFC 0009 Phase 1 batch 2 — bulk-write a 2D rectangular block of values
+ *  starting at a top-left cell address. Implemented as a set_cell loop
+ *  (no special Numbers JXA bulk-write verb exists in the public dictionary).
+ *  Cell addresses are computed from the start anchor + (row, col) offsets
+ *  using A1-style notation (A1, B1, ..., Z1, AA1, AB1, ...). Each cell
+ *  string value is set via \`.value = ...\`; if the value starts with \`=\`,
+ *  Numbers parses it as a formula automatically — same semantics as
+ *  set_cell. Returns the count of cells written. */
+export function setRangeScript(documentName: string, sheet: string, startCell: string, values: string[][]): string {
+  // Pre-compute the JXA payload as a JSON literal so the script doesn't have
+  // to splice arbitrary user content into JS string literals row-by-row.
+  // The double-stringify dance escapes embedded quotes correctly.
+  const payload = JSON.stringify(values);
+  return `
+    const Numbers = Application('com.apple.Numbers');
+    ${iworkDocLookup("Numbers", documentName)}
+    ${sheetTableLookup(sheet)}
+    const start = '${esc(startCell)}';
+    const m = start.match(/^([A-Z]+)([0-9]+)$/);
+    if (!m) throw new Error('Invalid start cell address: ' + start);
+    function colToNum(col) {
+      let n = 0;
+      for (const c of col) { n = n * 26 + (c.charCodeAt(0) - 64); }
+      return n;
+    }
+    function numToCol(n) {
+      let s = '';
+      while (n > 0) { const r = (n - 1) % 26; s = String.fromCharCode(65 + r) + s; n = Math.floor((n - 1) / 26); }
+      return s;
+    }
+    const startCol = colToNum(m[1]);
+    const startRow = parseInt(m[2], 10);
+    const values = ${payload};
+    let written = 0;
+    for (let r = 0; r < values.length; r++) {
+      for (let c = 0; c < values[r].length; c++) {
+        const addr = numToCol(startCol + c) + (startRow + r);
+        table.cells[addr].value = values[r][c];
+        written++;
+      }
+    }
+    JSON.stringify({written: written, startCell: start, rows: values.length, cols: values[0] ? values[0].length : 0});
+  `;
+}
+
+/** RFC 0009 Phase 1 batch 2 — resize a table by setting its rowCount /
+ *  columnCount in place. Numbers' JXA exposes both as settable integer
+ *  properties. Growing the table appends empty rows/columns on the
+ *  bottom/right; shrinking discards the trailing rows/columns AND THEIR
+ *  CONTENT — so this is destructiveHint: true. The PR uses it as the
+ *  primitive for future insert_row / append_row tools that don't need a
+ *  positional insert verb. */
+export function resizeTableScript(
+  documentName: string,
+  sheet: string,
+  rowCount: number | null,
+  columnCount: number | null,
+): string {
+  const setRow = rowCount !== null ? `table.rowCount = ${rowCount};` : "";
+  const setCol = columnCount !== null ? `table.columnCount = ${columnCount};` : "";
+  return `
+    const Numbers = Application('com.apple.Numbers');
+    ${iworkDocLookup("Numbers", documentName)}
+    ${sheetTableLookup(sheet)}
+    const before = { rowCount: table.rowCount(), columnCount: table.columnCount() };
+    ${setRow}
+    ${setCol}
+    const after = { rowCount: table.rowCount(), columnCount: table.columnCount() };
+    JSON.stringify({resized: true, before: before, after: after});
+  `;
+}

--- a/src/numbers/tools.ts
+++ b/src/numbers/tools.ts
@@ -17,6 +17,10 @@ import {
   listTablesScript,
   getFormulaScript,
   renameSheetScript,
+  listChartsScript,
+  setFormulaScript,
+  setRangeScript,
+  resizeTableScript,
 } from "./scripts.js";
 
 export function registerNumbersTools(server: McpServer, _config: AirMcpConfig): void {
@@ -267,6 +271,137 @@ export function registerNumbersTools(server: McpServer, _config: AirMcpConfig): 
         return ok(await runJxa(renameSheetScript(document, sheet, newName)));
       } catch (e) {
         return errJxaFor("rename Numbers sheet", e);
+      }
+    },
+  );
+
+  // RFC 0009 Phase 1 batch 2 — list_charts (read) + set_formula / set_range / resize_table (edit).
+
+  server.registerTool(
+    "numbers_list_charts",
+    {
+      title: "List Numbers Charts",
+      description:
+        "List every chart in a Numbers sheet with its name + chart type. " +
+        "A sheet can carry multiple charts (revenue trend + segment pie + region bar); " +
+        "a model picking which one to interrogate or update needs to enumerate them first. " +
+        "Symmetric to numbers_list_tables.",
+      inputSchema: {
+        document: z.string().max(500).describe("Document name"),
+        sheet: z.string().max(500).describe("Sheet name"),
+      },
+      annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: false },
+    },
+    async ({ document, sheet }) => {
+      try {
+        return ok(await runJxa(listChartsScript(document, sheet)));
+      } catch (e) {
+        return errJxaFor("list Numbers charts", e);
+      }
+    },
+  );
+
+  server.registerTool(
+    "numbers_set_formula",
+    {
+      title: "Set Numbers Cell Formula",
+      description:
+        "Write a formula expression to a cell (e.g. '=SUM(A1:A10)'). " +
+        "The leading '=' is optional — passing 'SUM(A1:A10)' or '=SUM(A1:A10)' both work. " +
+        "Errors in the formula (bad reference, unknown function) surface as errJxa with the Numbers parse message. " +
+        "Symmetric to numbers_get_formula.",
+      inputSchema: {
+        document: z.string().max(500).describe("Document name"),
+        sheet: z.string().max(500).describe("Sheet name"),
+        cell: z.string().max(500).describe("Cell address (e.g. 'A1')"),
+        formula: z.string().min(1).max(10000).describe("Formula expression — '=' prefix optional"),
+      },
+      annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: true, openWorldHint: false },
+    },
+    async ({ document, sheet, cell, formula }) => {
+      try {
+        return ok(await runJxa(setFormulaScript(document, sheet, cell, formula)));
+      } catch (e) {
+        return errJxaFor("set Numbers formula", e);
+      }
+    },
+  );
+
+  server.registerTool(
+    "numbers_set_range",
+    {
+      title: "Set Numbers Cell Range",
+      description:
+        "Bulk-write a 2D rectangular block of string values starting at a top-left cell address (e.g. 'B2'). " +
+        "Each value is written via the .value setter — values starting with '=' are parsed as formulas (same as numbers_set_cell). " +
+        "Cell addresses use A1 notation; the script auto-extends past Z (AA, AB, …). " +
+        "Returns the count of cells written. Capped at 1000 cells per call to stay within Phase 1's range-size budget (RFC 0009 §6.2).",
+      inputSchema: {
+        document: z.string().max(500).describe("Document name"),
+        sheet: z.string().max(500).describe("Sheet name"),
+        startCell: z
+          .string()
+          .regex(/^[A-Z]+[0-9]+$/)
+          .max(20)
+          .describe("Top-left cell address in A1 notation (e.g. 'B2')"),
+        values: z
+          .array(z.array(z.string().max(10000)))
+          .min(1)
+          .max(1000)
+          .describe("2D array: outer = rows, inner = columns. Max 1000 cells total."),
+      },
+      annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: true, openWorldHint: false },
+    },
+    async ({ document, sheet, startCell, values }) => {
+      try {
+        const total = values.reduce((sum: number, row: string[]) => sum + row.length, 0);
+        if (total > 1000) {
+          throw new Error(`Range size ${total} exceeds Phase 1 cap of 1000 cells (RFC 0009 §6.2)`);
+        }
+        return ok(await runJxa(setRangeScript(document, sheet, startCell, values)));
+      } catch (e) {
+        return errJxaFor("set Numbers range", e);
+      }
+    },
+  );
+
+  server.registerTool(
+    "numbers_resize_table",
+    {
+      title: "Resize Numbers Table",
+      description:
+        "Resize a table by setting its rowCount and/or columnCount. " +
+        "Growing appends empty rows/columns on the bottom/right. " +
+        "Shrinking DISCARDS the trailing rows/columns AND THEIR CONTENT — destructive. " +
+        "Pass null for either dimension to leave it unchanged.",
+      inputSchema: {
+        document: z.string().max(500).describe("Document name"),
+        sheet: z.string().max(500).describe("Sheet name"),
+        rowCount: z
+          .number()
+          .int()
+          .min(1)
+          .max(100000)
+          .nullable()
+          .describe("New row count (null to leave unchanged). Shrinking truncates trailing rows."),
+        columnCount: z
+          .number()
+          .int()
+          .min(1)
+          .max(1000)
+          .nullable()
+          .describe("New column count (null to leave unchanged). Shrinking truncates trailing columns."),
+      },
+      annotations: { readOnlyHint: false, destructiveHint: true, idempotentHint: true, openWorldHint: false },
+    },
+    async ({ document, sheet, rowCount, columnCount }) => {
+      try {
+        if (rowCount === null && columnCount === null) {
+          throw new Error("At least one of rowCount or columnCount must be provided");
+        }
+        return ok(await runJxa(resizeTableScript(document, sheet, rowCount, columnCount)));
+      } catch (e) {
+        return errJxaFor("resize Numbers table", e);
       }
     },
   );

--- a/swift/Sources/AirMCPKit/Generated/MCPIntents.swift
+++ b/swift/Sources/AirMCPKit/Generated/MCPIntents.swift
@@ -2,7 +2,7 @@
 //
 // Source: docs/tool-manifest.json
 // Generator: scripts/gen-swift-intents.mjs
-// RFC 0007 Phase A.2b.2 + A.4.1 — 232 auto-selected read-only
+// RFC 0007 Phase A.2b.2 + A.4.1 — 235 auto-selected read-only
 // tools (65 with typed drift-guards + Interactive Snippet
 // SwiftUI views) + 9 AppShortcutsProvider entries.
 // Run `npm run gen:intents` to refresh after tool metadata changes.
@@ -4579,6 +4579,29 @@ public struct NumbersGetFormulaIntent: AppIntent {
     }
 }
 
+// Tool: numbers_list_charts
+public struct NumbersListChartsIntent: AppIntent {
+    nonisolated(unsafe) public static var title: LocalizedStringResource = "List Numbers Charts"
+    nonisolated(unsafe) public static var description = IntentDescription("List every chart in a Numbers sheet with its name + chart type. A sheet can carry multiple charts (revenue trend + segment pie + region bar); a model picking which one to interrogate or update needs to enumerate them first. Symmetric to numbers_list_tables.")
+    nonisolated(unsafe) public static var openAppWhenRun: Bool = false
+
+    public init() {}
+
+    @Parameter(title: "Document name")
+    public var document: String
+
+    @Parameter(title: "Sheet name")
+    public var sheet: String
+
+    public func perform() async throws -> some IntentResult & ReturnsValue<String> {
+        let result = try await MCPIntentRouter.shared.call(
+            tool: "numbers_list_charts",
+            args: ["document": document, "sheet": sheet]
+        )
+        return .result(value: result)
+    }
+}
+
 // Tool: numbers_list_documents
 public struct NumbersListDocumentsIntent: AppIntent {
     nonisolated(unsafe) public static var title: LocalizedStringResource = "List Numbers Documents"
@@ -4724,6 +4747,61 @@ public struct NumbersSetCellIntent: AppIntent {
         let result = try await MCPIntentRouter.shared.call(
             tool: "numbers_set_cell",
             args: ["document": document, "sheet": sheet, "cell": cell, "value": value]
+        )
+        return .result(value: result)
+    }
+}
+
+// Tool: numbers_set_formula
+public struct NumbersSetFormulaIntent: AppIntent {
+    nonisolated(unsafe) public static var title: LocalizedStringResource = "Set Numbers Cell Formula"
+    nonisolated(unsafe) public static var description = IntentDescription("Write a formula expression to a cell (e.g. '=SUM(A1:A10)'). The leading '=' is optional — passing 'SUM(A1:A10)' or '=SUM(A1:A10)' both work. Errors in the formula (bad reference, unknown function) surface as errJxa with the Numbers parse message. Symmetric to numbers_get_formula.")
+    nonisolated(unsafe) public static var openAppWhenRun: Bool = false
+
+    public init() {}
+
+    @Parameter(title: "Document name")
+    public var document: String
+
+    @Parameter(title: "Sheet name")
+    public var sheet: String
+
+    @Parameter(title: "Cell address (e.g. 'A1')")
+    public var cell: String
+
+    @Parameter(title: "Formula expression — '=' prefix optional")
+    public var formula: String
+
+    public func perform() async throws -> some IntentResult & ReturnsValue<String> {
+        let result = try await MCPIntentRouter.shared.call(
+            tool: "numbers_set_formula",
+            args: ["document": document, "sheet": sheet, "cell": cell, "formula": formula]
+        )
+        return .result(value: result)
+    }
+}
+
+// Tool: numbers_set_range
+public struct NumbersSetRangeIntent: AppIntent {
+    nonisolated(unsafe) public static var title: LocalizedStringResource = "Set Numbers Cell Range"
+    nonisolated(unsafe) public static var description = IntentDescription("Bulk-write a 2D rectangular block of string values starting at a top-left cell address (e.g. 'B2'). Each value is written via the .value setter — values starting with '=' are parsed as formulas (same as numbers_set_cell). Cell addresses use A1 notation; the script auto-extends past Z (AA, AB, …). Returns the count of cells written. Capped at 1000 cells per call to stay within Phase 1's range-size budget (RFC 0009 §6.2).")
+    nonisolated(unsafe) public static var openAppWhenRun: Bool = false
+
+    public init() {}
+
+    @Parameter(title: "Document name")
+    public var document: String
+
+    @Parameter(title: "Sheet name")
+    public var sheet: String
+
+    @Parameter(title: "Top-left cell address in A1 notation (e.g. 'B2')")
+    public var startCell: String
+
+    public func perform() async throws -> some IntentResult & ReturnsValue<String> {
+        let result = try await MCPIntentRouter.shared.call(
+            tool: "numbers_set_range",
+            args: ["document": document, "sheet": sheet, "startCell": startCell]
         )
         return .result(value: result)
     }

--- a/tests/numbers-tools.test.js
+++ b/tests/numbers-tools.test.js
@@ -31,8 +31,8 @@ describe('Numbers tools registration', () => {
     registerNumbersTools(server, {});
   });
 
-  test('registers all 12 numbers tools', () => {
-    expect(server.tools.size).toBe(12);
+  test('registers all 16 numbers tools', () => {
+    expect(server.tools.size).toBe(16);
     const expected = [
       'numbers_list_documents',
       'numbers_create_document',
@@ -43,10 +43,15 @@ describe('Numbers tools registration', () => {
       'numbers_add_sheet',
       'numbers_export_pdf',
       'numbers_close_document',
-      // RFC 0009 Phase 1 first batch
+      // RFC 0009 Phase 1 first batch (PR #197)
       'numbers_list_tables',
       'numbers_get_formula',
       'numbers_rename_sheet',
+      // RFC 0009 Phase 1 batch 2 (this PR)
+      'numbers_list_charts',
+      'numbers_set_formula',
+      'numbers_set_range',
+      'numbers_resize_table',
     ];
     for (const name of expected) {
       expect(server.tools.has(name)).toBe(true);


### PR DESCRIPTION
## Summary

Four new Numbers tools advance **RFC 0009 §4.1 Phase 1 from 3/17 → 7/17**. Tool surface **272 → 276**, AppIntents **232 → 235**.

## New tools

### `numbers_list_charts` — read
Symmetric to `numbers_list_tables`. A sheet often carries multiple charts (trend + pie + bar); a model picking which one to update needs to enumerate.

### `numbers_set_formula` — write
Write counterpart to `numbers_get_formula`. `.formula` setter is symmetric with the existing `.formula()` getter. `=` prefix normalized TS-side. Parse errors surface as `errJxa`.

### `numbers_set_range` — write (bulk)
Bulk 2D write starting at a top-left cell address. `set_cell` loop with A1-notation arithmetic (auto-extends past Z → AA, AB). Capped at 1000 cells per RFC 0009 §6.2.

### `numbers_resize_table` — write (destructive)
`rowCount` / `columnCount` settable properties. Growing appends empty cells; shrinking discards trailing rows/cols + content. `destructiveHint: true`. Also serves as the primitive for future `append_row`-style tools that don't need positional insert verbs.

## Pattern fidelity

PR #197 set the pattern (3 tools, mechanical replication). This batch follows it verbatim — same JXA-script pattern in `scripts.ts`, same `errJxaFor` registration in `tools.ts`, same drift-check coverage (manifest + intents + llms + stats:sync auto-update).

## Auto-synced artifacts

| Artifact | Change |
|----------|--------|
| `docs/tool-manifest.json` | 272 → 276 tools |
| `llms.txt` / `llms-full.txt` | regen, 276 / 32 / 29 |
| `swift/Sources/AirMCPKit/Generated/MCPIntents.swift` | 232 → 235 (`set_range` ineligible — `string[][]` 2D-array input) |
| `server.json` / `mcp.json` / `glama.json` / `smithery.yaml` | description bumped 272 → 276 |
| `README.md` Features / `.github/AGENTS.md` Stats / `docs/TERMS_OF_SERVICE.md` / `docs/skills.md` / `docs/index.html` `tryit_footer` | 272 → 276 |

## Deferred (batch 3)

`insert_row`, `insert_column`, `delete_row`, `delete_column`, `duplicate_sheet`, `create_table` — each needs a Numbers JXA verb (`make new row at`, `delete`, `duplicate`) that wants real-device verification on macOS 26.0+ before landing. Pattern is clear; gating is empirical.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm test` — 101 suites / 1640 tests pass; `numbers-tools.test.js` count 12 → 16 with the four new names
- [x] `npm run format:check` — clean
- [x] `npm run llms:check` — OK 276 / 32 / 29
- [x] `npm run gen:intents:check` — OK 235
- [x] `npm run gen:manifest:check` — OK
- [x] `npm run stats:check` — all 19 cross-validate at 276
- [ ] **Real-device verification needed** before merge:
  - `numbers_set_range` 2D-array write (verify Numbers' value setter handles `=`-prefix parse on bulk set)
  - `numbers_resize_table` shrink semantics (verify content discard behaviour)
  - `numbers_list_charts` on a sheet with mixed chart types (verify `chartType()` accessor doesn't error on chart variants without it)

## RFC 0009 progress

| Phase 1 surface | Status |
|------|--------|
| Read | ✅ Complete (list_sheets, list_tables, list_charts, get_cell, get_formula, read_cells) |
| Edit (cell-level) | ✅ Complete (set_cell, set_formula, set_range, rename_sheet) |
| Edit (structural) | ⏳ Partial (add_sheet ✓, resize_table ✓; insert_row/col, delete_row/col, duplicate_sheet, create_table → batch 3) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)