### PR TITLE
ci: add MCP Registry publish workflow (OIDC) to sync io.github.heznpc/airmcp

### DIFF
--- a/.github/workflows/publish-registry.yml
+++ b/.github/workflows/publish-registry.yml
@@ -1,0 +1,52 @@
+name: Publish to MCP Registry
+
+# Syncs the server METADATA (server.json) to the official MCP Registry
+# (registry.modelcontextprotocol.io). The npm package `airmcp` itself is
+# published by the existing release pipeline; this workflow only publishes the
+# manifest, which the registry verifies against the already-published npm
+# package (package.json carries the matching `mcpName: io.github.heznpc/airmcp`).
+#
+# Why this exists: the official registry had drifted — the only entry was the
+# pre-rename `io.github.heznpc/iconnect@0.1.1`, with no automation to update it,
+# so `io.github.heznpc/airmcp` was never published there. Downstream aggregators
+# (Glama, scorecards, directories) scrape the registry, so the stale name
+# propagated. This keeps the airmcp entry in sync from now on.
+#
+# Auth: GitHub OIDC proves this repo owns the io.github.heznpc/* namespace — no
+# secret required (`id-token: write` is the only permission needed).
+#
+# Triggers:
+#   - workflow_dispatch: run once now (Actions tab → Run workflow) to publish the
+#     CURRENT server.json version and unstick the iconnect@0.1.1 drift.
+#   - release published: keep the registry in sync on every future release.
+#     server.json's version is kept current by scripts/sync-version.mjs, so the
+#     released commit always carries the right version. If a release fires before
+#     the matching npm version is live, mcp-publisher fails loudly and the run is
+#     simply re-triggerable via workflow_dispatch — it never drifts silently.
+
+on:
+  workflow_dispatch:
+  release:
+    types: [published]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write # OIDC auth to the MCP Registry — no secret needed
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+
+      - name: Install mcp-publisher (pinned)
+        env:
+          MCP_PUBLISHER_VERSION: v1.7.9
+        run: |
+          curl -fsSL "https://github.com/modelcontextprotocol/registry/releases/download/${MCP_PUBLISHER_VERSION}/mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" | tar xz mcp-publisher
+
+      - name: Authenticate to MCP Registry (GitHub OIDC)
+        run: ./mcp-publisher login github-oidc
+
+      - name: Publish server.json
+        run: ./mcp-publisher publish


### PR DESCRIPTION
The official MCP Registry (registry.modelcontextprotocol.io) had drifted: the
only entry was the pre-rename `io.github.heznpc/iconnect@0.1.1`, and
`io.github.heznpc/airmcp` was never published there because nothing automated
it — someone hand-published iconnect once in the iConnect era and there was no
follow-up. Downstream aggregators (Glama, mcp-scorecard, directories) scrape the
registry, so the dead `iconnect` name kept propagating.

server.json and package.json are already correct and matching
(`io.github.heznpc/airmcp@2.12.0`, with the required `mcpName`); the only missing
piece was a publisher. Add `.github/workflows/publish-registry.yml`:

- Auth via GitHub OIDC (`id-token: write`) — proves this repo owns the
  io.github.heznpc/* namespace, no secret required.
- Pinned to repo convention: actions/checkout by SHA, mcp-publisher v1.7.9
  (not `latest`).
- Only publishes the manifest; the npm package is still published by the
  existing release pipeline. The registry verifies the manifest against the
  already-published npm package.
- Triggers: workflow_dispatch (run once now to unstick the drift and publish the
  current version) + release published (keep it in sync going forward;
  scripts/sync-version.mjs already keeps server.json's version current). Does NOT
  fire on PR merge, so merging this only adds the capability — the first publish
  is an explicit manual dispatch.

Follow-up (operator-side, needs maintainer auth, not in this PR): deprecate the
old npm zombies (`@heznpc/imcp`, `iconnect-mcp`) and the registry's stale
`io.github.heznpc/iconnect` entry; consolidate the Glama listing off the
`iconnect` slug.
