### PR TITLE
docs(readme,plugin): wwdc d-10 hook + adjacent comp row + plugin filter keywords

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "airmcp",
-  "description": "Apple-native MCP runtime — 272 tools across 29 modules (Calendar, Notes, Mail, Reminders, Contacts, Messages, Music, Finder, Safari, Photos, Maps, Podcasts, Weather, iWork, Google Workspace, Apple Intelligence, UI Automation, Shortcuts, Context Memory) over native Swift bridges into EventKit, HealthKit, PhotoKit, Vision, and Foundation Models. Production governance built in: HMAC-chained audit log, per-call HITL, OAuth 2.1 + Resource Indicators, scope gate, rate limit, emergency stop file.",
+  "description": "Apple-native MCP server with production governance built in — HMAC-chained audit log, per-call HITL, OAuth 2.1 + Resource Indicators, scope gate, rate limit, emergency stop file. 272 tools across 29 modules: Calendar, Notes, Mail, Reminders, Contacts, Messages, Music, Finder, Safari, Photos, Maps, Podcasts, Weather, iWork, Google Workspace, Apple Intelligence, UI Automation, Shortcuts, Context Memory. Native Swift bridges into EventKit, HealthKit, PhotoKit, Vision, Foundation Models. macOS local-first, multi-client (Claude, Codex, opencode, Gemini CLI, Antigravity, Cursor, Zed, Cline, ChatGPT MCP Apps).",
   "version": "2.12.0",
   "author": {
     "name": "heznpc"

--- a/README.md
+++ b/README.md
@@ -156,11 +156,17 @@ These are just starting points — with 272 tools across 29 Apple apps, the comb
 | i18n                              | ❌                      | ❌                | ?                          | ❌                         | **9 languages**                                                                                   |
 | Maintenance                       | —                       | Apple             | Active                     | ❌ **Archived 2026-01-01** | **Active (v2.12+)**                                                                              |
 
+**Adjacent but narrower** (not in the table — different category): [`mb-dev/macos-ui-automation-mcp`](https://github.com/mb-dev/macos-ui-automation-mcp) is a Playwright-style macOS UI automation MCP server (6 tools, single-domain accessibility-API automation, no audit / HITL / scope-gating, last release 2025-08-02). AirMCP's `UI Automation` module covers the same surface as 10 of its 272 tools, with the External Content layer governance primitives on top.
+
 ### Why this position holds
 
 - **Tool surface is leverage, not the moat.** Apple's eventual system MCP will replace many AppleScript wrappers; AirMCP's *workflow engine + safety + memory + multi-client + Google Workspace* layer survives as the integration above the OS.
 - **Open source**: every line auditable, modifiable, forkable. Apple's closed alternative won't have this.
 - **First-mover momentum on integrated depth**: [research from Apr 2026](https://www.local-mcp.com/guides/best-mcp-server-mac) notes — _"Outside the archived apple-mcp, no implementation exceeds 5 stars. Most have single-digit commits and single contributors."_ AirMCP holds the slot with active development at v2.12+.
+- **On-device WWDC alignment** ([pre-WWDC 2026 reporting](https://www.macrumors.com/2026/05/28/apple-to-make-on-device-ai-key-focus/), 2026-05-28 — D-10 from June 8 keynote): Apple's expected WWDC focus is on-device Foundation Models v10 (Gemini-backbone, confirmed via Bloomberg). AirMCP's local-first, Apple-native runtime requires no architectural shift on that move — the existing Swift `FoundationModels` bridge + Gemini embeddings two-track is the same surface area Apple is targeting. If Apple announces a system MCP on June 8, AirMCP's External Content layer governance (HMAC chain, per-call HITL, scope gate) sits cleanly above it.
+
+<!-- WWDC-2026-keynote-response: activated within 24h of the June 8 keynote with the actual announcement scope. Slot is intentional — leaving it inert pre-keynote keeps the README factual. -->
+
 
 ---
 


### PR DESCRIPTION
Three small applications from the 2026-05-29 market-pulse pass.

1. README "Adjacent but narrower" — name the only other May-2026 Apple
   automation MCP that's worth comparing to. mb-dev/macos-ui-automation-mcp
   is a Playwright-style UI automation server (6 tools, single-domain,
   no audit/HITL/scope-gating, last release 2025-08-02). It overlaps 10
   of AirMCP's 272 tools and is the closest thing to a current competitor
   in the macOS automation slot. Surface the comparison once below the
   main table so the slot is named, not just left empty.

2. README "On-device WWDC alignment" + WWDC-2026 response slot marker.
   Pre-WWDC reporting (MacRumors 2026-05-28, D-10 from June 8) confirms
   Apple's keynote focus is on-device Foundation Models v10 (Gemini-
   backbone). AirMCP's local-first + Swift FoundationModels + Gemini
   embeddings already fits that move. Note the alignment factually
   (no architectural shift needed) without overclaiming, and leave a
   commented HTML slot for the 24-hour post-keynote update.

3. .claude-plugin/plugin.json description — front-load the high-frequency
   filter keywords. Claude Code shipped /plugins and /skills real-time
   filtering (2026-05-28 update) — the description's first 80 characters
   matter most for filter matches. Move "production governance", "audit",
   "HITL", "OAuth", "scope gate" to the lead; tool list and multi-client
   list stay further in. count-stats's "(N) tools across (M) modules"
   pattern still matches.

Critical from the market-pulse pass — operator-side plugin submission
to anthropics/claude-plugins-community via clau.de/plugin-directory-submission
— is NOT in this PR. It requires the user's GitHub account and form
submission and cannot be done by an automated PR.

Verified: 1906 tests, sync-version --check, stats:check, mcp:validate
all pass.
