### PR TITLE
fix(circuit-breaker): single-probe contract under concurrent HALF_OPEN entry

### DIFF
--- a/src/shared/circuit-breaker.ts
+++ b/src/shared/circuit-breaker.ts
@@ -57,6 +57,15 @@ export class CircuitBreaker {
   private state: BreakerState = "closed";
   private consecutiveFailures = 0;
   private openedAt = 0;
+  /**
+   * True while a HALF_OPEN probe is currently `await`ing its `fn()`. Required
+   * to preserve the single-probe contract under concurrent callers: without
+   * this flag, two `execute()` calls landing after `openMs` would both see
+   * `state==="open"`, both transition to HALF_OPEN, and both run their `fn()`
+   * in parallel — exactly what the breaker is meant to prevent on a
+   * recovering upstream. (Caught by the audit at tests/circuit-breaker-race.test.js.)
+   */
+  private probeInFlight = false;
   private readonly name: string;
   private readonly failureThreshold: number;
   private readonly openMs: number;
@@ -74,8 +83,19 @@ export class CircuitBreaker {
       if (elapsed < this.openMs) {
         throw new BreakerOpenError(this.name, this.openMs - elapsed);
       }
+      // Transition to HALF_OPEN and claim the probe slot. Both writes are
+      // synchronous and run before the `await fn()` below, so they're
+      // atomic with respect to any other call to `execute()`.
       this.state = "half_open";
+      this.probeInFlight = true;
       log.info("circuit breaker probing (half-open)", { name: this.name });
+    } else if (this.state === "half_open" && this.probeInFlight) {
+      // Another call already claimed the probe slot and is awaiting fn().
+      // Reject this caller with retryInMs=0 so callers can retry the next
+      // tick — by then the in-flight probe has resolved and either closed
+      // the breaker (subsequent calls go through) or re-opened it
+      // (subsequent calls get a normal BreakerOpenError with retryInMs).
+      throw new BreakerOpenError(this.name, 0);
     }
 
     try {
@@ -103,6 +123,7 @@ export class CircuitBreaker {
     this.state = "closed";
     this.consecutiveFailures = 0;
     this.openedAt = 0;
+    this.probeInFlight = false;
   }
 
   private recordSuccess(): void {
@@ -111,6 +132,7 @@ export class CircuitBreaker {
     }
     this.state = "closed";
     this.consecutiveFailures = 0;
+    this.probeInFlight = false;
   }
 
   private recordFailure(): void {
@@ -127,6 +149,7 @@ export class CircuitBreaker {
   private trip(reason: "probe-failed" | "threshold-reached"): void {
     this.state = "open";
     this.openedAt = Date.now();
+    this.probeInFlight = false;
     const event = reason === "probe-failed" ? "re-opened" : "tripped — opening";
     log.warn(`circuit breaker ${event}`, {
       name: this.name,

--- a/tests/circuit-breaker.test.js
+++ b/tests/circuit-breaker.test.js
@@ -126,6 +126,62 @@ describe("CircuitBreaker", () => {
     expect(b.getState()).toBe("closed");
   });
 
+  test("HALF_OPEN admits exactly one in-flight probe (concurrent callers)", async () => {
+    // Regression for the 2nd-pass audit (2026-05-21) — prior implementation
+    // let two concurrent callers both transition to HALF_OPEN and both run
+    // their fn() in parallel, violating the single-probe contract.
+    const b = new CircuitBreaker({ failureThreshold: 1, openMs: 10, name: "race" });
+    await expect(b.execute(async () => { throw new Error("trip"); })).rejects.toThrow("trip");
+    expect(b.getState()).toBe("open");
+    await new Promise((r) => setTimeout(r, 20));
+
+    let probeCalls = 0;
+    const slowProbe = async () => {
+      probeCalls++;
+      await new Promise((r) => setTimeout(r, 50));
+      return "probe-ok";
+    };
+    // Both calls land while the breaker is OPEN-past-deadline. Exactly one
+    // should claim the probe slot; the other must reject immediately with
+    // BreakerOpenError(retryInMs=0).
+    const [r1, r2] = await Promise.all([
+      b.execute(slowProbe).catch((e) => e),
+      b.execute(slowProbe).catch((e) => e),
+    ]);
+    expect(probeCalls).toBe(1);
+    const successes = [r1, r2].filter((r) => r === "probe-ok").length;
+    const rejections = [r1, r2].filter((r) => r instanceof BreakerOpenError).length;
+    expect(successes).toBe(1);
+    expect(rejections).toBe(1);
+    // After a successful probe the breaker should be closed and the probe
+    // slot released — a fresh call must go through.
+    expect(b.getState()).toBe("closed");
+    await b.execute(async () => "follow-up");
+  });
+
+  test("HALF_OPEN releases the probe slot after a failed probe", async () => {
+    // Companion to the race-probe test: a *failed* probe must also release
+    // the in-flight flag (it transitions back to OPEN, so subsequent
+    // callers get a normal BreakerOpenError with retryInMs > 0, not an
+    // immediate-retry response based on a stuck flag).
+    const b = new CircuitBreaker({ failureThreshold: 1, openMs: 10, name: "race-fail" });
+    await expect(b.execute(async () => { throw new Error("trip"); })).rejects.toThrow("trip");
+    await new Promise((r) => setTimeout(r, 20));
+
+    await expect(b.execute(async () => { throw new Error("probe-fail"); })).rejects.toThrow("probe-fail");
+    expect(b.getState()).toBe("open");
+    // Subsequent caller during the new OPEN window must see a retryInMs > 0,
+    // proving the probe slot did not leak the half_open lock.
+    try {
+      await b.execute(async () => "x");
+      throw new Error("expected BreakerOpenError");
+    } catch (e) {
+      expect(e).toBeInstanceOf(BreakerOpenError);
+      expect(e.message).toMatch(/retry in ~\d+ms/);
+      expect(e.message).not.toMatch(/retry in ~0ms/);
+    }
+  });
+
   test("BreakerOpenError carries the retry-in-ms message", async () => {
     const b = new CircuitBreaker({ failureThreshold: 1, openMs: 5_000, name: "open-meteo" });
     await expect(b.execute(async () => { throw new Error("trip"); })).rejects.toThrow("trip");


### PR DESCRIPTION
**Previously declared done; 2nd-pass audit (2026-05-21) caught a race
that broke the breaker's load-bearing single-probe contract.**

Reproducible failure (now in the regression suite at
tests/circuit-breaker.test.js):

  1. Breaker trips after one failure (state=OPEN).
  2. openMs elapses.
  3. Two callers invoke execute() at the same tick.
  4. Both observe state==="open" with elapsed>openMs, both transition
     to state="half_open", both call fn() — TWO probes in flight.

This violates the documented behaviour in the header comment ("exactly
one probe is allowed; success closes the breaker, failure re-opens it")
and the test suite's "OPEN → HALF_OPEN → CLOSED on successful probe"
case, which only exercised single-caller flow.

Fix: add a `probeInFlight` flag, set synchronously when the first
caller transitions to HALF_OPEN, before the `await fn()`. Concurrent
callers landing in HALF_OPEN with the flag set throw
BreakerOpenError(retryInMs=0) — i.e. retry-next-tick — instead of
launching a second probe. recordSuccess() / recordFailure() / trip() /
reset() all clear the flag.

Two new regression tests:
- HALF_OPEN admits exactly one in-flight probe (concurrent callers)
- HALF_OPEN releases the probe slot after a failed probe (no stuck lock)

Net: 1898 → 1900 tests pass.
