### PR TITLE
fix(registry): drop invalid http package from server.json (schema: stdio only)

### DIFF
--- a/server.json
+++ b/server.json
@@ -16,17 +16,6 @@
       "transport": {
         "type": "stdio"
       }
-    },
-    {
-      "registryType": "npm",
-      "identifier": "airmcp",
-      "version": "2.12.0",
-      "transport": {
-        "type": "http",
-        "args": [
-          "--http"
-        ]
-      }
     }
   ]
 }


### PR DESCRIPTION
Second publish attempt got past the description fix and failed local schema
validation with 6 issues, all on packages[1].transport. The MCP Registry
schema (2025-12-11) allows packages[].transport.type of only stdio /
streamable-http / sse — "http" is not a value, and streamable-http/sse require
a `url`. The second package entry was `{type:"http", args:["--http"]}` with no
url, which is invalid.

AirMCP's --http is a local runtime flag, not a hosted remote with a public URL,
so it doesn't belong as a registry package (nor as a `remotes` entry). The
registry advertises the npm stdio package; --http stays documented in the README.
Dropped packages[1], leaving the single valid npm/stdio package. JSON valid,
stats:check ok (server.json), 1923 tests pass.
