### PR TITLE
ci: route all 3 boot gates through shared cleanBootEnv (STARTER default)

### DIFF
--- a/scripts/lib/clean-boot-env.mjs
+++ b/scripts/lib/clean-boot-env.mjs
@@ -1,0 +1,50 @@
+// Shared child-process env for the three "boot the server and read tools/list"
+// gates — smoke-mcp.mjs, mcp-validate.mjs, verify-published-package.mjs — so
+// they all measure the DEFAULT STARTER tool surface deterministically,
+// independent of the host's ~/.config/airmcp/config.json or any exported
+// AIRMCP_*.
+//
+// Why this is shared, not special-cased in one gate: in CI (no config.json) the
+// server already applies the STARTER preset, so all three measure the same
+// ~111-tool surface there. On a dev box, an existing config.json (which may
+// disable modules), an exported AIRMCP_FULL, or a per-module override would make
+// the SAME gate measure a different surface — and could false-fail a floor
+// (smoke-mcp's MIN_TOOLS >= 100) or silently validate the wrong set. Routing all
+// three through one helper gives local <-> CI parity instead of three gates that
+// drift on whatever the host happens to have configured.
+//
+// Surgical, not a full `env -i`: strip every AIRMCP_* from the inherited env
+// (drops AIRMCP_FULL, any per-module override, and an inherited
+// AIRMCP_CONFIG_PATH), then re-set only the two the gates legitimately need:
+//   - AIRMCP_TEST_MODE=1 — gates test-only shutdown/error paths; kept symmetric
+//     across all three gates.
+//   - AIRMCP_CONFIG_PATH — pointed at a guaranteed-absent file so loadConfig
+//     falls through to the STARTER preset (config.ts loadFileConfig returns
+//     fileExists:false on ENOENT, and parseConfig then applies STARTER).
+// Non-AIRMCP env (PATH / HOME / npm_config_*) is preserved so node, npx, and the
+// npm cache keep working on any runner.
+
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+// Parent directory deliberately does not exist, so readFileSync throws ENOENT
+// (not EACCES or a parse error) and the server treats it as "no config file".
+// Nothing ever writes here — it is a read-only sentinel path.
+const ABSENT_CONFIG = join(tmpdir(), "airmcp-nonexistent-config-dir", "config.json");
+
+/**
+ * Build a child-process env that boots AirMCP at its DEFAULT (STARTER) surface,
+ * regardless of host config.json or exported AIRMCP_*.
+ *
+ * @param {NodeJS.ProcessEnv} [base=process.env] - env to derive from.
+ * @returns {NodeJS.ProcessEnv}
+ */
+export function cleanBootEnv(base = process.env) {
+  const env = { ...base };
+  for (const key of Object.keys(env)) {
+    if (key.startsWith("AIRMCP_")) delete env[key];
+  }
+  env.AIRMCP_TEST_MODE = "1";
+  env.AIRMCP_CONFIG_PATH = ABSENT_CONFIG;
+  return env;
+}

--- a/scripts/mcp-validate.mjs
+++ b/scripts/mcp-validate.mjs
@@ -17,10 +17,11 @@
  *    both streams, exits non-zero on (a) child exit != 0, (b) any `"error"`
  *    or `"isError":true` token in the response, (c) zero-tool response.
  *
- * 3. Sets AIRMCP_TEST_MODE=1 to match scripts/smoke-mcp.mjs. The two CI steps
- *    that boot dist/index.js used to disagree on this env; aligning them
- *    keeps the contract symmetric so future TEST_MODE-gated startup paths
- *    don't drift between the two gates.
+ * 3. Boots via cleanBootEnv (scripts/lib/clean-boot-env.mjs) — the shared env
+ *    for all three boot gates (smoke-mcp / verify-published / here). It strips
+ *    host AIRMCP_*, pins a STARTER config path, and sets AIRMCP_TEST_MODE=1, so
+ *    the three gates measure the same default surface instead of drifting on
+ *    whatever the host has configured.
  *
  * 4. Bounded by an internal timeout (INSPECTOR_TIMEOUT_MS). Inspector usually
  *    exits cleanly after `--method tools/list`, but a teardown bug in the
@@ -31,6 +32,7 @@
 import { spawn } from "node:child_process";
 import { resolve, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
+import { cleanBootEnv } from "./lib/clean-boot-env.mjs";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = resolve(__dirname, "..");
@@ -48,7 +50,7 @@ function run() {
       ["-y", INSPECTOR_PKG, "--cli", "node", resolve(REPO_ROOT, "dist/index.js"), "--method", "tools/list"],
       {
         cwd: REPO_ROOT,
-        env: { ...process.env, AIRMCP_TEST_MODE: "1" },
+        env: cleanBootEnv(),
         stdio: ["ignore", "pipe", "pipe"],
       },
     );

--- a/scripts/smoke-mcp.mjs
+++ b/scripts/smoke-mcp.mjs
@@ -10,13 +10,13 @@
 // tool handler that needs TCC permissions; the handshake + tools/list
 // round-trip is the contract it guards.
 //
-// The server only registers modules whose runtime gates pass (macOS version,
-// Swift bridge availability, HealthKit, OAuth credentials, etc.), so the
-// registered count is smaller than the static `count-stats` total. On a
-// vanilla CI runner without the Swift bridge, ~111 tools register; a
-// healthy macOS with the bridge built + default config lands closer to 200.
-// SMOKE_MIN_TOOLS defaults to 100 — enough to catch a broken-boot regression
-// without flaking on partial-environment runners.
+// Boots at the DEFAULT (STARTER) surface via cleanBootEnv (see
+// scripts/lib/clean-boot-env.mjs): the host's config.json and AIRMCP_* are
+// stripped, so the registered count is the deterministic ~111-tool starter set
+// on any runner (local or CI), not whatever the host has enabled — the smaller
+// surface vs the static `count-stats` total is by design. SMOKE_MIN_TOOLS
+// defaults to 100 — headroom under the ~111 starter floor to catch a
+// broken-boot regression (top-level throw, dead registration path).
 //
 // Env knobs:
 //   SMOKE_MIN_TOOLS  — minimum tools/list length to pass (default: 100)
@@ -24,13 +24,14 @@
 
 import { spawn } from "node:child_process";
 import { createInterface } from "node:readline";
+import { cleanBootEnv } from "./lib/clean-boot-env.mjs";
 
 const MIN_TOOLS = Number(process.env.SMOKE_MIN_TOOLS ?? 100);
 const TIMEOUT_MS = Number(process.env.SMOKE_TIMEOUT_MS ?? 20_000);
 
 const server = spawn("node", ["dist/index.js"], {
   stdio: ["pipe", "pipe", "inherit"],
-  env: { ...process.env, AIRMCP_TEST_MODE: "1" },
+  env: cleanBootEnv(),
 });
 
 const rl = createInterface({ input: server.stdout });

--- a/scripts/verify-published-package.mjs
+++ b/scripts/verify-published-package.mjs
@@ -32,6 +32,7 @@ import { mkdtempSync, rmSync, existsSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { resolve, dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
+import { cleanBootEnv } from "./lib/clean-boot-env.mjs";
 
 const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 
@@ -64,24 +65,11 @@ function sh(cmd, args, opts = {}) {
 
 function bootAndList(entry, cwd) {
   return new Promise((done) => {
-    // Measure the DEFAULT user surface deterministically, regardless of the
-    // host's ~/.config/airmcp/config.json or any exported AIRMCP_* — the same
-    // pollution-free discipline as the clean-room recipe (env -i + fresh HOME),
-    // applied surgically: strip every AIRMCP_* from the inherited env, then pin
-    // the config path to a guaranteed-absent file so loadConfig falls through to
-    // the STARTER preset (config.ts loadFileConfig → fileExists:false, parseConfig
-    // applies the preset). Non-AIRMCP env (PATH/HOME/npm_config_*) is preserved so
-    // npx and the npm cache keep working on any runner; AIRMCP_TEST_MODE=1 is
-    // re-set to stay symmetric with smoke-mcp / mcp-validate. Without this, a dev
-    // box whose config.json disables modules would make this gate measure a
-    // polluted surface — and could false-fail the >=100 floor — instead of the
-    // ~111-tool starter default a fresh `npx -y airmcp` user actually gets.
-    const env = { ...process.env };
-    for (const k of Object.keys(env)) {
-      if (k.startsWith("AIRMCP_")) delete env[k];
-    }
-    env.AIRMCP_TEST_MODE = "1";
-    env.AIRMCP_CONFIG_PATH = join(cwd, "airmcp-no-config-here.json"); // absent → STARTER preset
+    // Boot the installed tarball at its DEFAULT (STARTER) surface, independent
+    // of host config / AIRMCP_* — see scripts/lib/clean-boot-env.mjs. This gate
+    // tests the *default user experience*, so the count must be the ~111-tool
+    // surface a fresh `npx -y airmcp` user gets, not whatever the host enables.
+    const env = cleanBootEnv();
     const proc = spawn(
       "npx",
       ["-y", INSPECTOR_PKG, "--cli", "node", entry, "--method", "tools/list"],


### PR DESCRIPTION
Max-effort code review of the previous PR flagged that the env-pollution fix
in verify-published-package.mjs was a special case: the two sibling boot-gates
that also boot the server and read tools/list — smoke-mcp.mjs (MIN_TOOLS>=100
floor) and mcp-validate.mjs — still inherited the host's full env, so on a dev
box whose ~/.config/airmcp/config.json disables modules they measured a
polluted surface and smoke could false-fail its floor.

Extract the discipline into scripts/lib/clean-boot-env.mjs (cleanBootEnv):
strip every inherited AIRMCP_* (drops AIRMCP_FULL / per-module overrides / an
inherited AIRMCP_CONFIG_PATH), then re-set AIRMCP_TEST_MODE=1 and pin
AIRMCP_CONFIG_PATH to a guaranteed-absent path so the server applies the
STARTER preset. Route all three gates through it.

CI behavior is unchanged: CI has no config.json, so all three already booted
STARTER (~111) there. The win is local<->CI parity — on this repo's own dev
machine (config disables 18 modules) `npm run smoke` now reports a
deterministic "7 modules / 111 tools" instead of a polluted count that could
trip the floor. Per-module registration stays covered by the unit suite; the
broad dev-box boot was never a CI guarantee. Stale comments in all three gates
updated to describe the shared deterministic behavior.

Verified locally: smoke / mcp:validate / verify:package all boot STARTER and
serve 111 tools; 1923 unit tests pass.
