### PR TITLE
chore: audit flush perf + drop unimplementable cancellation promise

### DIFF
--- a/docs/tool-manifest.json
+++ b/docs/tool-manifest.json
@@ -8655,7 +8655,7 @@
     {
       "name": "prevent_sleep",
       "title": "Prevent Sleep",
-      "description": "Prevent the Mac from sleeping for a specified duration using caffeinate. Returns the process PID for cancellation.",
+      "description": "Prevent the Mac from sleeping for a specified duration using caffeinate. The assertion is transient — it auto-releases when the timer elapses; no manual stop is required.",
       "inputSchema": {
         "type": "object",
         "properties": {

--- a/src/shared/audit.ts
+++ b/src/shared/audit.ts
@@ -277,7 +277,16 @@ async function flushBuffer(): Promise<void> {
       // the JSON without _hmac/_prev, so verifiers reconstruct the same body.
       const body = JSON.stringify(obj);
       const hmac = computeHmac(prev, body);
-      const sealed = JSON.stringify({ ...obj, _prev: prev, _hmac: hmac });
+      // Build the sealed line by string surgery instead of `JSON.stringify({
+      // ...obj, _prev, _hmac })` to skip the second serialise of `obj`. Safe
+      // because: (1) `body` starts with "{" and ends with "}" — JSON.stringify
+      // of a non-null object is guaranteed to; (2) audit entries always carry
+      // at least timestamp/tool/args/status, so body is never the empty "{}"
+      // edge case where we'd need a leading comma guard; (3) `prev` and `hmac`
+      // are hex strings (`[0-9a-f]{64}`) and need no JSON escaping. Verifier
+      // round-trip (parse → delete _prev/_hmac → re-stringify) reconstructs
+      // exactly `body` because V8 preserves parsed-object insertion order.
+      const sealed = body.slice(0, -1) + `,"_prev":"${prev}","_hmac":"${hmac}"}`;
       sealedLines.push(sealed);
       lastHmac = hmac;
     } catch {

--- a/src/system/tools.ts
+++ b/src/system/tools.ts
@@ -570,7 +570,7 @@ export function registerSystemTools(server: McpServer, _config: AirMcpConfig): v
     {
       title: "Prevent Sleep",
       description:
-        "Prevent the Mac from sleeping for a specified duration using caffeinate. Returns the process PID for cancellation.",
+        "Prevent the Mac from sleeping for a specified duration using caffeinate. The assertion is transient — it auto-releases when the timer elapses; no manual stop is required.",
       inputSchema: {
         seconds: z
           .number()

--- a/swift/Sources/AirMCPKit/Generated/MCPIntents.swift
+++ b/swift/Sources/AirMCPKit/Generated/MCPIntents.swift
@@ -5332,7 +5332,7 @@ public struct PodcastPlaybackControlIntent: AppIntent {
 // Tool: prevent_sleep
 public struct PreventSleepIntent: AppIntent {
     nonisolated(unsafe) public static var title: LocalizedStringResource = "Prevent Sleep"
-    nonisolated(unsafe) public static var description = IntentDescription("Prevent the Mac from sleeping for a specified duration using caffeinate. Returns the process PID for cancellation.")
+    nonisolated(unsafe) public static var description = IntentDescription("Prevent the Mac from sleeping for a specified duration using caffeinate. The assertion is transient — it auto-releases when the timer elapses; no manual stop is required.")
     nonisolated(unsafe) public static var openAppWhenRun: Bool = false
 
     public init() {}


### PR DESCRIPTION
Two small follow-ups from the 2nd-pass audit findings list.

1. src/shared/audit.ts — single stringify per audit entry at flush time
   The flush path was serialising each parsed entry twice: once to
   compute the HMAC over the canonical body, then again with the spread
   `{ ...obj, _prev, _hmac }` to produce the wire line. Replace the
   second JSON.stringify with `body.slice(0, -1) + ',"_prev":"...","_hmac":"..."}'`
   string surgery. Safe because:
     - body is JSON.stringify of a non-null object → always "{...}"
     - audit entries always carry ≥4 fields (timestamp/tool/args/status),
       so body is never the "{}" edge case that would need a leading
       comma guard
     - prev and hmac are hex strings ([0-9a-f]{64}), no JSON escaping
       needed
     - verifier round-trip (parse → delete _prev/_hmac → re-stringify)
       reconstructs exactly the same body bytes because V8 preserves
       parsed-object insertion order
   All 6 audit test suites / 74 tests still pass including the HMAC
   tamper-detection contract (tests/audit-tamper-detection.test.js).

2. src/system/tools.ts — drop the cancellation promise from prevent_sleep
   The description claimed "Returns the process PID for cancellation",
   but no allow_sleep / stop_caffeinate tool exists to actually use that
   PID. The 2nd-pass audit flagged this as a public-API contract gap.
   Honest framing: caffeinate is a *transient* assertion (it auto-
   releases when the timer elapses) — that's what the tool actually
   guarantees, and it's enough for the use cases the tool exists for
   (block sleep during a long export, a focus session, etc.). If a
   real demand for mid-window cancellation surfaces, that's the trigger
   for an allow_sleep tool — not before.
   Tool manifest regenerated (npm run gen:manifest) to propagate the
   description change to downstream AppIntents.
