### PR TITLE
feat: outputSchema Wave 6 — 7 system + 3 music read tools

### DIFF
--- a/docs/tool-manifest.json
+++ b/docs/tool-manifest.json
@@ -2414,7 +2414,50 @@
         "type": "object",
         "properties": {}
       },
-      "outputSchema": null,
+      "outputSchema": {
+        "type": "object",
+        "properties": {
+          "percentage": {
+            "anyOf": [
+              {
+                "type": "integer",
+                "minimum": 0,
+                "maximum": 100
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "charging": {
+            "type": "boolean"
+          },
+          "source": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "timeRemaining": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "raw": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "percentage",
+          "charging",
+          "source",
+          "timeRemaining",
+          "raw"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
       "annotations": {
         "readOnlyHint": true,
         "destructiveHint": false,
@@ -2452,7 +2495,32 @@
         "type": "object",
         "properties": {}
       },
-      "outputSchema": null,
+      "outputSchema": {
+        "type": "object",
+        "properties": {
+          "brightness": {
+            "anyOf": [
+              {
+                "type": "number",
+                "minimum": 0,
+                "maximum": 1
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "raw": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "brightness",
+          "raw"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
       "annotations": {
         "readOnlyHint": true,
         "destructiveHint": false,
@@ -3063,7 +3131,35 @@
         "additionalProperties": false,
         "$schema": "http://json-schema.org/draft-07/schema#"
       },
-      "outputSchema": null,
+      "outputSchema": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "artist": {
+            "type": "string"
+          },
+          "rating": {
+            "type": "integer"
+          },
+          "favorited": {
+            "type": "boolean"
+          },
+          "disliked": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "name",
+          "artist",
+          "rating",
+          "favorited",
+          "disliked"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
       "annotations": {
         "readOnlyHint": true,
         "destructiveHint": false,
@@ -3082,7 +3178,64 @@
         "type": "object",
         "properties": {}
       },
-      "outputSchema": null,
+      "outputSchema": {
+        "type": "object",
+        "properties": {
+          "displays": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string"
+                },
+                "resolution": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "pixelWidth": {
+                  "anyOf": [
+                    {
+                      "type": "integer"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "pixelHeight": {
+                  "anyOf": [
+                    {
+                      "type": "integer"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "retina": {
+                  "type": "boolean"
+                }
+              },
+              "required": [
+                "name",
+                "resolution",
+                "pixelWidth",
+                "pixelHeight",
+                "retina"
+              ],
+              "additionalProperties": false
+            }
+          }
+        },
+        "required": [
+          "displays"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
       "annotations": {
         "readOnlyHint": true,
         "destructiveHint": false,
@@ -3156,7 +3309,90 @@
         "additionalProperties": false,
         "$schema": "http://json-schema.org/draft-07/schema#"
       },
-      "outputSchema": null,
+      "outputSchema": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer"
+          },
+          "name": {
+            "type": "string"
+          },
+          "artist": {
+            "type": "string"
+          },
+          "album": {
+            "type": "string"
+          },
+          "albumArtist": {
+            "type": "string"
+          },
+          "genre": {
+            "type": "string"
+          },
+          "year": {
+            "type": "integer"
+          },
+          "trackNumber": {
+            "type": "integer"
+          },
+          "discNumber": {
+            "type": "integer"
+          },
+          "duration": {
+            "type": "number"
+          },
+          "playedCount": {
+            "type": "integer"
+          },
+          "rating": {
+            "type": "integer"
+          },
+          "favorited": {
+            "type": "boolean"
+          },
+          "disliked": {
+            "type": "boolean"
+          },
+          "dateAdded": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "sampleRate": {
+            "type": "integer"
+          },
+          "bitRate": {
+            "type": "integer"
+          },
+          "size": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "artist",
+          "album",
+          "albumArtist",
+          "genre",
+          "year",
+          "trackNumber",
+          "discNumber",
+          "duration",
+          "playedCount",
+          "rating",
+          "favorited",
+          "disliked",
+          "dateAdded",
+          "sampleRate",
+          "bitRate",
+          "size"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
       "annotations": {
         "readOnlyHint": true,
         "destructiveHint": false,
@@ -3353,7 +3589,66 @@
         "type": "object",
         "properties": {}
       },
-      "outputSchema": null,
+      "outputSchema": {
+        "type": "object",
+        "properties": {
+          "ssid": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "bssid": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "signalStrength": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "noiseLevel": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "channel": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "connected": {
+            "type": "boolean"
+          },
+          "raw": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "ssid",
+          "bssid",
+          "signalStrength",
+          "noiseLevel",
+          "channel",
+          "connected",
+          "raw"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
       "annotations": {
         "readOnlyHint": true,
         "destructiveHint": false,
@@ -4502,7 +4797,90 @@
         "type": "object",
         "properties": {}
       },
-      "outputSchema": null,
+      "outputSchema": {
+        "type": "object",
+        "properties": {
+          "total": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "windows": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "app": {
+                  "type": "string"
+                },
+                "pid": {
+                  "type": "integer"
+                },
+                "title": {
+                  "type": "string"
+                },
+                "position": {
+                  "anyOf": [
+                    {
+                      "type": "array",
+                      "minItems": 2,
+                      "maxItems": 2,
+                      "items": [
+                        {
+                          "type": "number"
+                        },
+                        {
+                          "type": "number"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "size": {
+                  "anyOf": [
+                    {
+                      "type": "array",
+                      "minItems": 2,
+                      "maxItems": 2,
+                      "items": [
+                        {
+                          "type": "number"
+                        },
+                        {
+                          "type": "number"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "minimized": {
+                  "type": "boolean"
+                }
+              },
+              "required": [
+                "app",
+                "pid",
+                "title",
+                "position",
+                "size",
+                "minimized"
+              ],
+              "additionalProperties": false
+            }
+          }
+        },
+        "required": [
+          "total",
+          "windows"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
       "annotations": {
         "readOnlyHint": true,
         "destructiveHint": false,
@@ -4521,7 +4899,54 @@
         "type": "object",
         "properties": {}
       },
-      "outputSchema": null,
+      "outputSchema": {
+        "type": "object",
+        "properties": {
+          "total": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "devices": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string"
+                },
+                "connected": {
+                  "type": "boolean"
+                },
+                "address": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "type": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                }
+              },
+              "required": [
+                "name",
+                "connected",
+                "address",
+                "type"
+              ],
+              "additionalProperties": false
+            }
+          }
+        },
+        "required": [
+          "total",
+          "devices"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
       "annotations": {
         "readOnlyHint": true,
         "destructiveHint": false,
@@ -6073,7 +6498,48 @@
         "type": "object",
         "properties": {}
       },
-      "outputSchema": null,
+      "outputSchema": {
+        "type": "object",
+        "properties": {
+          "total": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "apps": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string"
+                },
+                "bundleIdentifier": {
+                  "type": "string"
+                },
+                "pid": {
+                  "type": "integer"
+                },
+                "visible": {
+                  "type": "boolean"
+                }
+              },
+              "required": [
+                "name",
+                "bundleIdentifier",
+                "pid",
+                "visible"
+              ],
+              "additionalProperties": false
+            }
+          }
+        },
+        "required": [
+          "total",
+          "apps"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
       "annotations": {
         "readOnlyHint": true,
         "destructiveHint": false,
@@ -10459,7 +10925,57 @@
         "additionalProperties": false,
         "$schema": "http://json-schema.org/draft-07/schema#"
       },
-      "outputSchema": null,
+      "outputSchema": {
+        "type": "object",
+        "properties": {
+          "total": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "returned": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "tracks": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "integer"
+                },
+                "name": {
+                  "type": "string"
+                },
+                "artist": {
+                  "type": "string"
+                },
+                "album": {
+                  "type": "string"
+                },
+                "duration": {
+                  "type": "number"
+                }
+              },
+              "required": [
+                "id",
+                "name",
+                "artist",
+                "album",
+                "duration"
+              ],
+              "additionalProperties": false
+            }
+          }
+        },
+        "required": [
+          "total",
+          "returned",
+          "tracks"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
       "annotations": {
         "readOnlyHint": true,
         "destructiveHint": false,

--- a/src/music/tools.ts
+++ b/src/music/tools.ts
@@ -2,7 +2,7 @@ import type { McpServer } from "../shared/mcp.js";
 import { z } from "zod";
 import { runJxa } from "../shared/jxa.js";
 import type { AirMcpConfig } from "../shared/config.js";
-import { ok, okLinkedStructured, okStructured, errJxaFor } from "../shared/result.js";
+import { ok, okLinkedStructured, okStructured, okUntrustedStructured, errJxaFor } from "../shared/result.js";
 // Side-effect import: register the now_playing poller with the shared registry
 // at module load time. The poller itself only starts when startPollers() is
 // invoked by the cross/event observer tool.
@@ -152,11 +152,24 @@ export function registerMusicTools(server: McpServer, _config: AirMcpConfig): vo
         query: z.string().max(500).describe("Search keyword"),
         limit: z.number().int().min(1).max(200).optional().default(30).describe("Max results (default: 30)"),
       },
+      outputSchema: {
+        total: z.number().int().min(0),
+        returned: z.number().int().min(0),
+        tracks: z.array(
+          z.object({
+            id: z.number().int(),
+            name: z.string(),
+            artist: z.string(),
+            album: z.string(),
+            duration: z.number(),
+          }),
+        ),
+      },
       annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: false },
     },
     async ({ query, limit }) => {
       try {
-        return ok(await runJxa(searchTracksScript(query, limit)));
+        return okUntrustedStructured(await runJxa(searchTracksScript(query, limit)));
       } catch (e) {
         return errJxaFor("search tracks", e);
       }
@@ -211,11 +224,31 @@ export function registerMusicTools(server: McpServer, _config: AirMcpConfig): vo
       inputSchema: {
         trackName: z.string().max(500).describe("Track name to look up"),
       },
+      outputSchema: {
+        id: z.number().int(),
+        name: z.string(),
+        artist: z.string(),
+        album: z.string(),
+        albumArtist: z.string(),
+        genre: z.string(),
+        year: z.number().int(),
+        trackNumber: z.number().int(),
+        discNumber: z.number().int(),
+        duration: z.number(),
+        playedCount: z.number().int(),
+        rating: z.number().int(),
+        favorited: z.boolean(),
+        disliked: z.boolean(),
+        dateAdded: z.string().nullable(),
+        sampleRate: z.number().int(),
+        bitRate: z.number().int(),
+        size: z.number(),
+      },
       annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: false },
     },
     async ({ trackName }) => {
       try {
-        return ok(await runJxa(getTrackInfoScript(trackName)));
+        return okUntrustedStructured(await runJxa(getTrackInfoScript(trackName)));
       } catch (e) {
         return errJxaFor("get track info", e);
       }
@@ -328,11 +361,18 @@ export function registerMusicTools(server: McpServer, _config: AirMcpConfig): vo
       inputSchema: {
         trackName: z.string().max(500).describe("Track name to look up"),
       },
+      outputSchema: {
+        name: z.string(),
+        artist: z.string(),
+        rating: z.number().int(),
+        favorited: z.boolean(),
+        disliked: z.boolean(),
+      },
       annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: false },
     },
     async ({ trackName }) => {
       try {
-        return ok(await runJxa(getRatingScript(trackName)));
+        return okUntrustedStructured(await runJxa(getRatingScript(trackName)));
       } catch (e) {
         return errJxaFor("get rating", e);
       }

--- a/src/system/tools.ts
+++ b/src/system/tools.ts
@@ -230,6 +230,17 @@ export function registerSystemTools(server: McpServer, _config: AirMcpConfig): v
       title: "List Running Apps",
       description: "List all running applications with name, bundle identifier, PID, and visibility.",
       inputSchema: {},
+      outputSchema: {
+        total: z.number().int().min(0),
+        apps: z.array(
+          z.object({
+            name: z.string(),
+            bundleIdentifier: z.string(),
+            pid: z.number().int(),
+            visible: z.boolean(),
+          }),
+        ),
+      },
       annotations: {
         readOnlyHint: true,
         destructiveHint: false,
@@ -239,7 +250,7 @@ export function registerSystemTools(server: McpServer, _config: AirMcpConfig): v
     },
     async () => {
       try {
-        return ok(await runJxa(listRunningAppsScript()));
+        return okUntrustedStructured(await runJxa(listRunningAppsScript()));
       } catch (e) {
         return errJxaFor("list running apps", e);
       }
@@ -252,6 +263,17 @@ export function registerSystemTools(server: McpServer, _config: AirMcpConfig): v
       title: "Get Screen Info",
       description: "Get display information including resolution, pixel dimensions, and Retina status.",
       inputSchema: {},
+      outputSchema: {
+        displays: z.array(
+          z.object({
+            name: z.string(),
+            resolution: z.string().nullable(),
+            pixelWidth: z.number().int().nullable(),
+            pixelHeight: z.number().int().nullable(),
+            retina: z.boolean(),
+          }),
+        ),
+      },
       annotations: {
         readOnlyHint: true,
         destructiveHint: false,
@@ -261,7 +283,7 @@ export function registerSystemTools(server: McpServer, _config: AirMcpConfig): v
     },
     async () => {
       try {
-        return ok(await runJxa(getScreenInfoScript()));
+        return okStructured(await runJxa(getScreenInfoScript()));
       } catch (e) {
         return errJxaFor("get screen info", e);
       }
@@ -334,6 +356,15 @@ export function registerSystemTools(server: McpServer, _config: AirMcpConfig): v
       title: "Get WiFi Status",
       description: "Get the current WiFi status including connected network name, signal strength, and channel.",
       inputSchema: {},
+      outputSchema: {
+        ssid: z.string().nullable(),
+        bssid: z.string().nullable(),
+        signalStrength: z.number().int().nullable(),
+        noiseLevel: z.number().int().nullable(),
+        channel: z.string().nullable(),
+        connected: z.boolean(),
+        raw: z.string(),
+      },
       annotations: {
         readOnlyHint: true,
         destructiveHint: false,
@@ -343,7 +374,7 @@ export function registerSystemTools(server: McpServer, _config: AirMcpConfig): v
     },
     async () => {
       try {
-        return ok(await runJxa(getWifiStatusScript()));
+        return okUntrustedStructured(await runJxa(getWifiStatusScript()));
       } catch (e) {
         return errJxaFor("get wifi status", e);
       }
@@ -380,6 +411,17 @@ export function registerSystemTools(server: McpServer, _config: AirMcpConfig): v
       title: "List Bluetooth Devices",
       description: "List paired Bluetooth devices with their connection status.",
       inputSchema: {},
+      outputSchema: {
+        total: z.number().int().min(0),
+        devices: z.array(
+          z.object({
+            name: z.string(),
+            connected: z.boolean(),
+            address: z.string().nullable(),
+            type: z.string().nullable(),
+          }),
+        ),
+      },
       annotations: {
         readOnlyHint: true,
         destructiveHint: false,
@@ -389,7 +431,7 @@ export function registerSystemTools(server: McpServer, _config: AirMcpConfig): v
     },
     async () => {
       try {
-        return ok(await runJxa(listBluetoothDevicesScript()));
+        return okUntrustedStructured(await runJxa(listBluetoothDevicesScript()));
       } catch (e) {
         return errJxaFor("list bluetooth devices", e);
       }
@@ -402,6 +444,13 @@ export function registerSystemTools(server: McpServer, _config: AirMcpConfig): v
       title: "Get Battery Status",
       description: "Get battery percentage, charging state, power source, and estimated time remaining.",
       inputSchema: {},
+      outputSchema: {
+        percentage: z.number().int().min(0).max(100).nullable(),
+        charging: z.boolean(),
+        source: z.string().nullable(),
+        timeRemaining: z.string().nullable(),
+        raw: z.string(),
+      },
       annotations: {
         readOnlyHint: true,
         destructiveHint: false,
@@ -411,7 +460,7 @@ export function registerSystemTools(server: McpServer, _config: AirMcpConfig): v
     },
     async () => {
       try {
-        return ok(await runJxa(getBatteryStatusScript()));
+        return okStructured(await runJxa(getBatteryStatusScript()));
       } catch (e) {
         return errJxaFor("get battery status", e);
       }
@@ -424,6 +473,10 @@ export function registerSystemTools(server: McpServer, _config: AirMcpConfig): v
       title: "Get Brightness",
       description: "Get the current display brightness level.",
       inputSchema: {},
+      outputSchema: {
+        brightness: z.number().min(0).max(1).nullable(),
+        raw: z.string(),
+      },
       annotations: {
         readOnlyHint: true,
         destructiveHint: false,
@@ -433,7 +486,7 @@ export function registerSystemTools(server: McpServer, _config: AirMcpConfig): v
     },
     async () => {
       try {
-        return ok(await runJxa(getBrightnessScript()));
+        return okStructured(await runJxa(getBrightnessScript()));
       } catch (e) {
         return errJxaFor("get brightness", e);
       }
@@ -647,11 +700,24 @@ export function registerSystemTools(server: McpServer, _config: AirMcpConfig): v
       title: "List All Windows",
       description: "List windows across all running applications with title, size, position, app name, and PID.",
       inputSchema: {},
+      outputSchema: {
+        total: z.number().int().min(0),
+        windows: z.array(
+          z.object({
+            app: z.string(),
+            pid: z.number().int(),
+            title: z.string(),
+            position: z.tuple([z.number(), z.number()]).nullable(),
+            size: z.tuple([z.number(), z.number()]).nullable(),
+            minimized: z.boolean(),
+          }),
+        ),
+      },
       annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: false },
     },
     async () => {
       try {
-        return ok(await runJxa(listAllWindowsScript()));
+        return okUntrustedStructured(await runJxa(listAllWindowsScript()));
       } catch (e) {
         return errJxaFor("list all windows", e);
       }

--- a/tests/output-schema-structured.test.js
+++ b/tests/output-schema-structured.test.js
@@ -370,6 +370,88 @@ const TOOL_FIXTURES = {
     args: { limit: 50 },
     mock: { total: 0, returned: 0, photos: [] },
   },
+  // ── Wave 6 additions ──
+  // system
+  list_running_apps: {
+    args: {},
+    mock: { total: 0, apps: [] },
+  },
+  get_screen_info: {
+    args: {},
+    mock: { displays: [] },
+  },
+  get_wifi_status: {
+    args: {},
+    mock: {
+      ssid: null,
+      bssid: null,
+      signalStrength: null,
+      noiseLevel: null,
+      channel: null,
+      connected: false,
+      raw: '',
+    },
+  },
+  list_bluetooth_devices: {
+    args: {},
+    mock: { total: 0, devices: [] },
+  },
+  get_battery_status: {
+    args: {},
+    mock: {
+      percentage: null,
+      charging: false,
+      source: null,
+      timeRemaining: null,
+      raw: '',
+    },
+  },
+  get_brightness: {
+    args: {},
+    mock: { brightness: null, raw: '' },
+  },
+  list_all_windows: {
+    args: {},
+    mock: { total: 0, windows: [] },
+  },
+  // music
+  search_tracks: {
+    args: { query: 'jazz', limit: 30 },
+    mock: { total: 0, returned: 0, tracks: [] },
+  },
+  get_track_info: {
+    args: { trackName: 'Take Five' },
+    mock: {
+      id: 1,
+      name: 'Take Five',
+      artist: 'Dave Brubeck',
+      album: 'Time Out',
+      albumArtist: 'Dave Brubeck',
+      genre: 'Jazz',
+      year: 1959,
+      trackNumber: 3,
+      discNumber: 1,
+      duration: 324,
+      playedCount: 0,
+      rating: 0,
+      favorited: false,
+      disliked: false,
+      dateAdded: null,
+      sampleRate: 44100,
+      bitRate: 256,
+      size: 12345678,
+    },
+  },
+  get_rating: {
+    args: { trackName: 'Take Five' },
+    mock: {
+      name: 'Take Five',
+      artist: 'Dave Brubeck',
+      rating: 0,
+      favorited: false,
+      disliked: false,
+    },
+  },
 };
 
 // ── Test suite ──────────────────────────────────────────────────────

--- a/tests/output-schema-wave6.test.js
+++ b/tests/output-schema-wave6.test.js
@@ -1,0 +1,352 @@
+/**
+ * outputSchema Wave 6 — drift guard for system + music read tools.
+ *
+ * Wave 5 covered photos. Wave 6 closes the device-state + music-context
+ * gap: 7 system reads (list_running_apps, get_screen_info, get_wifi_status,
+ * list_bluetooth_devices, get_battery_status, get_brightness,
+ * list_all_windows) + 3 music reads (search_tracks, get_track_info,
+ * get_rating).
+ *
+ * Each case seeds runJxa (the underlying transport for both modules) with
+ * realistic JSON and asserts `structuredContent` parses through the tool's
+ * own outputSchema under strict Zod.
+ *
+ * Schemas use `z.tuple([z.number(), z.number()])` for window position/size
+ * because JXA's `window.position()` and `window.size()` always return a
+ * fixed-length 2-tuple via NSArray; tolerating a longer/shorter array
+ * would silently mask shape regressions in the AppleScript dictionary.
+ */
+import { describe, test, expect, beforeEach } from '@jest/globals';
+import { z } from 'zod';
+import { setupPlatformMocks } from './helpers/mock-runtime.js';
+import { createMockServer } from './helpers/mock-server.js';
+import { createMockConfig } from './helpers/mock-config.js';
+
+const { mockRunJxa } = setupPlatformMocks();
+const { registerSystemTools } = await import('../dist/system/tools.js');
+const { registerMusicTools } = await import('../dist/music/tools.js');
+
+function schemaFor(server, toolName) {
+  const tool = server._tools.get(toolName);
+  expect(tool).toBeDefined();
+  expect(tool.opts.outputSchema).toBeDefined();
+  return z.object(tool.opts.outputSchema).strict();
+}
+
+function assertConforms(server, toolName, structured) {
+  const schema = schemaFor(server, toolName);
+  const parsed = schema.safeParse(structured);
+  if (!parsed.success) {
+    throw new Error(`${toolName} drift: ${JSON.stringify(parsed.error.issues, null, 2)}`);
+  }
+}
+
+function setupSystemServer() {
+  const server = createMockServer();
+  registerSystemTools(server, createMockConfig());
+  return server;
+}
+
+function setupMusicServer() {
+  const server = createMockServer();
+  registerMusicTools(server, createMockConfig());
+  return server;
+}
+
+beforeEach(() => {
+  mockRunJxa.mockReset();
+});
+
+// ── system.list_running_apps ──────────────────────────────────────────
+
+describe('Wave 6 — system.list_running_apps', () => {
+  test('full row with several apps', async () => {
+    const server = setupSystemServer();
+    mockRunJxa.mockResolvedValue({
+      total: 3,
+      apps: [
+        { name: 'Finder', bundleIdentifier: 'com.apple.finder', pid: 1, visible: true },
+        { name: 'Terminal', bundleIdentifier: 'com.apple.Terminal', pid: 2345, visible: true },
+        { name: 'Helper', bundleIdentifier: 'com.example.helper', pid: 9999, visible: false },
+      ],
+    });
+    const result = await server.callTool('list_running_apps', {});
+    assertConforms(server, 'list_running_apps', result.structuredContent);
+  });
+
+  test('empty list', async () => {
+    const server = setupSystemServer();
+    mockRunJxa.mockResolvedValue({ total: 0, apps: [] });
+    const result = await server.callTool('list_running_apps', {});
+    assertConforms(server, 'list_running_apps', result.structuredContent);
+  });
+});
+
+// ── system.get_screen_info ────────────────────────────────────────────
+
+describe('Wave 6 — system.get_screen_info', () => {
+  test('multi-display Retina + non-Retina', async () => {
+    const server = setupSystemServer();
+    mockRunJxa.mockResolvedValue({
+      displays: [
+        { name: 'Built-in Retina', resolution: '3024 x 1964', pixelWidth: 3024, pixelHeight: 1964, retina: true },
+        { name: 'External', resolution: '2560 x 1440', pixelWidth: 2560, pixelHeight: 1440, retina: false },
+      ],
+    });
+    const result = await server.callTool('get_screen_info', {});
+    assertConforms(server, 'get_screen_info', result.structuredContent);
+  });
+
+  test('null pixel dimensions tolerated', async () => {
+    const server = setupSystemServer();
+    mockRunJxa.mockResolvedValue({
+      displays: [{ name: 'Display', resolution: null, pixelWidth: null, pixelHeight: null, retina: false }],
+    });
+    const result = await server.callTool('get_screen_info', {});
+    assertConforms(server, 'get_screen_info', result.structuredContent);
+  });
+});
+
+// ── system.get_wifi_status ────────────────────────────────────────────
+
+describe('Wave 6 — system.get_wifi_status', () => {
+  test('connected with full info', async () => {
+    const server = setupSystemServer();
+    mockRunJxa.mockResolvedValue({
+      ssid: 'HomeNet',
+      bssid: '00:11:22:33:44:55',
+      signalStrength: -52,
+      noiseLevel: -91,
+      channel: '36',
+      connected: true,
+      raw: 'agrCtlRSSI: -52\nSSID: HomeNet\n',
+    });
+    const result = await server.callTool('get_wifi_status', {});
+    assertConforms(server, 'get_wifi_status', result.structuredContent);
+  });
+
+  test('disconnected (all nullable fields null)', async () => {
+    const server = setupSystemServer();
+    mockRunJxa.mockResolvedValue({
+      ssid: null,
+      bssid: null,
+      signalStrength: null,
+      noiseLevel: null,
+      channel: null,
+      connected: false,
+      raw: 'WiFi off',
+    });
+    const result = await server.callTool('get_wifi_status', {});
+    assertConforms(server, 'get_wifi_status', result.structuredContent);
+  });
+});
+
+// ── system.list_bluetooth_devices ─────────────────────────────────────
+
+describe('Wave 6 — system.list_bluetooth_devices', () => {
+  test('mixed paired + connected devices', async () => {
+    const server = setupSystemServer();
+    mockRunJxa.mockResolvedValue({
+      total: 2,
+      devices: [
+        { name: 'AirPods Pro', connected: true, address: 'aa:bb:cc:dd:ee:ff', type: 'Headphones' },
+        { name: 'Magic Mouse', connected: false, address: null, type: 'Mouse' },
+      ],
+    });
+    const result = await server.callTool('list_bluetooth_devices', {});
+    assertConforms(server, 'list_bluetooth_devices', result.structuredContent);
+  });
+
+  test('empty paired list', async () => {
+    const server = setupSystemServer();
+    mockRunJxa.mockResolvedValue({ total: 0, devices: [] });
+    const result = await server.callTool('list_bluetooth_devices', {});
+    assertConforms(server, 'list_bluetooth_devices', result.structuredContent);
+  });
+});
+
+// ── system.get_battery_status ─────────────────────────────────────────
+
+describe('Wave 6 — system.get_battery_status', () => {
+  test('charging on AC', async () => {
+    const server = setupSystemServer();
+    mockRunJxa.mockResolvedValue({
+      percentage: 85,
+      charging: true,
+      source: 'AC Power',
+      timeRemaining: '0:45',
+      raw: 'AC Power; 85%; charging; 0:45 remaining',
+    });
+    const result = await server.callTool('get_battery_status', {});
+    assertConforms(server, 'get_battery_status', result.structuredContent);
+  });
+
+  test('Mac mini (no battery — all percentage/time null)', async () => {
+    const server = setupSystemServer();
+    mockRunJxa.mockResolvedValue({
+      percentage: null,
+      charging: false,
+      source: null,
+      timeRemaining: null,
+      raw: 'No batteries',
+    });
+    const result = await server.callTool('get_battery_status', {});
+    assertConforms(server, 'get_battery_status', result.structuredContent);
+  });
+});
+
+// ── system.get_brightness ─────────────────────────────────────────────
+
+describe('Wave 6 — system.get_brightness', () => {
+  test('typical reading', async () => {
+    const server = setupSystemServer();
+    mockRunJxa.mockResolvedValue({ brightness: 0.75, raw: '"brightness" = 768' });
+    const result = await server.callTool('get_brightness', {});
+    assertConforms(server, 'get_brightness', result.structuredContent);
+  });
+
+  test('external display (no brightness reported — null tolerated)', async () => {
+    const server = setupSystemServer();
+    mockRunJxa.mockResolvedValue({ brightness: null, raw: '' });
+    const result = await server.callTool('get_brightness', {});
+    assertConforms(server, 'get_brightness', result.structuredContent);
+  });
+});
+
+// ── system.list_all_windows ───────────────────────────────────────────
+
+describe('Wave 6 — system.list_all_windows', () => {
+  test('windows across multiple apps', async () => {
+    const server = setupSystemServer();
+    mockRunJxa.mockResolvedValue({
+      total: 2,
+      windows: [
+        { app: 'Safari', pid: 100, title: 'AirMCP — heznpc/AirMCP', position: [0, 25], size: [1440, 900], minimized: false },
+        { app: 'Notes', pid: 200, title: 'My Note', position: [200, 100], size: [800, 600], minimized: true },
+      ],
+    });
+    const result = await server.callTool('list_all_windows', {});
+    assertConforms(server, 'list_all_windows', result.structuredContent);
+  });
+
+  test('window with null position/size (accessibility lookup failed)', async () => {
+    const server = setupSystemServer();
+    mockRunJxa.mockResolvedValue({
+      total: 1,
+      windows: [{ app: 'Background Process', pid: 999, title: '', position: null, size: null, minimized: false }],
+    });
+    const result = await server.callTool('list_all_windows', {});
+    assertConforms(server, 'list_all_windows', result.structuredContent);
+  });
+});
+
+// ── music.search_tracks ───────────────────────────────────────────────
+
+describe('Wave 6 — music.search_tracks', () => {
+  test('returns several tracks', async () => {
+    const server = setupMusicServer();
+    mockRunJxa.mockResolvedValue({
+      total: 1500,
+      returned: 2,
+      tracks: [
+        { id: 101, name: 'Take Five', artist: 'Dave Brubeck', album: 'Time Out', duration: 324 },
+        { id: 102, name: 'Blue in Green', artist: 'Miles Davis', album: 'Kind of Blue', duration: 337 },
+      ],
+    });
+    const result = await server.callTool('search_tracks', { query: 'jazz', limit: 30 });
+    assertConforms(server, 'search_tracks', result.structuredContent);
+  });
+
+  test('empty result set', async () => {
+    const server = setupMusicServer();
+    mockRunJxa.mockResolvedValue({ total: 0, returned: 0, tracks: [] });
+    const result = await server.callTool('search_tracks', { query: 'no-match', limit: 30 });
+    assertConforms(server, 'search_tracks', result.structuredContent);
+  });
+});
+
+// ── music.get_track_info ──────────────────────────────────────────────
+
+describe('Wave 6 — music.get_track_info', () => {
+  test('full metadata', async () => {
+    const server = setupMusicServer();
+    mockRunJxa.mockResolvedValue({
+      id: 42,
+      name: 'Take Five',
+      artist: 'Dave Brubeck',
+      album: 'Time Out',
+      albumArtist: 'Dave Brubeck Quartet',
+      genre: 'Jazz',
+      year: 1959,
+      trackNumber: 3,
+      discNumber: 1,
+      duration: 324.5,
+      playedCount: 17,
+      rating: 80,
+      favorited: true,
+      disliked: false,
+      dateAdded: '2024-03-15T08:30:00Z',
+      sampleRate: 44100,
+      bitRate: 256,
+      size: 13107200,
+    });
+    const result = await server.callTool('get_track_info', { trackName: 'Take Five' });
+    assertConforms(server, 'get_track_info', result.structuredContent);
+  });
+
+  test('missing dateAdded tolerated', async () => {
+    const server = setupMusicServer();
+    mockRunJxa.mockResolvedValue({
+      id: 0,
+      name: 'Untitled',
+      artist: '',
+      album: '',
+      albumArtist: '',
+      genre: '',
+      year: 0,
+      trackNumber: 0,
+      discNumber: 0,
+      duration: 0,
+      playedCount: 0,
+      rating: 0,
+      favorited: false,
+      disliked: false,
+      dateAdded: null,
+      sampleRate: 0,
+      bitRate: 0,
+      size: 0,
+    });
+    const result = await server.callTool('get_track_info', { trackName: 'Untitled' });
+    assertConforms(server, 'get_track_info', result.structuredContent);
+  });
+});
+
+// ── music.get_rating ──────────────────────────────────────────────────
+
+describe('Wave 6 — music.get_rating', () => {
+  test('rated + favorited track', async () => {
+    const server = setupMusicServer();
+    mockRunJxa.mockResolvedValue({
+      name: 'Take Five',
+      artist: 'Dave Brubeck',
+      rating: 100,
+      favorited: true,
+      disliked: false,
+    });
+    const result = await server.callTool('get_rating', { trackName: 'Take Five' });
+    assertConforms(server, 'get_rating', result.structuredContent);
+  });
+
+  test('unrated track', async () => {
+    const server = setupMusicServer();
+    mockRunJxa.mockResolvedValue({
+      name: 'New Track',
+      artist: '',
+      rating: 0,
+      favorited: false,
+      disliked: false,
+    });
+    const result = await server.callTool('get_rating', { trackName: 'New Track' });
+    assertConforms(server, 'get_rating', result.structuredContent);
+  });
+});

--- a/tests/system-tools.test.js
+++ b/tests/system-tools.test.js
@@ -297,17 +297,24 @@ describe('list_all_windows', () => {
 
   test('returns window list', async () => {
     const { server } = setup();
-    mockRunJxa.mockResolvedValue([
-      { app: 'Safari', title: 'Google', x: 0, y: 0, width: 1200, height: 800 },
-      { app: 'Finder', title: 'Documents', x: 100, y: 100, width: 600, height: 400 },
-    ]);
+    // Wave 6: list_all_windows now declares outputSchema so structuredContent
+    // is the source of truth. Mock matches the actual script return shape
+    // (was previously a bare array; the script always returned {total, windows}).
+    mockRunJxa.mockResolvedValue({
+      total: 2,
+      windows: [
+        { app: 'Safari', pid: 100, title: 'Google', position: [0, 0], size: [1200, 800], minimized: false },
+        { app: 'Finder', pid: 200, title: 'Documents', position: [100, 100], size: [600, 400], minimized: false },
+      ],
+    });
 
     const result = await server.callTool('list_all_windows', {});
 
     expect(result.isError).toBeUndefined();
-    const parsed = JSON.parse(result.content[0].text);
-    expect(parsed).toHaveLength(2);
-    expect(parsed[0].app).toBe('Safari');
+    expect(result.structuredContent).toBeDefined();
+    expect(result.structuredContent.total).toBe(2);
+    expect(result.structuredContent.windows).toHaveLength(2);
+    expect(result.structuredContent.windows[0].app).toBe('Safari');
   });
 });
 


### PR DESCRIPTION
## Summary

Closes the **device-state + music-context outputSchema gap**. Wave 5 took photos to ~55%; **Wave 6 covers the highest-traffic untyped reads in `system` and `music`** — exactly the tools an agent loads at the start of a session ("what's my battery / wifi / playing"). No new tools registered — pure typing layer on existing handlers, with the upstream-content marker (`okUntrustedStructured`) applied wherever returns include user content (app names / SSID / BT device names / window titles / library track names).

## Re-scoping note

Wave 6 was originally framed as "**Communication core** — contacts/messages/music/system". On inspection:

| Module | Reads typed coming in | Reads typed after Wave 6 |
|--------|----------------------|--------------------------|
| contacts | 5/5 ✅ already complete | 5/5 |
| messages | 4/4 ✅ already complete | 4/4 |
| music | 3/17 → 6/17 | (remaining 11 are write/control) |
| system | 6/27 → 13/27 | (untyped reads: 1 — `is_app_running` for Wave 7) |

→ The actual untyped read surface lives in **system state + music context**, not contacts/messages. Wave 6 picks reflect this.

## Schemas

### system (7)

- **`list_running_apps`** — `{ total, apps: [{ name, bundleIdentifier, pid, visible }] }`. `okUntrustedStructured` (app names = user-installed strings).
- **`get_screen_info`** — `{ displays: [{ name, resolution, pixelWidth, pixelHeight, retina }] }`. Pixel dims nullable (`system_profiler` parse can fail per-display). `okStructured` (display metadata).
- **`get_wifi_status`** — `{ ssid, bssid, signalStrength, noiseLevel, channel, connected, raw }`. Most fields nullable (airport CLI returns sparse output when WiFi off). `okUntrustedStructured` (SSID = router-admin-controlled).
- **`list_bluetooth_devices`** — `{ total, devices: [{ name, connected, address, type }] }`. Address/type nullable. `okUntrustedStructured` ("John's AirPods").
- **`get_battery_status`** — `{ percentage, charging, source, timeRemaining, raw }`. percentage/source/timeRemaining nullable for Mac mini / Mac Pro (no battery). `okStructured`.
- **`get_brightness`** — `{ brightness, raw }`. brightness nullable when `ioreg` doesn't expose backlight (external display). `okStructured`.
- **`list_all_windows`** — `{ total, windows: [{ app, pid, title, position: [x,y]?, size: [w,h]?, minimized }] }`. position/size are tuples (JXA `window.position()` always 2-element NSArray); both nullable for accessibility-locked apps where the property accessor throws. `okUntrustedStructured` (window titles = doc names).

### music (3)

- **`search_tracks`** — `{ total, returned, tracks: [{ id, name, artist, album, duration }] }`. `okUntrustedStructured`.
- **`get_track_info`** — full 18-field metadata (id/name/artist/album/albumArtist/genre/year/trackNumber/discNumber/duration/playedCount/rating/favorited/disliked/dateAdded/sampleRate/bitRate/size). `dateAdded` nullable. `okUntrustedStructured`.
- **`get_rating`** — `{ name, artist, rating, favorited, disliked }`. `okUntrustedStructured`.

## Tests

- **`tests/output-schema-wave6.test.js`** — 20 new drift-guard cases (2 per tool: full + null/empty).
- **`tests/output-schema-structured.test.js`** — 10 new fixture entries; the exhaustive coverage check now sees the 10 new schemas and validates each against its mock.
- **`tests/system-tools.test.js`** — `list_all_windows` test updated: was using a bare-array mock that didn't match the actual script return shape (`{ total, windows }`); also switched from `JSON.parse(content[0].text)` to `result.structuredContent` since the text now carries the `[UNTRUSTED CONTENT]` prefix from `okUntrustedStructured`. (Pre-existing test bug caught in passing.)

## Coverage progression

| Wave | Module(s) | Tools added | Cumulative typed reads |
|------|-----------|-------------|------------------------|
| 1-5 | notes / reminders / calendar / contacts / mail / safari / finder / music / health / weather / messages / shortcuts / photos | 41 | 41 |
| **6** | **system / music** | **10** | **51** |

`outputSchema` coverage of read tools: **~55% → ~70%**.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm test` — **102 suites / 1670 tests pass** (was 101/1640; +1 suite +30 tests)
- [x] `npm run format:check` — clean
- [x] `npm run llms:check` — OK 272 / 32 / 29 (no count change)
- [x] `npm run gen:intents:check` — OK 232 intents (no count change)
- [x] `npm run gen:manifest:check` — OK 285 (manifest count drift separately tracked)
- [x] `npm run stats:check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)