### PR TITLE
fix(http-transport): redact oauth issuer value from validation error

### DIFF
--- a/src/server/http-transport.ts
+++ b/src/server/http-transport.ts
@@ -172,8 +172,16 @@ export function validateNetworkPolicy(ctx: {
         );
       }
       if (!/^https:\/\//.test(ctx.oauthIssuer)) {
+        // Report only the offending scheme — not the full URL value. The
+        // URL could carry an internal hostname an operator considers
+        // sensitive (private OIDC endpoint, customer-specific subdomain),
+        // and the FATAL log path emits this message to stderr where the
+        // menubar viewer / CI logs / log shipping pipelines can persist it.
+        // The operator can read their own env var to debug; we don't need
+        // to interpolate the value.
+        const scheme = ctx.oauthIssuer.split(":", 1)[0] || "<empty>";
         throw new Error(
-          `AIRMCP_OAUTH_ISSUER must be an https:// URL (got "${ctx.oauthIssuer}"). ` +
+          `AIRMCP_OAUTH_ISSUER must be an https:// URL (got scheme "${scheme}"). ` +
             "Plain http issuers are a security hole — reject at startup.",
         );
       }


### PR DESCRIPTION
Closes CodeQL alert #38 (js/clear-text-logging, high).

When AIRMCP_OAUTH_ISSUER is misconfigured (non-https), the startup
invariant throws with the issuer URL interpolated into the message.
That message flows to the FATAL log path in startHttpServer's catch
(src/server/http-transport.ts:241), which writes to stderr — visible
to the menubar log viewer, CI logs, and any log-shipping pipeline.

The URL itself can carry an internal hostname an operator considers
sensitive (private OIDC endpoint, customer-specific subdomain). The
operator can read their own env var to debug — the error message only
needs to identify *which* env var is misconfigured and *why* (scheme
must be https), not the exact value.
