### PR TITLE
feat(review): make stratified review executable — review-route.mjs + CI + /review

### DIFF
--- a/.claude/commands/review.md
+++ b/.claude/commands/review.md
@@ -1,0 +1,47 @@
+---
+description: Stratified code review routed by risk tier (RFC 0013/0014) — not a flat scan
+---
+
+Run a **risk-tier-routed** review of the current changes, per
+`docs/rfc/0013-review-process.md`. A flat scan over 272 tools dilutes attention
+and misses the silent-systemic defects (audit seal / HITL bypass / OAuth /
+rate-limit) that actually matter. Route effort to blast radius instead.
+
+## Step 1 — get the routing plan (don't skip; this is the mechanism)
+
+Run the executable router and read its output:
+
+```
+node scripts/review-route.mjs --base "${ARGUMENTS:-origin/main}"
+```
+
+It prints, for the diff: each changed file's **tier**, the **failure modes to
+hunt** per touched T0/T1 area, the **guard tests** that must stay green, and a
+**⚠ warning** for any T0 file changed without touching its guard test.
+
+(For a periodic audit of *unchanged* infra — RFC 0013 §5 — run
+`node scripts/review-route.mjs --audit` instead and review every T0 area.)
+
+## Step 2 — review at the routed depth, NOT uniformly
+
+- **T0 (critical infra)** — review at MAX depth. For each touched area, hunt the
+  *specific* failure mode the router named (e.g. audit → seal/_prev mismatch +
+  tamper-not-detected; OAuth → alg=none/HS confusion + scope bypass). A generic
+  "looks fine" is not a T0 review. Confirm the named guard tests cover the change;
+  if a T0 file changed with no guard-test change, treat closing that gap as
+  higher priority than the feature itself.
+- **T1 (system / ui / finder / shortcuts)** — the agent-drives-the-Mac surface.
+  Verify HITL coverage, `destructiveHint` annotations, scope-gate mapping, and
+  rate-limit tier (RFC 0014 §4.5).
+- **T2 (JXA-thin modules)** — light. Check `esc()`/escaping, the
+  `okUntrusted`/`toolError` result shape, and that the contract test still passes.
+  Don't spend max effort here; it fails loud, blast radius is one call.
+- **T3 (generated / vendored)** — review the **generator** (e.g.
+  `scripts/gen-swift-intents.mjs`) and the drift guard, never the generated
+  output.
+
+## Step 3 — report
+
+Lead with the **highest tier touched** and the T0/T1 findings against the hunt
+list. Note any unguarded-T0 gap explicitly. Keep T2/T3 to a line unless the
+contract tests fail.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,19 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Review route plan (RFC 0013/0014 — stratified review)
+        if: github.event_name == 'pull_request'
+        env:
+          # Pass the base ref through env (not interpolated into the run string)
+          # per the workflow-injection guidance — no shell metachar interpretation.
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+        run: |
+          git fetch origin "$BASE_REF" --depth=1 2>/dev/null || true
+          node scripts/review-route.mjs --base "origin/$BASE_REF" --check
+        # Informational: prints the tier plan + per-area failure modes to hunt +
+        # any T0 file changed without its guard test. Not a blocker (no --strict)
+        # — its job is to make review depth match blast radius on every PR.
+
       - name: Cache tsbuildinfo
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v4
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -40,8 +40,10 @@ llms-full.txt
 .env.local
 .vscode/
 
-# Claude Code local worktrees + project state
-.claude/
+# Claude Code local worktrees + project state (keep local) — but DO share the
+# repo review command, which is part of the RFC 0013 review process.
+.claude/*
+!.claude/commands/
 
 # Local design-rationale notes (not for publication)
 CLAUDE.md

--- a/docs/rfc/0013-review-process.md
+++ b/docs/rfc/0013-review-process.md
@@ -69,13 +69,14 @@ T0 is, in fact, well-covered by behaviour tests — audit (6), HITL (3), OAuth (
 network/transport (1), tool-registry (2), outputSchema (8), escaping (3), codegen
 (3). The floor is real, not aspirational.
 
-**One real gap:** the **manifest ↔ doc drift guard** (`tests/tool-count-drift.test.js`)
-is **uncommitted** and, per the 2026-06-09 `/code-review`, carries a **false
-invariant** (asserts README tool count `== manifest.toolCount`, i.e. 272 == 285 —
-unsatisfiable, since the manifest counts a superset incl. 9 `skill_*` + 3 MCP-app
-tools). Until it's fixed and committed, README↔manifest drift has only the CI
-`stats:check` / `llms:check` guards, which cover *counts* but not the
-generated-Swift sub-numbers (SnippetView / AppEnum). **Floor-fix backlog item #1.**
+**Floor-fix #1 — CLOSED.** The **manifest ↔ doc drift guard**
+(`tests/tool-count-drift.test.js`) was uncommitted and carried a false invariant
+(README tool count `== manifest.toolCount`, i.e. 272 == 285 — unsatisfiable, since
+the manifest is a superset incl. `skill_*` + MCP-app tools). It is now committed,
+the assertion rewritten to the true superset relationship, and the stale
+README sub-numbers (SnippetView 50→82, AppEnum 17→13) reconciled — so README ↔
+manifest ↔ generated-Swift drift is caught on every CI run. The T0 floor now has
+no known gap.
 
 ## 4. The automated floor is non-negotiable
 
@@ -103,13 +104,25 @@ So:
 - **Floor maintenance**: any time a §2 guard is found missing or wrong (e.g. the
   drift test in §3), fixing it outranks new feature review.
 
-## 6. How to invoke `/code-review` under this process
+## 6. How to invoke it — this is executable, not prose
 
-- Pass the **tier** and the **failure-mode catalog rows** for the touched area,
-  not just the diff. "Review at T0 depth; hunt audit-seal + HITL-bypass."
-- For a T0 deep audit, scope it to `src/shared/<area>` + the catalog, *not* a diff.
-- For T2 diffs, the ask is narrow: "escaping + result-shape + does the contract
-  test still pass" — don't spend max effort here.
+The tiers + failure-mode catalog above are encoded in **`scripts/review-route.mjs`**,
+so routing is mechanical, not a thing you remember to do:
+
+- **`npm run review:route`** (or `node scripts/review-route.mjs --base <ref>`) —
+  classifies the diff, prints each file's tier, the *specific* failure modes to
+  hunt per touched T0/T1 area, the guard tests that must stay green, and a ⚠ for
+  any T0 file changed without touching its guard test. `--json` drives tooling;
+  `--check --strict` exits non-zero on an unguarded T0 change.
+- **`npm run review:audit`** — the RFC §5 cadence: emits the full T0 deep-audit
+  plan over *unchanged* infra, independent of any diff.
+- **`/review`** (`.claude/commands/review.md`) — runs the router, then reviews at
+  the routed depth instead of scanning uniformly.
+- **CI** runs the router on every PR (informational step in `ci.yml`), so the
+  tier plan + hunt list + unguarded-T0 warnings are visible on each change.
+
+Keep `scripts/review-route.mjs`'s tier lists + catalog in sync with §1/§2 — when
+a T0 invariant is added, add its row there *and* its behaviour test (§4).
 
 ## 7. Non-goals
 

--- a/package.json
+++ b/package.json
@@ -113,6 +113,8 @@
     "llms": "node scripts/gen-llms-txt.mjs",
     "llms:check": "node scripts/gen-llms-txt.mjs --check",
     "tokens": "node scripts/measure-tool-tokens.mjs",
+    "review:route": "node scripts/review-route.mjs",
+    "review:audit": "node scripts/review-route.mjs --audit",
     "prepare": "husky"
   },
   "peerDependencies": {

--- a/scripts/review-route.mjs
+++ b/scripts/review-route.mjs
@@ -1,0 +1,290 @@
+#!/usr/bin/env node
+/**
+ * review-route.mjs — make /code-review stratified by construction (RFC 0013).
+ *
+ * A flat diff-scan over 29 modules / 272 tools dilutes attention and misses the
+ * silent-systemic defects (audit-seal / HITL-bypass / OAuth / rate-limit) that
+ * actually matter. This script is the EXECUTABLE form of RFC 0013: it takes a
+ * diff, classifies every changed file into a risk tier, and emits the exact
+ * failure modes to hunt + the contract tests that must stay green — so review
+ * effort is ROUTED to blast radius instead of spread evenly.
+ *
+ * It is not another doc. It runs.
+ *
+ * Usage:
+ *   node scripts/review-route.mjs                 # route the diff vs origin/main
+ *   node scripts/review-route.mjs --base <ref>    # route the diff vs <ref>
+ *   node scripts/review-route.mjs --audit         # full T0 deep-audit plan (RFC 0013 §5 cadence)
+ *   node scripts/review-route.mjs --json          # machine-readable (drives /review + CI)
+ *   node scripts/review-route.mjs --check         # CI: print plan; warn on T0 touched w/o its guard test
+ *   node scripts/review-route.mjs --check --strict# CI: exit 1 on a T0 change with no guard-test change
+ *
+ * The tier lists + failure-mode catalog below are the source of truth that
+ * RFC 0013 §1/§2 describe in prose. Keep them in sync — when you add a T0
+ * invariant, add its row here AND its behaviour test.
+ */
+
+import { execFileSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..");
+
+// ── Failure-mode catalog (RFC 0013 §2): area → what to hunt + guarding tests ──
+// `files` are exact repo-relative paths or path prefixes that belong to the area.
+const CATALOG = [
+  {
+    area: "audit-chain",
+    tier: 0,
+    files: ["src/shared/audit.ts"],
+    hunt: "seal/_prev mismatch, rotation re-anchor, genesis, tamper not detected",
+    tests: ["audit-tamper-detection", "audit-genesis-check", "audit-rotation-resume", "audit-recovery"],
+  },
+  {
+    area: "hitl-gate",
+    tier: 0,
+    files: ["src/shared/hitl.ts", "src/shared/hitl-guard.ts", "src/shared/share-guard.ts"],
+    hunt: "per-call bypass, batched 'next N calls' regression, deny-on-unreachable",
+    tests: ["hitl-client", "hitl-guard", "skills-hitl-queue"],
+  },
+  {
+    area: "rate-limit",
+    tier: 0,
+    files: ["src/shared/rate-limit.ts"],
+    hunt: "off-by-one, reset-window drift, counter race",
+    tests: ["rate-limit"],
+  },
+  {
+    area: "oauth",
+    tier: 0,
+    files: ["src/server/oauth-verifier.ts", "src/shared/oauth-scope.ts", "src/server/well-known-card.ts"],
+    hunt: "alg confusion (alg=none/HS), scope-gate bypass, RFC 8707 audience, RFC 9728 PRM",
+    tests: ["oauth-verifier", "oauth-scope", "well-known-card"],
+  },
+  {
+    area: "network-transport",
+    tier: 0,
+    files: ["src/server/http-transport.ts", "src/server/init.ts", "src/server/mcp-setup.ts", "src/server/shutdown.ts"],
+    hunt: "SSRF, allowlist bypass, Origin 403, bind-all-without-token, boot-order invariants",
+    tests: ["http-transport"],
+  },
+  {
+    area: "tool-registry",
+    tier: 0,
+    files: ["src/shared/tool-registry.ts", "src/shared/registry.ts", "src/shared/tool-filter.ts"],
+    hunt: "wrapper not forwarding, re-entry/recursion, scope-gate not applied",
+    tests: ["tool-registry", "tool-registry-scope-gate"],
+  },
+  {
+    area: "jxa-escaping",
+    tier: 0,
+    files: ["src/shared/esc.ts", "src/shared/jxa.ts", "src/shared/swift.ts"],
+    hunt: "injection via esc/escShell/escJxaShell, prototype-pollution in the Swift JSON reviver",
+    tests: ["esc", "jxa", "jxa-scripts-ast"],
+  },
+  {
+    area: "result-validators",
+    tier: 0,
+    files: ["src/shared/result.ts", "src/shared/validate.ts", "src/shared/mcp.ts"],
+    hunt: "declared outputSchema with no matching runtime structuredContent → SDK validation error in prod",
+    tests: ["output-schema-structured", "script-shape-contract"],
+  },
+  {
+    area: "circuit-breaker",
+    tier: 0,
+    files: ["src/shared/circuit-breaker.ts"],
+    hunt: "HALF_OPEN probe race, state-transition gaps, never-resets",
+    tests: ["circuit-breaker"],
+  },
+  {
+    area: "logger-stdout-discipline",
+    tier: 0,
+    files: ["src/shared/logger.ts", "src/shared/banner.ts"],
+    hunt: "stdout pollution on the stdio transport (must be stderr); ANSI on a pipe",
+    tests: ["logger"],
+  },
+  {
+    area: "codegen-contract",
+    tier: 0,
+    files: ["scripts/gen-swift-intents.mjs", "scripts/dump-tool-manifest.mjs"],
+    hunt: "manifest ↔ AppIntents ↔ README drift; destructive-confirmation body; eligible-set selection",
+    tests: ["codegen-destructive-dialog", "codegen-helpers", "tool-count-drift"],
+  },
+  {
+    area: "agent-controls-the-mac",
+    tier: 1,
+    files: ["src/system/", "src/ui/", "src/finder/", "src/shortcuts/"],
+    hunt: "missing HITL on a destructive action, absent destructiveHint annotation, scope-gate gap, rate-limit tier (RFC 0014 §4.5)",
+    tests: ["output-schema-wave1", "output-schema-wave2"],
+  },
+];
+
+// ── Tier classification (RFC 0013 §1) ──
+// Returns { tier, label, depth, area? } for a repo-relative path.
+function classify(file) {
+  // T3 — generated / vendored: review the generator, not the output.
+  if (
+    file.includes("/Generated/") ||
+    file.startsWith("dist/") ||
+    file === "package-lock.json" ||
+    file.startsWith("docs/llms") ||
+    file === "docs/tool-manifest.json"
+  ) {
+    return { tier: 3, label: "T3 generated/vendored", depth: "review the generator + the drift guard, never the output" };
+  }
+
+  // T0 / T1 — by catalog membership (exact file or path-prefix).
+  for (const row of CATALOG) {
+    for (const f of row.files) {
+      const isPrefix = f.endsWith("/");
+      if (isPrefix ? file.startsWith(f) : file === f) {
+        return {
+          tier: row.tier,
+          label: row.tier === 0 ? "T0 critical infra" : "T1 high-blast surface",
+          depth: row.tier === 0 ? "MAX — adversarial, per failure mode below" : "HIGH — governance + the failure mode below",
+          area: row.area,
+        };
+      }
+    }
+  }
+
+  // T2 — JXA-thin tool modules (any other src/<module>/ source).
+  if (file.startsWith("src/") && file.endsWith(".ts")) {
+    return { tier: 2, label: "T2 JXA-thin module", depth: "LIGHT — escaping + result-shape + contract test still green" };
+  }
+
+  // Everything else (docs, workflows, config) — context, not risk-routed.
+  return { tier: 9, label: "— non-code", depth: "context only" };
+}
+
+// ── Inputs ──
+const argv = process.argv.slice(2);
+const mode = argv.includes("--audit") ? "audit" : argv.includes("--check") ? "check" : "route";
+const asJson = argv.includes("--json");
+const strict = argv.includes("--strict");
+const baseIdx = argv.indexOf("--base");
+const base = baseIdx >= 0 ? argv[baseIdx + 1] : "origin/main";
+
+function changedFiles() {
+  // execFileSync (no shell) — `base` comes from argv, so never interpolate it
+  // into a shell string. The repo's own rule: don't build shell/JXA strings
+  // from outside input. A review-routing tool must follow it.
+  try {
+    const out = execFileSync("git", ["diff", "--name-only", `${base}...HEAD`], { cwd: ROOT, encoding: "utf8" });
+    return out.split("\n").map((s) => s.trim()).filter(Boolean);
+  } catch {
+    // No base ref (shallow clone / detached) — fall back to staged + unstaged.
+    const out = execFileSync("git", ["diff", "--name-only", "HEAD"], { cwd: ROOT, encoding: "utf8" });
+    return out.split("\n").map((s) => s.trim()).filter(Boolean);
+  }
+}
+
+function testTouched(testStem) {
+  // Is the guarding test in the diff? (heuristic for "did you re-verify the contract")
+  return changed.some((f) => f === `tests/${testStem}.test.js`);
+}
+
+// ── AUDIT mode: the full T0 deep-audit plan, regardless of diff (RFC 0013 §5) ──
+if (mode === "audit") {
+  const t0 = CATALOG.filter((r) => r.tier === 0);
+  if (asJson) {
+    console.log(JSON.stringify({ mode: "audit", areas: t0 }, null, 2));
+    process.exit(0);
+  }
+  console.log("RFC 0013 §5 — T0 deep audit (re-read these top to bottom against the catalog):\n");
+  for (const r of t0) {
+    const present = r.files.filter((f) => existsSync(join(ROOT, f)));
+    console.log(`■ ${r.area}`);
+    console.log(`  files: ${present.join(", ")}`);
+    console.log(`  hunt:  ${r.hunt}`);
+    console.log(`  guard: ${r.tests.map((t) => `tests/${t}.test.js`).join(", ")}\n`);
+  }
+  process.exit(0);
+}
+
+// ── ROUTE / CHECK mode: classify the diff ──
+const changed = changedFiles();
+const routed = changed.map((file) => ({ file, ...classify(file) }));
+const byTier = (t) => routed.filter((r) => r.tier === t);
+const touchedAreas = [...new Set(routed.map((r) => r.area).filter(Boolean))];
+const catalogFor = (area) => CATALOG.find((r) => r.area === area);
+
+// Teeth: a T0 area changed but its guard test did not (RFC 0013 §4).
+const unguarded = touchedAreas
+  .map(catalogFor)
+  .filter((r) => r && r.tier === 0)
+  .filter((r) => !r.tests.some(testTouched));
+
+if (asJson) {
+  console.log(
+    JSON.stringify(
+      {
+        base,
+        changed: routed,
+        highestTier: Math.min(...routed.map((r) => r.tier), 9),
+        touchedAreas: touchedAreas.map((a) => catalogFor(a)),
+        unguardedT0: unguarded.map((r) => r.area),
+      },
+      null,
+      2,
+    ),
+  );
+  process.exit(strict && unguarded.length ? 1 : 0);
+}
+
+if (!changed.length) {
+  console.log(`No changes vs ${base}. (Use --audit for the periodic T0 deep audit.)`);
+  process.exit(0);
+}
+
+console.log(`Review plan — ${changed.length} file(s) vs ${base}\n`);
+
+const TIER_ORDER = [0, 1, 2, 3, 9];
+const TIER_NAME = {
+  0: "T0 — CRITICAL INFRA (silent, systemic — review at MAX depth)",
+  1: "T1 — HIGH-BLAST SURFACE (agent drives the Mac — review at HIGH depth)",
+  2: "T2 — JXA-THIN MODULES (fails loud — light review, lean on contract tests)",
+  3: "T3 — GENERATED/VENDORED (review the generator, not the output)",
+  9: "— NON-CODE (context only)",
+};
+
+for (const t of TIER_ORDER) {
+  const rows = byTier(t);
+  if (!rows.length) continue;
+  console.log(`${TIER_NAME[t]}`);
+  for (const r of rows) console.log(`  • ${r.file}${r.area ? `  [${r.area}]` : ""}`);
+  console.log("");
+}
+
+// For each touched T0/T1 area, print the exact failure modes + guard tests.
+const hot = touchedAreas.map(catalogFor).filter(Boolean).sort((a, b) => a.tier - b.tier);
+if (hot.length) {
+  console.log("Hunt these (do not run a generic scan):");
+  for (const r of hot) {
+    console.log(`  ■ T${r.tier} ${r.area}`);
+    console.log(`    hunt:  ${r.hunt}`);
+    console.log(`    guard: ${r.tests.map((t) => `tests/${t}.test.js`).join(", ")} (must be green)`);
+  }
+  console.log("");
+}
+
+if (unguarded.length) {
+  console.log("⚠ T0 changed WITHOUT touching its guard test — confirm the invariant is still covered:");
+  for (const r of unguarded) {
+    console.log(`  • ${r.area} → expected one of ${r.tests.map((t) => `tests/${t}.test.js`).join(", ")}`);
+  }
+  console.log("");
+  if (mode === "check" && strict) {
+    console.error("review-route: --strict and a T0 area changed with no guard-test change. Failing.");
+    process.exit(1);
+  }
+}
+
+const highest = Math.min(...routed.map((r) => r.tier), 9);
+if (highest <= 1) {
+  console.log(`→ Highest tier touched: T${highest}. Run /code-review at T${highest} depth with the hunt list above.`);
+} else {
+  console.log(`→ Highest tier touched: T${highest}. Light review sufficient; ensure contract tests pass.`);
+}
+process.exit(0);


### PR DESCRIPTION
RFC 0013 described the stratified review process; this makes it RUN, so the
next /code-review isn't a flat scan that misses the silent-systemic class.
The process now has teeth, not just prose:

- scripts/review-route.mjs — the executable router. Encodes the RFC 0013 §1
  tiers + §2 failure-mode catalog as data, then for a diff:
    • classifies every changed file into T0/T1/T2/T3,
    • prints the SPECIFIC failure modes to hunt per touched T0/T1 area + the
      guard tests that must stay green (not "look for bugs"),
    • ⚠ warns when a T0 file changed without touching its guard test,
    • --audit emits the full T0 deep-audit plan over UNCHANGED infra (§5 cadence),
    • --json drives tooling, --check --strict is a hard CI gate.
  Verified on a real T0 diff: routes audit/transport/circuit-breaker/logger to
  T0, system to T1, tool modules to T2, Generated/lockfile to T3.
- .github/workflows/ci.yml — runs the router on every PR (informational), so
  the tier plan + hunt list + unguarded-T0 warnings are visible on each change.
  Base ref passed via env per the workflow-injection guidance.
- .claude/commands/review.md — a repo `/review` command that runs the router
  then reviews at the routed depth. Un-ignored from .claude/ (settings stay local).
- package.json — review:route / review:audit scripts.
- RFC 0013: §3 floor gap marked CLOSED (the drift guard was fixed + committed),
  §6 rewritten to point at the executable instead of prose.

Note on the build of this very change: the security-guidance plugin flagged two
real issues mid-write — an execSync shell-string (→ execFileSync + arg array)
and a workflow run-string interpolation (→ env var). Both fixed. A review-process
tool that shipped with an injection smell would be self-refuting.
