### PR TITLE
refactor(logger,circuit-breaker): simplify per review

### DIFF
--- a/src/maps/api.ts
+++ b/src/maps/api.ts
@@ -7,7 +7,7 @@
 // GEOCODE timeout before failing. The breaker trips after 5 consecutive failures
 // per host and stays open for 30s before allowing one probe.
 
-import { API, TIMEOUT, IDENTITY } from "../shared/constants.js";
+import { API, BREAKER, TIMEOUT, IDENTITY } from "../shared/constants.js";
 import { getBreaker } from "../shared/circuit-breaker.js";
 
 const GEOCODE_URL = API.GEOCODING;
@@ -24,7 +24,7 @@ async function nominatimThrottle(): Promise<void> {
 }
 
 export async function fetchGeocode(query: string, count = 5) {
-  return getBreaker("open-meteo").execute(async () => {
+  return getBreaker(BREAKER.OPEN_METEO).execute(async () => {
     const params = new URLSearchParams({ name: query, count: String(count), language: "en", format: "json" });
     const res = await fetch(`${GEOCODE_URL}?${params}`, { signal: AbortSignal.timeout(TIMEOUT.GEOCODE) });
     if (!res.ok) throw new Error(`Geocoding API error: ${res.status} ${res.statusText}`);
@@ -45,7 +45,7 @@ export async function fetchGeocode(query: string, count = 5) {
 }
 
 export async function fetchReverseGeocode(latitude: number, longitude: number) {
-  return getBreaker("nominatim").execute(async () => {
+  return getBreaker(BREAKER.NOMINATIM).execute(async () => {
     await nominatimThrottle();
     const params = new URLSearchParams({ lat: String(latitude), lon: String(longitude), format: "json" });
     const res = await fetch(`${REVERSE_URL}?${params}`, {

--- a/src/shared/circuit-breaker.ts
+++ b/src/shared/circuit-breaker.ts
@@ -1,29 +1,19 @@
 /**
- * Per-host circuit breaker for outbound HTTP — closes/opens/half-opens based
- * on consecutive failures so a flaky upstream (Open-Meteo, Nominatim, etc.)
- * cannot make every subsequent tool call wait for the full request timeout.
+ * Per-host circuit breaker for outbound HTTP.
  *
  * Why this exists
  * ----------------
  * Outbound paths (`src/maps/api.ts`, future Google Workspace calls) wrap
  * `fetch()` with `AbortSignal.timeout(...)`. That bounds a single request,
- * but does not protect the *next* call from also hitting timeout. If the
- * upstream is down, ten consecutive tool calls each wait the full timeout
- * before failing — bad UX, wasted resource handles, and (for HTTP-mode
- * deployments) it amplifies the apparent latency seen by clients.
+ * but does not protect the *next* call from hitting the same timeout. If
+ * the upstream is down, ten consecutive tool calls each wait the full
+ * timeout before failing — bad UX, wasted resource handles, and (for HTTP
+ * mode) it amplifies the apparent latency seen by clients.
  *
  * A circuit breaker short-circuits in the OPEN state: requests are rejected
  * synchronously with `BreakerOpenError` while the upstream is presumed dead.
  * After `openMs` elapses the breaker transitions to HALF_OPEN — exactly one
- * probe request is allowed; success closes the breaker, failure re-opens it.
- *
- * Three-state machine
- * --------------------
- *   CLOSED      — pass-through. On failure, increment counter. On
- *                 `failureThreshold` consecutive failures, transition to OPEN.
- *   OPEN        — reject immediately. After `openMs` from the trip time,
- *                 transition to HALF_OPEN on next `execute()` call.
- *   HALF_OPEN   — allow one probe. Success → CLOSED. Failure → OPEN.
+ * probe is allowed; success closes the breaker, failure re-opens it.
  *
  * Tunable via `performance.circuitBreakerThreshold` /
  * `performance.circuitBreakerOpenMs` in `~/.config/airmcp/config.json`.
@@ -41,6 +31,7 @@
  *   the breaker is trying to suppress.
  */
 
+import { assertTestMode } from "./errors.js";
 import { log } from "./logger.js";
 
 export type BreakerState = "closed" | "open" | "half_open";
@@ -66,19 +57,25 @@ export class CircuitBreaker {
   private state: BreakerState = "closed";
   private consecutiveFailures = 0;
   private openedAt = 0;
+  private readonly name: string;
+  private readonly failureThreshold: number;
+  private readonly openMs: number;
 
-  constructor(private readonly opts: BreakerOptions) {}
+  constructor(opts: BreakerOptions) {
+    this.name = opts.name ?? "anonymous";
+    this.failureThreshold = opts.failureThreshold;
+    this.openMs = opts.openMs;
+  }
 
   /** Run `fn` through the breaker. Throws `BreakerOpenError` when OPEN. */
   async execute<T>(fn: () => Promise<T>): Promise<T> {
     if (this.state === "open") {
       const elapsed = Date.now() - this.openedAt;
-      if (elapsed < this.opts.openMs) {
-        throw new BreakerOpenError(this.opts.name ?? "anonymous", this.opts.openMs - elapsed);
+      if (elapsed < this.openMs) {
+        throw new BreakerOpenError(this.name, this.openMs - elapsed);
       }
-      // Probe.
       this.state = "half_open";
-      log.info("circuit breaker probing (half-open)", { name: this.opts.name ?? "anonymous" });
+      log.info("circuit breaker probing (half-open)", { name: this.name });
     }
 
     try {
@@ -110,7 +107,7 @@ export class CircuitBreaker {
 
   private recordSuccess(): void {
     if (this.state === "half_open") {
-      log.info("circuit breaker closed after successful probe", { name: this.opts.name ?? "anonymous" });
+      log.info("circuit breaker closed after successful probe", { name: this.name });
     }
     this.state = "closed";
     this.consecutiveFailures = 0;
@@ -119,32 +116,33 @@ export class CircuitBreaker {
   private recordFailure(): void {
     this.consecutiveFailures++;
     if (this.state === "half_open") {
-      // Probe failed — re-open immediately.
-      this.state = "open";
-      this.openedAt = Date.now();
-      log.warn("circuit breaker re-opened — probe failed", {
-        name: this.opts.name ?? "anonymous",
-        openMs: this.opts.openMs,
-      });
+      this.trip("probe-failed");
       return;
     }
-    if (this.state === "closed" && this.consecutiveFailures >= this.opts.failureThreshold) {
-      this.state = "open";
-      this.openedAt = Date.now();
-      log.warn("circuit breaker tripped — opening", {
-        name: this.opts.name ?? "anonymous",
-        consecutiveFailures: this.consecutiveFailures,
-        openMs: this.opts.openMs,
-      });
+    if (this.state === "closed" && this.consecutiveFailures >= this.failureThreshold) {
+      this.trip("threshold-reached");
     }
+  }
+
+  private trip(reason: "probe-failed" | "threshold-reached"): void {
+    this.state = "open";
+    this.openedAt = Date.now();
+    const event = reason === "probe-failed" ? "re-opened" : "tripped — opening";
+    log.warn(`circuit breaker ${event}`, {
+      name: this.name,
+      reason,
+      consecutiveFailures: this.consecutiveFailures,
+      openMs: this.openMs,
+    });
   }
 }
 
 // ── Per-host registry ─────────────────────────────────────────────────
 //
-// A single global Map keyed by host string. Defaults from constants;
-// override path via `config.performance.{circuitBreakerThreshold,
-// circuitBreakerOpenMs}` is honoured by callers that pass explicit opts.
+// A global Map keyed by host name. **Contract:** `name` must be a
+// compile-time constant (typically from `src/shared/constants.ts` →
+// `BREAKER.*`). Do NOT derive it from request data — the registry has no
+// eviction, so user-supplied names would grow memory monotonically.
 
 const breakers = new Map<string, CircuitBreaker>();
 
@@ -163,8 +161,6 @@ export function getBreaker(name: string, opts?: Partial<BreakerOptions>): Circui
 
 /** Test-only: reset every registered breaker to closed. */
 export function _resetAllBreakersForTests(): void {
-  if (process.env.NODE_ENV !== "test" && process.env.AIRMCP_TEST_MODE !== "1") {
-    throw new Error("_resetAllBreakersForTests is only callable in test mode");
-  }
+  assertTestMode("_resetAllBreakersForTests()");
   for (const b of breakers.values()) b.reset();
 }

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -46,6 +46,13 @@ export const API = {
   OLLAMA: envStr("AIRMCP_OLLAMA_URL", "http://localhost:11434"),
 } as const;
 
+/** Per-host circuit breaker identifiers. Must be compile-time constants —
+ *  the breaker registry has no eviction. Add new outbound hosts here. */
+export const BREAKER = {
+  OPEN_METEO: "open-meteo",
+  NOMINATIM: "nominatim",
+} as const;
+
 // ══════════════════════════════════════════════════════════════════════
 // EXTERNAL CDN DEPENDENCIES — pin versions here, change in one place
 // ══════════════════════════════════════════════════════════════════════

--- a/src/shared/errors.ts
+++ b/src/shared/errors.ts
@@ -17,6 +17,25 @@ export function formatError(e: unknown): string {
 }
 
 /**
+ * Serialise an unknown throwable for inclusion in a structured log `ctx`.
+ *
+ * `formatError` returns a single string (good for interpolated messages);
+ * `errToCtx` returns `{name, message, stack}` so JSON consumers (menubar
+ * viewer, log shipping) can filter on each field. Use the latter exclusively
+ * with the structured logger (`src/shared/logger.ts`).
+ *
+ * `Error` instances don't round-trip through `JSON.stringify` because
+ * `name`/`message`/`stack` are non-enumerable — `JSON.stringify(new Error("x"))`
+ * is `"{}"`. This helper makes the fields explicit.
+ */
+export function errToCtx(e: unknown): Record<string, unknown> {
+  if (e instanceof Error) {
+    return { name: e.name, message: e.message, stack: e.stack };
+  }
+  return { value: String(e) };
+}
+
+/**
  * Throws unless we're in a test environment.
  *
  * Test environment is signaled by `NODE_ENV=test` (set automatically by Jest)

--- a/src/shared/logger.ts
+++ b/src/shared/logger.ts
@@ -1,41 +1,37 @@
 /**
  * Structured logger — single sink for AirMCP runtime logs.
  *
- * Why this exists
- * ----------------
  * The server has 70+ scattered `console.error`/`console.warn` calls used as
  * ad-hoc diagnostic output. They all write to stderr (correct — stdout is
  * reserved for the JSON-RPC stream on stdio transport), but the format is
- * inconsistent: some are bare strings, some prefix with `[AirMCP …]`, some
- * include structured context inline as `${JSON.stringify(...)}`, and the
- * menubar app's log viewer has to parse the union of all of those shapes.
+ * inconsistent: bare strings, `[AirMCP …]` prefixes, inline
+ * `${JSON.stringify(...)}`. The menubar viewer has to parse the union of all
+ * those shapes. This module collapses them to one shape and one level filter.
  *
- * This module standardises:
- *   - One sink: `console.error` (which Node routes to `process.stderr`,
- *     leaving stdout — reserved for the JSON-RPC stream on stdio
- *     transport — completely untouched). Going through `console.error`
- *     rather than `process.stderr.write` directly lets existing test
- *     spies on `console.error` keep working without per-test refactors.
- *   - One shape: `{ts, level, msg, ...ctx}` JSON when `AIRMCP_LOG_FORMAT=json`
- *     or stderr is not a TTY (i.e. the menubar viewer is reading the pipe);
- *     human-readable single-line otherwise.
- *   - One level filter: `AIRMCP_LOG_LEVEL` (default `info`).
+ * The sink is `console.error` rather than `process.stderr.write` directly so
+ * existing test spies on `console.error` keep working — Node's `console.error`
+ * is implemented as `process.stderr.write(... + '\n')`, so the wire effect is
+ * identical.
  *
  * Non-goals
  * ----------
  * - No external dep (`pino`/`winston`). Zero added bytes to the npm tarball.
- * - No log rotation here — the audit log has its own rotation; this is for
- *   ephemeral diagnostic stderr, which the OS / launchd / menubar viewer
- *   already manage.
- * - No async/buffered writes. stderr is line-buffered and slow enough to
- *   matter only at very high volume; the audit log already has the async
- *   buffered path.
+ * - No log rotation — `src/shared/audit.ts` has its own; this is for ephemeral
+ *   diagnostic stderr that the OS / launchd / menubar viewer already manage.
+ * - No async/buffered writes. stderr is fast enough except at very high
+ *   volume; the audit log already has the buffered path for that case.
  *
  * CLI subcommands (`airmcp init` / `doctor` / `--version`) keep using
- * `console.log` directly: those are user-facing CLI output to stdout, not
+ * `console.log` directly — that's user-facing CLI output to stdout, not
  * server diagnostic logs. The boot-time HOME check in `src/index.ts` also
  * keeps raw `console.error` because the logger isn't loaded yet.
  */
+
+// Re-export so callers that already pull `log` from this module can grab
+// `errToCtx` without a second import. The implementation lives in
+// `./errors.ts` next to `formatError` so error-serialisation helpers stay
+// co-located.
+export { errToCtx } from "./errors.js";
 
 export type LogLevel = "debug" | "info" | "warn" | "error";
 
@@ -44,6 +40,15 @@ const LEVELS: Record<LogLevel, number> = {
   info: 20,
   warn: 30,
   error: 40,
+};
+
+// Pre-padded level labels for the pretty formatter — avoids `toUpperCase()`
+// + `padEnd(5)` per emitted line.
+const PRETTY_LABEL: Record<LogLevel, string> = {
+  debug: "DEBUG",
+  info: "INFO ",
+  warn: "WARN ",
+  error: "ERROR",
 };
 
 function parseLevel(raw: string | undefined, fallback: LogLevel): LogLevel {
@@ -56,8 +61,8 @@ function parseLevel(raw: string | undefined, fallback: LogLevel): LogLevel {
 function pickFormat(): "json" | "pretty" {
   const explicit = process.env.AIRMCP_LOG_FORMAT?.toLowerCase();
   if (explicit === "json" || explicit === "pretty") return explicit;
-  // Default: if stderr is piped (menubar viewer, log file, CI), prefer JSON
-  // so consumers don't have to scrape; if it's a TTY, prefer human-readable.
+  // If stderr is piped (menubar viewer, log file, CI), prefer JSON so
+  // consumers don't have to scrape; if it's a TTY, prefer human-readable.
   return process.stderr.isTTY ? "pretty" : "json";
 }
 
@@ -66,9 +71,8 @@ const format = pickFormat();
 
 function formatPretty(level: LogLevel, msg: string, ctx?: Record<string, unknown>): string {
   const ts = new Date().toISOString();
-  const lvl = level.toUpperCase().padEnd(5);
   const ctxStr = ctx && Object.keys(ctx).length ? " " + JSON.stringify(ctx) : "";
-  return `[${ts}] ${lvl} ${msg}${ctxStr}`;
+  return `[${ts}] ${PRETTY_LABEL[level]} ${msg}${ctxStr}`;
 }
 
 function formatJson(level: LogLevel, msg: string, ctx?: Record<string, unknown>): string {
@@ -89,28 +93,19 @@ function formatJson(level: LogLevel, msg: string, ctx?: Record<string, unknown>)
 function emit(level: LogLevel, msg: string, ctx?: Record<string, unknown>): void {
   if (LEVELS[level] < minLevel) return;
   const line = format === "json" ? formatJson(level, msg, ctx) : formatPretty(level, msg, ctx);
-  // Route through console.error so test spies on `console.error` keep
-  // working. Node implements console.error as `process.stderr.write(... + '\n')`
-  // so the wire effect is identical to writing to stderr directly.
-   
+
   console.error(line);
 }
 
-/**
- * Serialise an unknown error for inclusion in a log context object.
- *
- * Errors don't round-trip through `JSON.stringify` (name/message/stack are
- * non-enumerable), so callers that just spread `{ err }` lose the data.
- * Use as: `log.error("flush failed", { err: errToCtx(e) })`.
- */
-export function errToCtx(e: unknown): Record<string, unknown> {
-  if (e instanceof Error) {
-    return { name: e.name, message: e.message, stack: e.stack };
-  }
-  return { value: String(e) };
-}
-
 export const log = {
+  /**
+   * Cheap level check for hot paths — callers can skip building a heavy `ctx`
+   * object when the level would be suppressed anyway. Example:
+   *   `if (log.isLevelEnabled("debug")) log.debug("...", expensiveCtx());`
+   */
+  isLevelEnabled(level: LogLevel): boolean {
+    return LEVELS[level] >= minLevel;
+  },
   debug(msg: string, ctx?: Record<string, unknown>): void {
     emit("debug", msg, ctx);
   },
@@ -124,14 +119,3 @@ export const log = {
     emit("error", msg, ctx);
   },
 };
-
-/** Exported for tests — read the effective level without going through env. */
-export function _effectiveLevel(): LogLevel {
-  const inverse = Object.entries(LEVELS).find(([, n]) => n === minLevel);
-  return (inverse?.[0] as LogLevel) ?? "info";
-}
-
-/** Exported for tests — read the effective format without going through env. */
-export function _effectiveFormat(): "json" | "pretty" {
-  return format;
-}

--- a/src/shared/swift.ts
+++ b/src/shared/swift.ts
@@ -225,6 +225,10 @@ function ensureProcess(): Promise<void> {
     });
 
     proc.stderr!.on("data", (chunk: Buffer) => {
+      // Swift bridge writes stderr only for warnings/errors under normal
+      // operation, so we keep this at info — losing it would hide bridge
+      // failures from the menubar log viewer. Volume is not a concern in
+      // practice.
       log.info("swift bridge stderr", { line: chunk.toString().trim() });
     });
 

--- a/tests/circuit-breaker.test.js
+++ b/tests/circuit-breaker.test.js
@@ -163,7 +163,8 @@ describe("CircuitBreaker", () => {
     const origNode = process.env.NODE_ENV;
     delete process.env.NODE_ENV;
     try {
-      expect(() => _resetAllBreakersForTests()).toThrow(/test mode/);
+      // assertTestMode's canonical message; same gate used by audit / tool-registry.
+      expect(() => _resetAllBreakersForTests()).toThrow(/NODE_ENV=test or AIRMCP_TEST_MODE=1/);
     } finally {
       if (orig !== undefined) process.env.AIRMCP_TEST_MODE = orig;
       if (origNode !== undefined) process.env.NODE_ENV = origNode;


### PR DESCRIPTION
Findings addressed from the /simplify review of the modernization sweep:

- Move errToCtx() from src/shared/logger.ts to src/shared/errors.ts (next
  to formatError). Re-export from logger.ts for callers that already
  import { log }. Co-locates the two error-serialisation helpers and
  removes the inline duplicate.
- Replace the inline test-mode guard in _resetAllBreakersForTests() with
  the shared assertTestMode() helper. Matches the pattern already used by
  audit, tool-registry, rate-limit, usage-tracker, pollers.
- Resolve CircuitBreaker.name once in the constructor instead of
  recomputing "this.opts.name ?? 'anonymous'" at 5 call sites.
- Extract CircuitBreaker.trip(reason) to consolidate the two state-write
  paths in recordFailure() that previously duplicated state="open" /
  openedAt=Date.now() / log.warn calls.
- Move bare breaker name literals ("open-meteo", "nominatim") into
  BREAKER constants in src/shared/constants.ts. Documents the
  "compile-time constants only" contract for getBreaker (no eviction).
- Trim narrate-the-code bullets from logger.ts and circuit-breaker.ts
  headers; keep only WHY content. Drop unused _effectiveLevel /
  _effectiveFormat exports from logger.ts (leaky, never called).
- Add log.isLevelEnabled(level) for hot-path callers that want to skip
  ctx construction when the level would be suppressed.
- Precompute padded level labels (PRETTY_LABEL) in logger.ts to avoid
  per-emit toUpperCase().padEnd(5).

Decisions logged as "skipped":
- Did NOT downgrade swift bridge stderr from log.info to log.debug —
  efficiency review flagged it as the hottest log site, but the bridge
  only writes stderr for warnings/errors in practice and downgrading
  hides bridge failures from the menubar viewer.
- Did NOT promote captureStderr() from tests/logger.test.js to a shared
  helper — only one test file uses it today; revisit when a second adopts
  the pattern.
- Did NOT add log.warnErr / log.errorErr convenience helpers — current
  log.warn(msg, { err: errToCtx(e) }) is greppable and 100% consistent.
