### PR TITLE
fix(registry): server.json description <=100 chars (registry validation)

### DIFF
--- a/server.json
+++ b/server.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.heznpc/airmcp",
-  "description": "MCP server for the entire Apple ecosystem — 272 tools across 29 modules with YAML skills, context memory, queryable audit log, and declarative HTTP network policy. macOS only.",
+  "description": "Apple-native MCP server - 272 tools across 29 modules. HITL, audit log, rate limits. macOS only.",
   "version": "2.12.0",
   "websiteUrl": "https://github.com/heznpc/AirMCP",
   "repository": {


### PR DESCRIPTION
The Publish to MCP Registry workflow (#290) ran on dispatch and got past
checkout + mcp-publisher install + GitHub OIDC auth, then failed at publish
with a 422 from registry.modelcontextprotocol.io:

  validation failed — body.description "expected length <= 100"

server.json's description was ~175 chars. Shortened to 96 chars, keeping the
exact "272 tools across 29 modules" substring that scripts/count-stats.mjs
syncs (stats:check still reports server.json ok). OIDC namespace auth already
works, so the next dispatch on this commit should publish io.github.heznpc/airmcp.
