### PR TITLE
ci(verify): pin config path + strip AIRMCP_* so the gate measures the starter default

### DIFF
--- a/scripts/verify-published-package.mjs
+++ b/scripts/verify-published-package.mjs
@@ -64,10 +64,28 @@ function sh(cmd, args, opts = {}) {
 
 function bootAndList(entry, cwd) {
   return new Promise((done) => {
+    // Measure the DEFAULT user surface deterministically, regardless of the
+    // host's ~/.config/airmcp/config.json or any exported AIRMCP_* — the same
+    // pollution-free discipline as the clean-room recipe (env -i + fresh HOME),
+    // applied surgically: strip every AIRMCP_* from the inherited env, then pin
+    // the config path to a guaranteed-absent file so loadConfig falls through to
+    // the STARTER preset (config.ts loadFileConfig → fileExists:false, parseConfig
+    // applies the preset). Non-AIRMCP env (PATH/HOME/npm_config_*) is preserved so
+    // npx and the npm cache keep working on any runner; AIRMCP_TEST_MODE=1 is
+    // re-set to stay symmetric with smoke-mcp / mcp-validate. Without this, a dev
+    // box whose config.json disables modules would make this gate measure a
+    // polluted surface — and could false-fail the >=100 floor — instead of the
+    // ~111-tool starter default a fresh `npx -y airmcp` user actually gets.
+    const env = { ...process.env };
+    for (const k of Object.keys(env)) {
+      if (k.startsWith("AIRMCP_")) delete env[k];
+    }
+    env.AIRMCP_TEST_MODE = "1";
+    env.AIRMCP_CONFIG_PATH = join(cwd, "airmcp-no-config-here.json"); // absent → STARTER preset
     const proc = spawn(
       "npx",
       ["-y", INSPECTOR_PKG, "--cli", "node", entry, "--method", "tools/list"],
-      { cwd, env: { ...process.env, AIRMCP_TEST_MODE: "1" }, stdio: ["ignore", "pipe", "pipe"] },
+      { cwd, env, stdio: ["ignore", "pipe", "pipe"] },
     );
     let stdout = "";
     let stderr = "";


### PR DESCRIPTION
verify:package booted the installed tarball with the host's full env
(...process.env + AIRMCP_TEST_MODE=1), so it inherited ~/.config/airmcp/
config.json and any exported AIRMCP_*. On a dev box whose config disables
modules, the gate measured a polluted surface — and could false-fail its
>=100 floor — instead of the starter default a fresh `npx -y airmcp` user
gets.

Apply the same pollution-free discipline as the clean-room recipe, but
surgically: strip every AIRMCP_* from the inherited env and pin
AIRMCP_CONFIG_PATH to a guaranteed-absent file so loadConfig falls through
to the STARTER preset (loadFileConfig → fileExists:false). Non-AIRMCP env
(PATH/HOME/npm_config_*) is kept so npx and the npm cache keep working on
any runner; AIRMCP_TEST_MODE=1 is re-set to stay symmetric with smoke-mcp /
mcp-validate. HOME is left intact — config determinism comes from the pinned
path, not HOME isolation — so the inspector download stays cache-warm.

Gate behavior unchanged (>=100 floor + required core tools); only the
measurement is now host-independent. Verified locally: this machine's
module-disabling config previously skewed it; the gate now reports 111
tools deterministically, matching the ~111 starter figure in README.
