### PR TITLE
feat: outputSchema Wave 7 — 6 numbers reads + system is_app_running

### DIFF
--- a/docs/tool-manifest.json
+++ b/docs/tool-manifest.json
@@ -4395,7 +4395,48 @@
         "additionalProperties": false,
         "$schema": "http://json-schema.org/draft-07/schema#"
       },
-      "outputSchema": null,
+      "outputSchema": {
+        "type": "object",
+        "properties": {
+          "running": {
+            "type": "boolean"
+          },
+          "name": {
+            "type": "string"
+          },
+          "bundleIdentifier": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "pid": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "visible": {
+            "type": [
+              "boolean",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "running",
+          "name",
+          "bundleIdentifier",
+          "pid",
+          "visible"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
       "annotations": {
         "readOnlyHint": true,
         "destructiveHint": false,
@@ -7696,7 +7737,27 @@
         "additionalProperties": false,
         "$schema": "http://json-schema.org/draft-07/schema#"
       },
-      "outputSchema": null,
+      "outputSchema": {
+        "type": "object",
+        "properties": {
+          "address": {
+            "type": "string"
+          },
+          "value": {},
+          "formattedValue": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "address",
+          "formattedValue"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
       "annotations": {
         "readOnlyHint": true,
         "destructiveHint": false,
@@ -7737,7 +7798,34 @@
         "additionalProperties": false,
         "$schema": "http://json-schema.org/draft-07/schema#"
       },
-      "outputSchema": null,
+      "outputSchema": {
+        "type": "object",
+        "properties": {
+          "address": {
+            "type": "string"
+          },
+          "formula": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "value": {},
+          "formattedValue": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "address",
+          "formula",
+          "formattedValue"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
       "annotations": {
         "readOnlyHint": true,
         "destructiveHint": false,
@@ -7756,7 +7844,42 @@
         "type": "object",
         "properties": {}
       },
-      "outputSchema": null,
+      "outputSchema": {
+        "type": "object",
+        "properties": {
+          "documents": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string"
+                },
+                "path": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "modified": {
+                  "type": "boolean"
+                }
+              },
+              "required": [
+                "name",
+                "path",
+                "modified"
+              ],
+              "additionalProperties": false
+            }
+          }
+        },
+        "required": [
+          "documents"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
       "annotations": {
         "readOnlyHint": true,
         "destructiveHint": false,
@@ -7785,7 +7908,36 @@
         "additionalProperties": false,
         "$schema": "http://json-schema.org/draft-07/schema#"
       },
-      "outputSchema": null,
+      "outputSchema": {
+        "type": "object",
+        "properties": {
+          "sheets": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string"
+                },
+                "tableCount": {
+                  "type": "integer",
+                  "minimum": 0
+                }
+              },
+              "required": [
+                "name",
+                "tableCount"
+              ],
+              "additionalProperties": false
+            }
+          }
+        },
+        "required": [
+          "sheets"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
       "annotations": {
         "readOnlyHint": true,
         "destructiveHint": false,
@@ -7820,7 +7972,41 @@
         "additionalProperties": false,
         "$schema": "http://json-schema.org/draft-07/schema#"
       },
-      "outputSchema": null,
+      "outputSchema": {
+        "type": "object",
+        "properties": {
+          "tables": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string"
+                },
+                "rowCount": {
+                  "type": "integer",
+                  "minimum": 0
+                },
+                "columnCount": {
+                  "type": "integer",
+                  "minimum": 0
+                }
+              },
+              "required": [
+                "name",
+                "rowCount",
+                "columnCount"
+              ],
+              "additionalProperties": false
+            }
+          }
+        },
+        "required": [
+          "tables"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
       "annotations": {
         "readOnlyHint": true,
         "destructiveHint": false,
@@ -7879,7 +8065,43 @@
         "additionalProperties": false,
         "$schema": "http://json-schema.org/draft-07/schema#"
       },
-      "outputSchema": null,
+      "outputSchema": {
+        "type": "object",
+        "properties": {
+          "rows": {
+            "type": "array",
+            "items": {
+              "type": "array",
+              "items": {}
+            }
+          },
+          "startRow": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "startCol": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "endRow": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "endCol": {
+            "type": "integer",
+            "minimum": 0
+          }
+        },
+        "required": [
+          "rows",
+          "startRow",
+          "startCol",
+          "endRow",
+          "endCol"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
       "annotations": {
         "readOnlyHint": true,
         "destructiveHint": false,

--- a/src/numbers/tools.ts
+++ b/src/numbers/tools.ts
@@ -2,7 +2,7 @@ import type { McpServer } from "../shared/mcp.js";
 import { z } from "zod";
 import { runJxa } from "../shared/jxa.js";
 import type { AirMcpConfig } from "../shared/config.js";
-import { ok, errJxaFor } from "../shared/result.js";
+import { ok, okUntrustedStructured, errJxaFor } from "../shared/result.js";
 import { zFilePath, resolveAndGuard } from "../shared/validate.js";
 import {
   listDocumentsScript,
@@ -26,11 +26,21 @@ export function registerNumbersTools(server: McpServer, _config: AirMcpConfig): 
       title: "List Numbers Documents",
       description: "List all open Numbers spreadsheets.",
       inputSchema: {},
+      outputSchema: {
+        documents: z.array(
+          z.object({
+            name: z.string(),
+            path: z.string().nullable(),
+            modified: z.boolean(),
+          }),
+        ),
+      },
       annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: false },
     },
     async () => {
       try {
-        return ok(await runJxa(listDocumentsScript()));
+        const documents = (await runJxa(listDocumentsScript())) as Array<unknown>;
+        return okUntrustedStructured({ documents });
       } catch (e) {
         return errJxaFor("list Numbers documents", e);
       }
@@ -62,11 +72,20 @@ export function registerNumbersTools(server: McpServer, _config: AirMcpConfig): 
       inputSchema: {
         document: z.string().max(500).describe("Document name"),
       },
+      outputSchema: {
+        sheets: z.array(
+          z.object({
+            name: z.string(),
+            tableCount: z.number().int().min(0),
+          }),
+        ),
+      },
       annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: false },
     },
     async ({ document }) => {
       try {
-        return ok(await runJxa(listSheetsScript(document)));
+        const sheets = (await runJxa(listSheetsScript(document))) as Array<unknown>;
+        return okUntrustedStructured({ sheets });
       } catch (e) {
         return errJxaFor("list Numbers sheets", e);
       }
@@ -83,11 +102,18 @@ export function registerNumbersTools(server: McpServer, _config: AirMcpConfig): 
         sheet: z.string().max(500).describe("Sheet name"),
         cell: z.string().max(500).describe("Cell address (e.g. 'A1', 'B3')"),
       },
+      outputSchema: {
+        address: z.string(),
+        // Cell values are dynamically typed in Numbers (number, string, date, boolean, null).
+        // Zod's `unknown()` keeps the contract honest rather than forcing a coercion.
+        value: z.unknown(),
+        formattedValue: z.string().nullable(),
+      },
       annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: false },
     },
     async ({ document, sheet, cell }) => {
       try {
-        return ok(await runJxa(getCellScript(document, sheet, cell)));
+        return okUntrustedStructured(await runJxa(getCellScript(document, sheet, cell)));
       } catch (e) {
         return errJxaFor("get Numbers cell", e);
       }
@@ -129,11 +155,22 @@ export function registerNumbersTools(server: McpServer, _config: AirMcpConfig): 
         endRow: z.number().int().min(0).describe("End row index (inclusive)"),
         endCol: z.number().int().min(0).describe("End column index (inclusive)"),
       },
+      outputSchema: {
+        // Outer array = rows. Inner array = cell values per row.
+        // Cell values stay `unknown` for the same dynamic-typing reason as get_cell.
+        rows: z.array(z.array(z.unknown())),
+        startRow: z.number().int().min(0),
+        startCol: z.number().int().min(0),
+        endRow: z.number().int().min(0),
+        endCol: z.number().int().min(0),
+      },
       annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: false },
     },
     async ({ document, sheet, startRow, startCol, endRow, endCol }) => {
       try {
-        return ok(await runJxa(readCellsScript(document, sheet, startRow, startCol, endRow, endCol)));
+        return okUntrustedStructured(
+          await runJxa(readCellsScript(document, sheet, startRow, startCol, endRow, endCol)),
+        );
       } catch (e) {
         return errJxaFor("read Numbers cells", e);
       }
@@ -215,11 +252,21 @@ export function registerNumbersTools(server: McpServer, _config: AirMcpConfig): 
         document: z.string().max(500).describe("Document name"),
         sheet: z.string().max(500).describe("Sheet name"),
       },
+      outputSchema: {
+        tables: z.array(
+          z.object({
+            name: z.string(),
+            rowCount: z.number().int().min(0),
+            columnCount: z.number().int().min(0),
+          }),
+        ),
+      },
       annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: false },
     },
     async ({ document, sheet }) => {
       try {
-        return ok(await runJxa(listTablesScript(document, sheet)));
+        const tables = (await runJxa(listTablesScript(document, sheet))) as Array<unknown>;
+        return okUntrustedStructured({ tables });
       } catch (e) {
         return errJxaFor("list Numbers tables", e);
       }
@@ -238,11 +285,18 @@ export function registerNumbersTools(server: McpServer, _config: AirMcpConfig): 
         sheet: z.string().max(500).describe("Sheet name"),
         cell: z.string().max(500).describe("Cell address (e.g. 'A1')"),
       },
+      outputSchema: {
+        address: z.string(),
+        // `formula` is null when the cell holds a constant (no formula behind it).
+        formula: z.string().nullable(),
+        value: z.unknown(),
+        formattedValue: z.string().nullable(),
+      },
       annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: false },
     },
     async ({ document, sheet, cell }) => {
       try {
-        return ok(await runJxa(getFormulaScript(document, sheet, cell)));
+        return okUntrustedStructured(await runJxa(getFormulaScript(document, sheet, cell)));
       } catch (e) {
         return errJxaFor("get Numbers formula", e);
       }

--- a/src/system/scripts.ts
+++ b/src/system/scripts.ts
@@ -328,7 +328,8 @@ export function isAppRunningScript(name: string): string {
       const p = procs[0];
       JSON.stringify({running: true, name: p.name(), bundleIdentifier: p.bundleIdentifier(), pid: p.unixId(), visible: p.visible()});
     } else {
-      JSON.stringify({running: false, name: '${esc(name)}'});
+      // Emit explicit nulls so the outputSchema's nullable contract holds.
+      JSON.stringify({running: false, name: '${esc(name)}', bundleIdentifier: null, pid: null, visible: null});
     }
   `;
 }

--- a/src/system/tools.ts
+++ b/src/system/tools.ts
@@ -681,11 +681,21 @@ export function registerSystemTools(server: McpServer, _config: AirMcpConfig): v
       inputSchema: {
         name: z.string().min(1).max(500).describe("Application name to check (e.g. 'Safari')"),
       },
+      outputSchema: {
+        running: z.boolean(),
+        name: z.string(),
+        // null when running === false. MCP SDK doesn't serialize z.optional()
+        // at the root of outputSchema — z.nullable() is the supported form for
+        // "may not be present" semantics; the script emits explicit nulls.
+        bundleIdentifier: z.string().nullable(),
+        pid: z.number().int().nullable(),
+        visible: z.boolean().nullable(),
+      },
       annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: false },
     },
     async ({ name }) => {
       try {
-        return ok(await runJxa(isAppRunningScript(name)));
+        return okUntrustedStructured(await runJxa(isAppRunningScript(name)));
       } catch (e) {
         return errJxaFor("check app running", e);
       }

--- a/swift/Sources/AirMCPKit/Generated/MCPIntents.swift
+++ b/swift/Sources/AirMCPKit/Generated/MCPIntents.swift
@@ -3,7 +3,7 @@
 // Source: docs/tool-manifest.json
 // Generator: scripts/gen-swift-intents.mjs
 // RFC 0007 Phase A.2b.2 + A.4.1 — 232 auto-selected read-only
-// tools (65 with typed drift-guards + Interactive Snippet
+// tools (82 with typed drift-guards + Interactive Snippet
 // SwiftUI views) + 9 AppShortcutsProvider entries.
 // Run `npm run gen:intents` to refresh after tool metadata changes.
 // CI guards against drift via `npm run gen:intents:check`.
@@ -74,6 +74,21 @@ public struct MCPDiscoverToolsOutput: Codable, Sendable {
     public let hint: String?
 }
 
+// Output type for: get_battery_status
+public struct MCPGetBatteryStatusOutput: Codable, Sendable {
+    public let percentage: String
+    public let charging: Bool
+    public let source: String?
+    public let timeRemaining: String?
+    public let raw: String
+}
+
+// Output type for: get_brightness
+public struct MCPGetBrightnessOutput: Codable, Sendable {
+    public let brightness: String
+    public let raw: String
+}
+
 // Output type for: get_clipboard
 public struct MCPGetClipboardOutput: Codable, Sendable {
     public let content: String
@@ -140,10 +155,54 @@ public struct MCPGetPhotoInfoOutput: Codable, Sendable {
     public let keywords: String
 }
 
+// Output type for: get_rating
+public struct MCPGetRatingOutput: Codable, Sendable {
+    public let name: String
+    public let artist: String
+    public let rating: Int
+    public let favorited: Bool
+    public let disliked: Bool
+}
+
+// Output type for: get_screen_info
+public struct MCPGetScreenInfoOutput: Codable, Sendable {
+    public struct DisplaysItem: Codable, Sendable {
+        public let name: String
+        public let resolution: String?
+        public let pixelWidth: String
+        public let pixelHeight: String
+        public let retina: Bool
+    }
+
+    public let displays: [DisplaysItem]
+}
+
 // Output type for: get_shortcut_detail
 public struct MCPGetShortcutDetailOutput: Codable, Sendable {
     public let shortcut: String
     public let detail: String
+}
+
+// Output type for: get_track_info
+public struct MCPGetTrackInfoOutput: Codable, Sendable {
+    public let id: Int
+    public let name: String
+    public let artist: String
+    public let album: String
+    public let albumArtist: String
+    public let genre: String
+    public let year: Int
+    public let trackNumber: Int
+    public let discNumber: Int
+    public let duration: Double
+    public let playedCount: Int
+    public let rating: Int
+    public let favorited: Bool
+    public let disliked: Bool
+    public let dateAdded: String?
+    public let sampleRate: Int
+    public let bitRate: Int
+    public let size: Double
 }
 
 // Output type for: get_unread_count
@@ -182,6 +241,26 @@ public struct MCPGetVolumeOutput: Codable, Sendable {
     public let outputMuted: Bool
 }
 
+// Output type for: get_wifi_status
+public struct MCPGetWifiStatusOutput: Codable, Sendable {
+    public let ssid: String?
+    public let bssid: String?
+    public let signalStrength: String
+    public let noiseLevel: String
+    public let channel: String?
+    public let connected: Bool
+    public let raw: String
+}
+
+// Output type for: is_app_running
+public struct MCPIsAppRunningOutput: Codable, Sendable {
+    public let running: Bool
+    public let name: String
+    public let bundleIdentifier: String?
+    public let pid: String
+    public let visible: Bool?
+}
+
 // Output type for: list_accounts
 public struct MCPListAccountsOutput: Codable, Sendable {
     public struct AccountsItem: Codable, Sendable {
@@ -191,6 +270,34 @@ public struct MCPListAccountsOutput: Codable, Sendable {
     }
 
     public let accounts: [AccountsItem]
+}
+
+// Output type for: list_all_windows
+public struct MCPListAllWindowsOutput: Codable, Sendable {
+    public struct WindowsItem: Codable, Sendable {
+        public let app: String
+        public let pid: Int
+        public let title: String
+        public let position: String
+        public let size: String
+        public let minimized: Bool
+    }
+
+    public let total: Int
+    public let windows: [WindowsItem]
+}
+
+// Output type for: list_bluetooth_devices
+public struct MCPListBluetoothDevicesOutput: Codable, Sendable {
+    public struct DevicesItem: Codable, Sendable {
+        public let name: String
+        public let connected: Bool
+        public let address: String?
+        public let type: String?
+    }
+
+    public let total: Int
+    public let devices: [DevicesItem]
 }
 
 // Output type for: list_bookmarks
@@ -464,6 +571,19 @@ public struct MCPListRemindersOutput: Codable, Sendable {
     public let reminders: [RemindersItem]
 }
 
+// Output type for: list_running_apps
+public struct MCPListRunningAppsOutput: Codable, Sendable {
+    public struct AppsItem: Codable, Sendable {
+        public let name: String
+        public let bundleIdentifier: String
+        public let pid: Int
+        public let visible: Bool
+    }
+
+    public let total: Int
+    public let apps: [AppsItem]
+}
+
 // Output type for: list_shortcuts
 public struct MCPListShortcutsOutput: Codable, Sendable {
     public let total: Double
@@ -555,6 +675,62 @@ public struct MCPMemoryStatsOutput: Codable, Sendable {
 public struct MCPNowPlayingOutput: Codable, Sendable {
     public let playerState: String
     public let track: String
+}
+
+// Output type for: numbers_get_cell
+public struct MCPNumbersGetCellOutput: Codable, Sendable {
+    public let address: String
+    public let value: String?
+    public let formattedValue: String?
+}
+
+// Output type for: numbers_get_formula
+public struct MCPNumbersGetFormulaOutput: Codable, Sendable {
+    public let address: String
+    public let formula: String?
+    public let value: String?
+    public let formattedValue: String?
+}
+
+// Output type for: numbers_list_documents
+public struct MCPNumbersListDocumentsOutput: Codable, Sendable {
+    public struct DocumentsItem: Codable, Sendable {
+        public let name: String
+        public let path: String?
+        public let modified: Bool
+    }
+
+    public let documents: [DocumentsItem]
+}
+
+// Output type for: numbers_list_sheets
+public struct MCPNumbersListSheetsOutput: Codable, Sendable {
+    public struct SheetsItem: Codable, Sendable {
+        public let name: String
+        public let tableCount: Int
+    }
+
+    public let sheets: [SheetsItem]
+}
+
+// Output type for: numbers_list_tables
+public struct MCPNumbersListTablesOutput: Codable, Sendable {
+    public struct TablesItem: Codable, Sendable {
+        public let name: String
+        public let rowCount: Int
+        public let columnCount: Int
+    }
+
+    public let tables: [TablesItem]
+}
+
+// Output type for: numbers_read_cells
+public struct MCPNumbersReadCellsOutput: Codable, Sendable {
+    public let rows: [[String]]
+    public let startRow: Int
+    public let startCol: Int
+    public let endRow: Int
+    public let endCol: Int
 }
 
 // Output type for: proactive_context
@@ -873,6 +1049,21 @@ public struct MCPSearchTabsOutput: Codable, Sendable {
 
     public let returned: Double
     public let tabs: [TabsItem]
+}
+
+// Output type for: search_tracks
+public struct MCPSearchTracksOutput: Codable, Sendable {
+    public struct TracksItem: Codable, Sendable {
+        public let id: Int
+        public let name: String
+        public let artist: String
+        public let album: String
+        public let duration: Double
+    }
+
+    public let total: Int
+    public let returned: Int
+    public let tracks: [TracksItem]
 }
 
 // Output type for: set_clipboard
@@ -2208,6 +2399,16 @@ public struct GetBatteryStatusIntent: AppIntent {
             tool: "get_battery_status",
             args: [String: any Sendable]()
         )
+        guard let data = result.data(using: .utf8) else {
+            throw MCPIntentError.toolCallFailed(tool: "get_battery_status", message: "empty result from router")
+        }
+        let decoded = try JSONDecoder().decode(MCPGetBatteryStatusOutput.self, from: data)
+        #if canImport(SwiftUI) && compiler(>=6.3)
+        if #available(macOS 26, iOS 26, *) {
+            return .result(value: result, view: MCPGetBatteryStatusSnippetView(data: decoded))
+        }
+        #endif
+        _ = decoded
         return .result(value: result)
     }
 }
@@ -2242,6 +2443,16 @@ public struct GetBrightnessIntent: AppIntent {
             tool: "get_brightness",
             args: [String: any Sendable]()
         )
+        guard let data = result.data(using: .utf8) else {
+            throw MCPIntentError.toolCallFailed(tool: "get_brightness", message: "empty result from router")
+        }
+        let decoded = try JSONDecoder().decode(MCPGetBrightnessOutput.self, from: data)
+        #if canImport(SwiftUI) && compiler(>=6.3)
+        if #available(macOS 26, iOS 26, *) {
+            return .result(value: result, view: MCPGetBrightnessSnippetView(data: decoded))
+        }
+        #endif
+        _ = decoded
         return .result(value: result)
     }
 }
@@ -2548,6 +2759,16 @@ public struct GetRatingIntent: AppIntent {
             tool: "get_rating",
             args: ["trackName": trackName]
         )
+        guard let data = result.data(using: .utf8) else {
+            throw MCPIntentError.toolCallFailed(tool: "get_rating", message: "empty result from router")
+        }
+        let decoded = try JSONDecoder().decode(MCPGetRatingOutput.self, from: data)
+        #if canImport(SwiftUI) && compiler(>=6.3)
+        if #available(macOS 26, iOS 26, *) {
+            return .result(value: result, view: MCPGetRatingSnippetView(data: decoded))
+        }
+        #endif
+        _ = decoded
         return .result(value: result)
     }
 }
@@ -2565,6 +2786,16 @@ public struct GetScreenInfoIntent: AppIntent {
             tool: "get_screen_info",
             args: [String: any Sendable]()
         )
+        guard let data = result.data(using: .utf8) else {
+            throw MCPIntentError.toolCallFailed(tool: "get_screen_info", message: "empty result from router")
+        }
+        let decoded = try JSONDecoder().decode(MCPGetScreenInfoOutput.self, from: data)
+        #if canImport(SwiftUI) && compiler(>=6.3)
+        if #available(macOS 26, iOS 26, *) {
+            return .result(value: result, view: MCPGetScreenInfoSnippetView(data: decoded))
+        }
+        #endif
+        _ = decoded
         return .result(value: result)
     }
 }
@@ -2615,6 +2846,16 @@ public struct GetTrackInfoIntent: AppIntent {
             tool: "get_track_info",
             args: ["trackName": trackName]
         )
+        guard let data = result.data(using: .utf8) else {
+            throw MCPIntentError.toolCallFailed(tool: "get_track_info", message: "empty result from router")
+        }
+        let decoded = try JSONDecoder().decode(MCPGetTrackInfoOutput.self, from: data)
+        #if canImport(SwiftUI) && compiler(>=6.3)
+        if #available(macOS 26, iOS 26, *) {
+            return .result(value: result, view: MCPGetTrackInfoSnippetView(data: decoded))
+        }
+        #endif
+        _ = decoded
         return .result(value: result)
     }
 }
@@ -2716,6 +2957,16 @@ public struct GetWifiStatusIntent: AppIntent {
             tool: "get_wifi_status",
             args: [String: any Sendable]()
         )
+        guard let data = result.data(using: .utf8) else {
+            throw MCPIntentError.toolCallFailed(tool: "get_wifi_status", message: "empty result from router")
+        }
+        let decoded = try JSONDecoder().decode(MCPGetWifiStatusOutput.self, from: data)
+        #if canImport(SwiftUI) && compiler(>=6.3)
+        if #available(macOS 26, iOS 26, *) {
+            return .result(value: result, view: MCPGetWifiStatusSnippetView(data: decoded))
+        }
+        #endif
+        _ = decoded
         return .result(value: result)
     }
 }
@@ -3135,6 +3386,16 @@ public struct IsAppRunningIntent: AppIntent {
             tool: "is_app_running",
             args: ["name": name]
         )
+        guard let data = result.data(using: .utf8) else {
+            throw MCPIntentError.toolCallFailed(tool: "is_app_running", message: "empty result from router")
+        }
+        let decoded = try JSONDecoder().decode(MCPIsAppRunningOutput.self, from: data)
+        #if canImport(SwiftUI) && compiler(>=6.3)
+        if #available(macOS 26, iOS 26, *) {
+            return .result(value: result, view: MCPIsAppRunningSnippetView(data: decoded))
+        }
+        #endif
+        _ = decoded
         return .result(value: result)
     }
 }
@@ -3362,6 +3623,16 @@ public struct ListAllWindowsIntent: AppIntent {
             tool: "list_all_windows",
             args: [String: any Sendable]()
         )
+        guard let data = result.data(using: .utf8) else {
+            throw MCPIntentError.toolCallFailed(tool: "list_all_windows", message: "empty result from router")
+        }
+        let decoded = try JSONDecoder().decode(MCPListAllWindowsOutput.self, from: data)
+        #if canImport(SwiftUI) && compiler(>=6.3)
+        if #available(macOS 26, iOS 26, *) {
+            return .result(value: result, view: MCPListAllWindowsSnippetView(data: decoded))
+        }
+        #endif
+        _ = decoded
         return .result(value: result)
     }
 }
@@ -3379,6 +3650,16 @@ public struct ListBluetoothDevicesIntent: AppIntent {
             tool: "list_bluetooth_devices",
             args: [String: any Sendable]()
         )
+        guard let data = result.data(using: .utf8) else {
+            throw MCPIntentError.toolCallFailed(tool: "list_bluetooth_devices", message: "empty result from router")
+        }
+        let decoded = try JSONDecoder().decode(MCPListBluetoothDevicesOutput.self, from: data)
+        #if canImport(SwiftUI) && compiler(>=6.3)
+        if #available(macOS 26, iOS 26, *) {
+            return .result(value: result, view: MCPListBluetoothDevicesSnippetView(data: decoded))
+        }
+        #endif
+        _ = decoded
         return .result(value: result)
     }
 }
@@ -4053,6 +4334,16 @@ public struct ListRunningAppsIntent: AppIntent {
             tool: "list_running_apps",
             args: [String: any Sendable]()
         )
+        guard let data = result.data(using: .utf8) else {
+            throw MCPIntentError.toolCallFailed(tool: "list_running_apps", message: "empty result from router")
+        }
+        let decoded = try JSONDecoder().decode(MCPListRunningAppsOutput.self, from: data)
+        #if canImport(SwiftUI) && compiler(>=6.3)
+        if #available(macOS 26, iOS 26, *) {
+            return .result(value: result, view: MCPListRunningAppsSnippetView(data: decoded))
+        }
+        #endif
+        _ = decoded
         return .result(value: result)
     }
 }
@@ -4549,6 +4840,16 @@ public struct NumbersGetCellIntent: AppIntent {
             tool: "numbers_get_cell",
             args: ["document": document, "sheet": sheet, "cell": cell]
         )
+        guard let data = result.data(using: .utf8) else {
+            throw MCPIntentError.toolCallFailed(tool: "numbers_get_cell", message: "empty result from router")
+        }
+        let decoded = try JSONDecoder().decode(MCPNumbersGetCellOutput.self, from: data)
+        #if canImport(SwiftUI) && compiler(>=6.3)
+        if #available(macOS 26, iOS 26, *) {
+            return .result(value: result, view: MCPNumbersGetCellSnippetView(data: decoded))
+        }
+        #endif
+        _ = decoded
         return .result(value: result)
     }
 }
@@ -4575,6 +4876,16 @@ public struct NumbersGetFormulaIntent: AppIntent {
             tool: "numbers_get_formula",
             args: ["document": document, "sheet": sheet, "cell": cell]
         )
+        guard let data = result.data(using: .utf8) else {
+            throw MCPIntentError.toolCallFailed(tool: "numbers_get_formula", message: "empty result from router")
+        }
+        let decoded = try JSONDecoder().decode(MCPNumbersGetFormulaOutput.self, from: data)
+        #if canImport(SwiftUI) && compiler(>=6.3)
+        if #available(macOS 26, iOS 26, *) {
+            return .result(value: result, view: MCPNumbersGetFormulaSnippetView(data: decoded))
+        }
+        #endif
+        _ = decoded
         return .result(value: result)
     }
 }
@@ -4592,6 +4903,16 @@ public struct NumbersListDocumentsIntent: AppIntent {
             tool: "numbers_list_documents",
             args: [String: any Sendable]()
         )
+        guard let data = result.data(using: .utf8) else {
+            throw MCPIntentError.toolCallFailed(tool: "numbers_list_documents", message: "empty result from router")
+        }
+        let decoded = try JSONDecoder().decode(MCPNumbersListDocumentsOutput.self, from: data)
+        #if canImport(SwiftUI) && compiler(>=6.3)
+        if #available(macOS 26, iOS 26, *) {
+            return .result(value: result, view: MCPNumbersListDocumentsSnippetView(data: decoded))
+        }
+        #endif
+        _ = decoded
         return .result(value: result)
     }
 }
@@ -4612,6 +4933,16 @@ public struct NumbersListSheetsIntent: AppIntent {
             tool: "numbers_list_sheets",
             args: ["document": document]
         )
+        guard let data = result.data(using: .utf8) else {
+            throw MCPIntentError.toolCallFailed(tool: "numbers_list_sheets", message: "empty result from router")
+        }
+        let decoded = try JSONDecoder().decode(MCPNumbersListSheetsOutput.self, from: data)
+        #if canImport(SwiftUI) && compiler(>=6.3)
+        if #available(macOS 26, iOS 26, *) {
+            return .result(value: result, view: MCPNumbersListSheetsSnippetView(data: decoded))
+        }
+        #endif
+        _ = decoded
         return .result(value: result)
     }
 }
@@ -4635,6 +4966,16 @@ public struct NumbersListTablesIntent: AppIntent {
             tool: "numbers_list_tables",
             args: ["document": document, "sheet": sheet]
         )
+        guard let data = result.data(using: .utf8) else {
+            throw MCPIntentError.toolCallFailed(tool: "numbers_list_tables", message: "empty result from router")
+        }
+        let decoded = try JSONDecoder().decode(MCPNumbersListTablesOutput.self, from: data)
+        #if canImport(SwiftUI) && compiler(>=6.3)
+        if #available(macOS 26, iOS 26, *) {
+            return .result(value: result, view: MCPNumbersListTablesSnippetView(data: decoded))
+        }
+        #endif
+        _ = decoded
         return .result(value: result)
     }
 }
@@ -4670,6 +5011,16 @@ public struct NumbersReadCellsIntent: AppIntent {
             tool: "numbers_read_cells",
             args: ["document": document, "sheet": sheet, "startRow": startRow, "startCol": startCol, "endRow": endRow, "endCol": endCol]
         )
+        guard let data = result.data(using: .utf8) else {
+            throw MCPIntentError.toolCallFailed(tool: "numbers_read_cells", message: "empty result from router")
+        }
+        let decoded = try JSONDecoder().decode(MCPNumbersReadCellsOutput.self, from: data)
+        #if canImport(SwiftUI) && compiler(>=6.3)
+        if #available(macOS 26, iOS 26, *) {
+            return .result(value: result, view: MCPNumbersReadCellsSnippetView(data: decoded))
+        }
+        #endif
+        _ = decoded
         return .result(value: result)
     }
 }
@@ -5933,6 +6284,16 @@ public struct SearchTracksIntent: AppIntent {
             tool: "search_tracks",
             args: ["query": query, "limit": limit]
         )
+        guard let data = result.data(using: .utf8) else {
+            throw MCPIntentError.toolCallFailed(tool: "search_tracks", message: "empty result from router")
+        }
+        let decoded = try JSONDecoder().decode(MCPSearchTracksOutput.self, from: data)
+        #if canImport(SwiftUI) && compiler(>=6.3)
+        if #available(macOS 26, iOS 26, *) {
+            return .result(value: result, view: MCPSearchTracksSnippetView(data: decoded))
+        }
+        #endif
+        _ = decoded
         return .result(value: result)
     }
 }
@@ -7226,6 +7587,79 @@ public struct MCPDiscoverToolsSnippetView: View {
     }
 }
 
+// Snippet view for: get_battery_status  (shape: scalar)
+@available(macOS 26, iOS 26, *)
+public struct MCPGetBatteryStatusSnippetView: View {
+    public let data: MCPGetBatteryStatusOutput
+    public init(data: MCPGetBatteryStatusOutput) { self.data = data }
+    public var body: some View {
+        VStack(alignment: .leading, spacing: 2) {
+            HStack {
+                Text("Percentage")
+                Spacer()
+                Text(String(describing: data.percentage))
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+            }
+            HStack {
+                Text("Charging")
+                Spacer()
+                Text((data.charging ? "Yes" : "No"))
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+            }
+            HStack {
+                Text("Source")
+                Spacer()
+                Text((data.source ?? "—"))
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+            }
+            HStack {
+                Text("Time Remaining")
+                Spacer()
+                Text((data.timeRemaining ?? "—"))
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+            }
+            HStack {
+                Text("Raw")
+                Spacer()
+                Text(data.raw)
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+            }
+        }
+        .padding()
+    }
+}
+
+// Snippet view for: get_brightness  (shape: scalar)
+@available(macOS 26, iOS 26, *)
+public struct MCPGetBrightnessSnippetView: View {
+    public let data: MCPGetBrightnessOutput
+    public init(data: MCPGetBrightnessOutput) { self.data = data }
+    public var body: some View {
+        VStack(alignment: .leading, spacing: 2) {
+            HStack {
+                Text("Brightness")
+                Spacer()
+                Text(String(describing: data.brightness))
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+            }
+            HStack {
+                Text("Raw")
+                Spacer()
+                Text(data.raw)
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+            }
+        }
+        .padding()
+    }
+}
+
 // Snippet view for: get_clipboard  (shape: scalar)
 @available(macOS 26, iOS 26, *)
 public struct MCPGetClipboardSnippetView: View {
@@ -7506,6 +7940,70 @@ public struct MCPGetPhotoInfoSnippetView: View {
     }
 }
 
+// Snippet view for: get_rating  (shape: scalar)
+@available(macOS 26, iOS 26, *)
+public struct MCPGetRatingSnippetView: View {
+    public let data: MCPGetRatingOutput
+    public init(data: MCPGetRatingOutput) { self.data = data }
+    public var body: some View {
+        VStack(alignment: .leading, spacing: 2) {
+            HStack {
+                Text("Name")
+                Spacer()
+                Text(data.name)
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+            }
+            HStack {
+                Text("Artist")
+                Spacer()
+                Text(data.artist)
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+            }
+            HStack {
+                Text("Rating")
+                Spacer()
+                Text(data.rating.formatted())
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+            }
+            HStack {
+                Text("Favorited")
+                Spacer()
+                Text((data.favorited ? "Yes" : "No"))
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+            }
+            HStack {
+                Text("Disliked")
+                Spacer()
+                Text((data.disliked ? "Yes" : "No"))
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+            }
+        }
+        .padding()
+    }
+}
+
+// Snippet view for: get_screen_info  (shape: list-object)
+@available(macOS 26, iOS 26, *)
+public struct MCPGetScreenInfoSnippetView: View {
+    public let data: MCPGetScreenInfoOutput
+    public init(data: MCPGetScreenInfoOutput) { self.data = data }
+    public var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            ForEach(Array(data.displays.enumerated()), id: \.offset) { _, row in
+                Text(row.name)
+                    .font(.body)
+                    .lineLimit(1)
+            }
+        }
+        .padding()
+    }
+}
+
 // Snippet view for: get_shortcut_detail  (shape: scalar)
 @available(macOS 26, iOS 26, *)
 public struct MCPGetShortcutDetailSnippetView: View {
@@ -7524,6 +8022,144 @@ public struct MCPGetShortcutDetailSnippetView: View {
                 Text("Detail")
                 Spacer()
                 Text(data.detail)
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+            }
+        }
+        .padding()
+    }
+}
+
+// Snippet view for: get_track_info  (shape: scalar)
+@available(macOS 26, iOS 26, *)
+public struct MCPGetTrackInfoSnippetView: View {
+    public let data: MCPGetTrackInfoOutput
+    public init(data: MCPGetTrackInfoOutput) { self.data = data }
+    public var body: some View {
+        VStack(alignment: .leading, spacing: 2) {
+            HStack {
+                Text("Id")
+                Spacer()
+                Text(data.id.formatted())
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+            }
+            HStack {
+                Text("Name")
+                Spacer()
+                Text(data.name)
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+            }
+            HStack {
+                Text("Artist")
+                Spacer()
+                Text(data.artist)
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+            }
+            HStack {
+                Text("Album")
+                Spacer()
+                Text(data.album)
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+            }
+            HStack {
+                Text("Album Artist")
+                Spacer()
+                Text(data.albumArtist)
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+            }
+            HStack {
+                Text("Genre")
+                Spacer()
+                Text(data.genre)
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+            }
+            HStack {
+                Text("Year")
+                Spacer()
+                Text(data.year.formatted())
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+            }
+            HStack {
+                Text("Track Number")
+                Spacer()
+                Text(data.trackNumber.formatted())
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+            }
+            HStack {
+                Text("Disc Number")
+                Spacer()
+                Text(data.discNumber.formatted())
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+            }
+            HStack {
+                Text("Duration")
+                Spacer()
+                Text(data.duration.formatted())
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+            }
+            HStack {
+                Text("Played Count")
+                Spacer()
+                Text(data.playedCount.formatted())
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+            }
+            HStack {
+                Text("Rating")
+                Spacer()
+                Text(data.rating.formatted())
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+            }
+            HStack {
+                Text("Favorited")
+                Spacer()
+                Text((data.favorited ? "Yes" : "No"))
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+            }
+            HStack {
+                Text("Disliked")
+                Spacer()
+                Text((data.disliked ? "Yes" : "No"))
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+            }
+            HStack {
+                Text("Date Added")
+                Spacer()
+                Text((data.dateAdded ?? "—"))
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+            }
+            HStack {
+                Text("Sample Rate")
+                Spacer()
+                Text(data.sampleRate.formatted())
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+            }
+            HStack {
+                Text("Bit Rate")
+                Spacer()
+                Text(data.bitRate.formatted())
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+            }
+            HStack {
+                Text("Size")
+                Spacer()
+                Text(data.size.formatted())
                     .lineLimit(1)
                     .truncationMode(.tail)
             }
@@ -7602,6 +8238,114 @@ public struct MCPGetVolumeSnippetView: View {
     }
 }
 
+// Snippet view for: get_wifi_status  (shape: scalar)
+@available(macOS 26, iOS 26, *)
+public struct MCPGetWifiStatusSnippetView: View {
+    public let data: MCPGetWifiStatusOutput
+    public init(data: MCPGetWifiStatusOutput) { self.data = data }
+    public var body: some View {
+        VStack(alignment: .leading, spacing: 2) {
+            HStack {
+                Text("Ssid")
+                Spacer()
+                Text((data.ssid ?? "—"))
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+            }
+            HStack {
+                Text("Bssid")
+                Spacer()
+                Text((data.bssid ?? "—"))
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+            }
+            HStack {
+                Text("Signal Strength")
+                Spacer()
+                Text(String(describing: data.signalStrength))
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+            }
+            HStack {
+                Text("Noise Level")
+                Spacer()
+                Text(String(describing: data.noiseLevel))
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+            }
+            HStack {
+                Text("Channel")
+                Spacer()
+                Text((data.channel ?? "—"))
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+            }
+            HStack {
+                Text("Connected")
+                Spacer()
+                Text((data.connected ? "Yes" : "No"))
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+            }
+            HStack {
+                Text("Raw")
+                Spacer()
+                Text(data.raw)
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+            }
+        }
+        .padding()
+    }
+}
+
+// Snippet view for: is_app_running  (shape: scalar)
+@available(macOS 26, iOS 26, *)
+public struct MCPIsAppRunningSnippetView: View {
+    public let data: MCPIsAppRunningOutput
+    public init(data: MCPIsAppRunningOutput) { self.data = data }
+    public var body: some View {
+        VStack(alignment: .leading, spacing: 2) {
+            HStack {
+                Text("Running")
+                Spacer()
+                Text((data.running ? "Yes" : "No"))
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+            }
+            HStack {
+                Text("Name")
+                Spacer()
+                Text(data.name)
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+            }
+            HStack {
+                Text("Bundle Identifier")
+                Spacer()
+                Text((data.bundleIdentifier ?? "—"))
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+            }
+            HStack {
+                Text("Pid")
+                Spacer()
+                Text(String(describing: data.pid))
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+            }
+            HStack {
+                Text("Visible")
+                Spacer()
+                Text((data.visible.map { $0 ? "Yes" : "No" } ?? "—"))
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+            }
+        }
+        .padding()
+    }
+}
+
 // Snippet view for: list_accounts  (shape: list-object)
 @available(macOS 26, iOS 26, *)
 public struct MCPListAccountsSnippetView: View {
@@ -7610,6 +8354,40 @@ public struct MCPListAccountsSnippetView: View {
     public var body: some View {
         VStack(alignment: .leading, spacing: 4) {
             ForEach(Array(data.accounts.enumerated()), id: \.offset) { _, row in
+                Text(row.name)
+                    .font(.body)
+                    .lineLimit(1)
+            }
+        }
+        .padding()
+    }
+}
+
+// Snippet view for: list_all_windows  (shape: list-object)
+@available(macOS 26, iOS 26, *)
+public struct MCPListAllWindowsSnippetView: View {
+    public let data: MCPListAllWindowsOutput
+    public init(data: MCPListAllWindowsOutput) { self.data = data }
+    public var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            ForEach(Array(data.windows.enumerated()), id: \.offset) { _, row in
+                Text(row.app)
+                    .font(.body)
+                    .lineLimit(1)
+            }
+        }
+        .padding()
+    }
+}
+
+// Snippet view for: list_bluetooth_devices  (shape: list-object)
+@available(macOS 26, iOS 26, *)
+public struct MCPListBluetoothDevicesSnippetView: View {
+    public let data: MCPListBluetoothDevicesOutput
+    public init(data: MCPListBluetoothDevicesOutput) { self.data = data }
+    public var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            ForEach(Array(data.devices.enumerated()), id: \.offset) { _, row in
                 Text(row.name)
                     .font(.body)
                     .lineLimit(1)
@@ -7960,6 +8738,23 @@ public struct MCPListRemindersSnippetView: View {
     }
 }
 
+// Snippet view for: list_running_apps  (shape: list-object)
+@available(macOS 26, iOS 26, *)
+public struct MCPListRunningAppsSnippetView: View {
+    public let data: MCPListRunningAppsOutput
+    public init(data: MCPListRunningAppsOutput) { self.data = data }
+    public var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            ForEach(Array(data.apps.enumerated()), id: \.offset) { _, row in
+                Text(row.name)
+                    .font(.body)
+                    .lineLimit(1)
+            }
+        }
+        .padding()
+    }
+}
+
 // Snippet view for: list_shortcuts  (shape: list-string)
 @available(macOS 26, iOS 26, *)
 public struct MCPListShortcutsSnippetView: View {
@@ -8119,6 +8914,177 @@ public struct MCPNowPlayingSnippetView: View {
                 Text("Track")
                 Spacer()
                 Text(String(describing: data.track))
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+            }
+        }
+        .padding()
+    }
+}
+
+// Snippet view for: numbers_get_cell  (shape: scalar)
+@available(macOS 26, iOS 26, *)
+public struct MCPNumbersGetCellSnippetView: View {
+    public let data: MCPNumbersGetCellOutput
+    public init(data: MCPNumbersGetCellOutput) { self.data = data }
+    public var body: some View {
+        VStack(alignment: .leading, spacing: 2) {
+            HStack {
+                Text("Address")
+                Spacer()
+                Text(data.address)
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+            }
+            HStack {
+                Text("Value")
+                Spacer()
+                Text(String(describing: data.value))
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+            }
+            HStack {
+                Text("Formatted Value")
+                Spacer()
+                Text((data.formattedValue ?? "—"))
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+            }
+        }
+        .padding()
+    }
+}
+
+// Snippet view for: numbers_get_formula  (shape: scalar)
+@available(macOS 26, iOS 26, *)
+public struct MCPNumbersGetFormulaSnippetView: View {
+    public let data: MCPNumbersGetFormulaOutput
+    public init(data: MCPNumbersGetFormulaOutput) { self.data = data }
+    public var body: some View {
+        VStack(alignment: .leading, spacing: 2) {
+            HStack {
+                Text("Address")
+                Spacer()
+                Text(data.address)
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+            }
+            HStack {
+                Text("Formula")
+                Spacer()
+                Text((data.formula ?? "—"))
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+            }
+            HStack {
+                Text("Value")
+                Spacer()
+                Text(String(describing: data.value))
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+            }
+            HStack {
+                Text("Formatted Value")
+                Spacer()
+                Text((data.formattedValue ?? "—"))
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+            }
+        }
+        .padding()
+    }
+}
+
+// Snippet view for: numbers_list_documents  (shape: list-object)
+@available(macOS 26, iOS 26, *)
+public struct MCPNumbersListDocumentsSnippetView: View {
+    public let data: MCPNumbersListDocumentsOutput
+    public init(data: MCPNumbersListDocumentsOutput) { self.data = data }
+    public var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            ForEach(Array(data.documents.enumerated()), id: \.offset) { _, row in
+                Text(row.name)
+                    .font(.body)
+                    .lineLimit(1)
+            }
+        }
+        .padding()
+    }
+}
+
+// Snippet view for: numbers_list_sheets  (shape: list-object)
+@available(macOS 26, iOS 26, *)
+public struct MCPNumbersListSheetsSnippetView: View {
+    public let data: MCPNumbersListSheetsOutput
+    public init(data: MCPNumbersListSheetsOutput) { self.data = data }
+    public var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            ForEach(Array(data.sheets.enumerated()), id: \.offset) { _, row in
+                Text(row.name)
+                    .font(.body)
+                    .lineLimit(1)
+            }
+        }
+        .padding()
+    }
+}
+
+// Snippet view for: numbers_list_tables  (shape: list-object)
+@available(macOS 26, iOS 26, *)
+public struct MCPNumbersListTablesSnippetView: View {
+    public let data: MCPNumbersListTablesOutput
+    public init(data: MCPNumbersListTablesOutput) { self.data = data }
+    public var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            ForEach(Array(data.tables.enumerated()), id: \.offset) { _, row in
+                Text(row.name)
+                    .font(.body)
+                    .lineLimit(1)
+            }
+        }
+        .padding()
+    }
+}
+
+// Snippet view for: numbers_read_cells  (shape: scalar)
+@available(macOS 26, iOS 26, *)
+public struct MCPNumbersReadCellsSnippetView: View {
+    public let data: MCPNumbersReadCellsOutput
+    public init(data: MCPNumbersReadCellsOutput) { self.data = data }
+    public var body: some View {
+        VStack(alignment: .leading, spacing: 2) {
+            HStack {
+                Text("Rows")
+                Spacer()
+                Text(String(describing: data.rows))
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+            }
+            HStack {
+                Text("Start Row")
+                Spacer()
+                Text(data.startRow.formatted())
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+            }
+            HStack {
+                Text("Start Col")
+                Spacer()
+                Text(data.startCol.formatted())
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+            }
+            HStack {
+                Text("End Row")
+                Spacer()
+                Text(data.endRow.formatted())
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+            }
+            HStack {
+                Text("End Col")
+                Spacer()
+                Text(data.endCol.formatted())
                     .lineLimit(1)
                     .truncationMode(.tail)
             }
@@ -8794,6 +9760,23 @@ public struct MCPSearchTabsSnippetView: View {
         VStack(alignment: .leading, spacing: 4) {
             ForEach(Array(data.tabs.enumerated()), id: \.offset) { _, row in
                 Text(row.title)
+                    .font(.body)
+                    .lineLimit(1)
+            }
+        }
+        .padding()
+    }
+}
+
+// Snippet view for: search_tracks  (shape: list-object)
+@available(macOS 26, iOS 26, *)
+public struct MCPSearchTracksSnippetView: View {
+    public let data: MCPSearchTracksOutput
+    public init(data: MCPSearchTracksOutput) { self.data = data }
+    public var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            ForEach(Array(data.tracks.enumerated()), id: \.offset) { _, row in
+                Text(row.name)
                     .font(.body)
                     .lineLimit(1)
             }

--- a/tests/output-schema-structured.test.js
+++ b/tests/output-schema-structured.test.js
@@ -37,6 +37,7 @@ const { registerMessagesTools } = await import('../dist/messages/tools.js');
 const { registerShortcutsTools } = await import('../dist/shortcuts/tools.js');
 const { registerWeatherTools } = await import('../dist/weather/tools.js');
 const { registerPhotosTools } = await import('../dist/photos/tools.js');
+const { registerNumbersTools } = await import('../dist/numbers/tools.js');
 const { fetchCurrentWeather } = await import('../dist/weather/api.js');
 
 // ── Per-tool args and mock responses ────────────────────────────────
@@ -370,6 +371,37 @@ const TOOL_FIXTURES = {
     args: { limit: 50 },
     mock: { total: 0, returned: 0, photos: [] },
   },
+  // ── Wave 7 additions ──
+  // numbers
+  numbers_list_documents: {
+    args: {},
+    mock: [],
+  },
+  numbers_list_sheets: {
+    args: { document: 'TestDoc' },
+    mock: [],
+  },
+  numbers_get_cell: {
+    args: { document: 'TestDoc', sheet: 'Sheet 1', cell: 'A1' },
+    mock: { address: 'A1', value: 42, formattedValue: '42' },
+  },
+  numbers_read_cells: {
+    args: { document: 'TestDoc', sheet: 'Sheet 1', startRow: 0, startCol: 0, endRow: 0, endCol: 1 },
+    mock: { rows: [[1, 2]], startRow: 0, startCol: 0, endRow: 0, endCol: 1 },
+  },
+  numbers_list_tables: {
+    args: { document: 'TestDoc', sheet: 'Sheet 1' },
+    mock: [],
+  },
+  numbers_get_formula: {
+    args: { document: 'TestDoc', sheet: 'Sheet 1', cell: 'B5' },
+    mock: { address: 'B5', formula: '=SUM(B1:B4)', value: 10, formattedValue: '10' },
+  },
+  // system
+  is_app_running: {
+    args: { name: 'Safari' },
+    mock: { running: true, name: 'Safari', bundleIdentifier: 'com.apple.Safari', pid: 1234, visible: true },
+  },
   // ── Wave 6 additions ──
   // system
   list_running_apps: {
@@ -476,6 +508,7 @@ describe('outputSchema → structuredContent contract', () => {
     registerShortcutsTools(server, config);
     registerWeatherTools(server, config);
     registerPhotosTools(server, config);
+    registerNumbersTools(server, config);
   });
 
   beforeEach(() => {

--- a/tests/system-tools.test.js
+++ b/tests/system-tools.test.js
@@ -277,14 +277,23 @@ describe('is_app_running', () => {
 
   test('returns running status', async () => {
     const { server } = setup();
-    mockRunJxa.mockResolvedValue({ running: true, name: 'Safari', pid: 1234 });
+    // Wave 7: is_app_running now has outputSchema → structuredContent is the
+    // source of truth. Mock matches the actual script return shape including
+    // the running:true variant fields (bundleIdentifier, visible).
+    mockRunJxa.mockResolvedValue({
+      running: true,
+      name: 'Safari',
+      bundleIdentifier: 'com.apple.Safari',
+      pid: 1234,
+      visible: true,
+    });
 
     const result = await server.callTool('is_app_running', { name: 'Safari' });
 
     expect(result.isError).toBeUndefined();
-    const parsed = JSON.parse(result.content[0].text);
-    expect(parsed.running).toBe(true);
-    expect(parsed.pid).toBe(1234);
+    expect(result.structuredContent).toBeDefined();
+    expect(result.structuredContent.running).toBe(true);
+    expect(result.structuredContent.pid).toBe(1234);
   });
 });
 


### PR DESCRIPTION
## Summary

Seven new typed reads bring outputSchema coverage of read tools to **~75%**. No new tools registered — pure typing layer on existing handlers. `okUntrustedStructured` used on all 7 since they return user content (filenames, sheet/table names, cell values, app process info).

## Coverage progression

| Wave | Modules | Cumulative typed reads | Coverage |
|------|---------|------------------------|----------|
| 1-5 | notes / reminders / calendar / contacts / mail / safari / finder / music / health / weather / messages / shortcuts / photos | 41 | ~55% |
| 6 | system / music | 51 | ~70% |
| **7** | **numbers / system** | **58** | **~75%** |

Numbers read surface now complete in this PR: `list_documents` / `list_sheets` / `list_tables` / `get_cell` / `read_cells` / `get_formula`. `list_charts` joins when PR #204 (batch 2) merges.

## Schemas

### numbers (6 reads)

| Tool | Schema notes |
|------|-------------|
| `numbers_list_documents` | `{ documents: [{name, path?, modified}] }`. Wraps bare-array script return in `{documents}` to satisfy MCP's object-required outputSchema. `path` nullable (unsaved doc). |
| `numbers_list_sheets` | `{ sheets: [{name, tableCount}] }`. Same wrap. |
| `numbers_get_cell` | `{ address, value, formattedValue }`. `value` uses `z.unknown()` — Numbers cells hold dynamic types (number/string/date/boolean/null), `z.union` would be brittle. |
| `numbers_read_cells` | `{ rows: [[value,...]], startRow, startCol, endRow, endCol }`. Inner cell values also `z.unknown()`. |
| `numbers_list_tables` | `{ tables: [{name, rowCount, columnCount}] }`. |
| `numbers_get_formula` | `{ address, formula?, value, formattedValue }`. `formula` nullable for cells holding constants. |

### system (1 read)

| Tool | Schema notes |
|------|-------------|
| `is_app_running` | `{ running, name, bundleIdentifier?, pid?, visible? }`. Optional fields only present when `running===true` (the JXA script returns one of two variant shapes). |

## Tests

- **`tests/output-schema-structured.test.js`** — +7 fixture entries + `registerNumbersTools` added to `beforeAll` setup. The exhaustive coverage check validates each new schema against its mock.
- **`tests/system-tools.test.js`** — `is_app_running` test switched from `JSON.parse(content[0].text)` to `result.structuredContent` (same fix pattern as Wave 6 `list_all_windows`). Mock expanded to include the full `running:true` variant shape.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm test` — **107 suites / 1762 tests pass**
- [x] `npm run format:check` — clean
- [x] `npm run lint` — 0 warnings
- [x] `npm run llms:check` / `gen:intents:check` / `stats:check` / `gen:manifest:check` — clean (no count change; this PR adds NO new tools)

🤖 Generated with [Claude Code](https://claude.com/claude-code)