### PR TITLE
fix(tools): whole-sentence compact descriptions + front-loaded behavior disclosure

### DIFF
--- a/docs/tool-manifest.json
+++ b/docs/tool-manifest.json
@@ -769,7 +769,7 @@
     {
       "name": "capture_screenshot",
       "title": "Capture Screenshot",
-      "description": "Take a screenshot and save to the specified path. Supports full screen, window, or selection capture.",
+      "description": "Capture the screen to an image file at the given path — writes a file; needs macOS Screen Recording permission. Supports full screen, window, or selection capture.",
       "inputSchema": {
         "$schema": "http://json-schema.org/draft-07/schema#",
         "type": "object",
@@ -1195,7 +1195,7 @@
     {
       "name": "create_folder",
       "title": "Create Folder",
-      "description": "Create a new folder. Optionally specify which account to create it in.",
+      "description": "Create a new folder in Apple Notes — a non-destructive write. Optionally specify which account to create it in.",
       "inputSchema": {
         "$schema": "http://json-schema.org/draft-07/schema#",
         "type": "object",
@@ -1565,7 +1565,7 @@
     {
       "name": "create_shortcut",
       "title": "Create Shortcut",
-      "description": "Create a new Siri Shortcut by name. Uses UI automation to open the Shortcuts app and create a new empty shortcut. The shortcut must be further configured in the Shortcuts app.",
+      "description": "Create a new empty Siri Shortcut by name — drives the Shortcuts app via UI automation (needs Accessibility permission; the app opens and takes focus). The shortcut must be further configured in the Shortcuts app.",
       "inputSchema": {
         "$schema": "http://json-schema.org/draft-07/schema#",
         "type": "object",
@@ -2102,7 +2102,7 @@
     {
       "name": "find_related",
       "title": "Find Related Items",
-      "description": "Given a note, event, reminder, or email ID, find semantically related items across all indexed Apple apps. Discovers cross-app connections (e.g., a calendar event related to notes and reminders about the same topic).",
+      "description": "Find items semantically related to a note, event, reminder, or email ID across indexed Apple apps — read-only; requires semantic_index to be built first. Discovers cross-app connections (e.g., a calendar event related to notes and reminders about the same topic).",
       "inputSchema": {
         "$schema": "http://json-schema.org/draft-07/schema#",
         "type": "object",
@@ -2909,7 +2909,7 @@
     {
       "name": "get_hourly_forecast",
       "title": "Get Hourly Forecast",
-      "description": "Get hourly weather forecast for a location.",
+      "description": "Get the hour-by-hour weather forecast (temperature, precipitation, wind) for a latitude/longitude via the Open-Meteo API — read-only, no API key needed.",
       "inputSchema": {
         "$schema": "http://json-schema.org/draft-07/schema#",
         "type": "object",
@@ -11495,7 +11495,7 @@
     {
       "name": "semantic_index",
       "title": "Build Semantic Index",
-      "description": "Index data from enabled Apple apps (Notes, Calendar, Reminders, Mail, Photos, Finder) into the local vector store for semantic search. Run this once, then use semantic_search. Replaces any existing index. Requires Swift bridge (npm run swift-build).",
+      "description": "Build the local vector index over enabled Apple apps for semantic search — replaces any existing index; embeddings need GEMINI_API_KEY or the Swift bridge. Covers Notes, Calendar, Reminders, Mail, Photos, and Finder. Run once, then use semantic_search.",
       "inputSchema": {
         "$schema": "http://json-schema.org/draft-07/schema#",
         "type": "object",
@@ -12156,7 +12156,7 @@
     {
       "name": "skill_clipboard-url-to-reading",
       "title": "Clipboard URL → Reading List",
-      "description": "[Skill] Listens for clipboard changes and, when a URL is on the pasteboard, pushes it into Safari's Reading List. Combines the `pasteboard_changed` event trigger with `on_error: continue` so non-URL clipboard content doesn't spam the user with errors — Safari's validator rejects the non-URL and the skill quietly moves on.",
+      "description": "[Skill] Watch the clipboard and add any copied URL to Safari's Reading List — writes to Reading List; non-URL clipboard content is ignored. Combines the `pasteboard_changed` event trigger with `on_error: continue` so Safari's validator rejects non-URLs and the skill quietly moves on.",
       "inputSchema": {
         "$schema": "http://json-schema.org/draft-07/schema#",
         "type": "object",
@@ -12175,7 +12175,7 @@
     {
       "name": "skill_daily-journal",
       "title": "Daily Journal → Memory",
-      "description": "[Skill] Captures today's events + open reminders, summarises them on-device, and persists the summary as a context-memory `episode` tagged `journal`. Demonstrates inputs + parallel + retry + the newly-exposed `memory_put` tool working together so ai_agent can later recall \"what did I do last Tuesday?\" via `memory_query`. DESTRUCTIVE: writes a memory entry (non-destructive to Apple apps).",
+      "description": "[Skill] Summarise today's events and open reminders on-device and save the result as a context-memory `episode` tagged `journal` — writes one memory entry. Nothing is written to Apple apps. Demonstrates inputs + parallel + retry + `memory_put` so ai_agent can later recall \"what did I do last Tuesday?\" via `memory_query`.",
       "inputSchema": {
         "$schema": "http://json-schema.org/draft-07/schema#",
         "type": "object",
@@ -12219,7 +12219,7 @@
     {
       "name": "skill_focus-block-planner",
       "title": "Focus Block Planner",
-      "description": "[Skill] Walks today's open reminders and drops a calendar time-block for each one. Uses `loop` with `on_error: continue` so a single failed event creation (e.g. conflicting calendar, missing permission) doesn't abort the rest of the plan — the skill result reports which reminders got blocked and which didn't. DESTRUCTIVE: creates calendar events; each insertion is gated by HITL approval.",
+      "description": "[Skill] Create a calendar time-block event for each of today's open reminders — writes calendar events (each creation HITL-gated); reminders are only read. Uses `loop` with `on_error: continue` so a single failed event creation (conflicting calendar, missing permission) doesn't abort the rest of the plan — the skill result reports which reminders got blocked and which didn't.",
       "inputSchema": {
         "$schema": "http://json-schema.org/draft-07/schema#",
         "type": "object",
@@ -12238,7 +12238,7 @@
     {
       "name": "skill_focus-guardian",
       "title": "Focus Mode Guardian",
-      "description": "[Skill] Auto-snapshots today's events and open reminders whenever the system focus mode changes (entering/leaving Do Not Disturb, Work, Personal, etc.) so the AI has fresh context right after you change mode. Showcases the `focus_mode_changed` event trigger plus parallel data gathering.",
+      "description": "[Skill] Snapshot today's events and open reminders whenever macOS Focus mode changes (Do Not Disturb, Personal, etc.) — read-only, nothing is written. Gives the AI fresh context right after a mode switch; showcases the `focus_mode_changed` event trigger plus parallel data gathering.",
       "inputSchema": {
         "$schema": "http://json-schema.org/draft-07/schema#",
         "type": "object",
@@ -12276,7 +12276,7 @@
     {
       "name": "skill_project-digest",
       "title": "Project Digest",
-      "description": "[Skill] Semantic-search the user's indexed Apple data for a topic, then loop over each match to pull semantically-related items — effectively a cross-app \"everything about this project\" view. Demonstrates the Skills DSL's loop construct and conditional execution.",
+      "description": "[Skill] Semantic-search indexed Apple data for a topic and expand each hit with related items — a read-only cross-app digest; needs semantic_index first. Demonstrates the Skills DSL's loop construct and conditional execution.",
       "inputSchema": {
         "$schema": "http://json-schema.org/draft-07/schema#",
         "type": "object",
@@ -12295,7 +12295,7 @@
     {
       "name": "skill_sender-to-tasks",
       "title": "Sender → Tasks",
-      "description": "[Skill] Scans mail for a keyword and turns each hit into a reminder so nothing in the inbox goes unresolved. Accepts runtime inputs so the same skill handles newsletter triage, a specific sender, or any ad-hoc query without editing YAML. Loop + `on_error: continue` means the rest of the batch still gets queued even if one reminder-create fails (HITL denial, Reminders permission, etc.). DESTRUCTIVE: creates reminders; each insertion is gated by HITL approval.",
+      "description": "[Skill] Scan Mail for a keyword or sender and create one reminder per matching message — writes reminders (each creation HITL-gated); mail is only read. Accepts runtime inputs so the same skill handles newsletter triage, a specific sender, or any ad-hoc query without editing YAML. Loop + `on_error: continue` means the rest of the batch still gets queued even if one reminder-create fails (HITL denial, Reminders permission, etc.).",
       "inputSchema": {
         "$schema": "http://json-schema.org/draft-07/schema#",
         "type": "object",
@@ -12480,7 +12480,7 @@
     {
       "name": "summarize_context",
       "title": "Summarize Context",
-      "description": "Collect context from all enabled Apple apps and ask the client's LLM to produce a concise briefing. Uses MCP Sampling — works with any LLM the client is using. No API keys required.",
+      "description": "Gather recent context from enabled Apple apps and produce a concise briefing via MCP sampling — read-only; the connected client must support sampling. Works with whatever LLM the client is using; no API keys required.",
       "inputSchema": {
         "$schema": "http://json-schema.org/draft-07/schema#",
         "type": "object",
@@ -13640,7 +13640,7 @@
     {
       "name": "update_reminder",
       "title": "Update Reminder",
-      "description": "Update reminder properties. Only specified fields are changed. Set dueDate to null to clear it. Recurrence rules cannot be modified via automation.",
+      "description": "Update fields of an existing reminder in Apple Reminders — a write to user data; only the fields you pass change. Set dueDate to null to clear it. Recurrence rules cannot be modified via automation.",
       "inputSchema": {
         "$schema": "http://json-schema.org/draft-07/schema#",
         "type": "object",

--- a/scripts/measure-tool-tokens.mjs
+++ b/scripts/measure-tool-tokens.mjs
@@ -44,12 +44,21 @@ if (!existsSync(MANIFEST)) {
 // Mirror src/shared/tool-filter.ts:compactDescription — keep them in
 // lockstep so the script's "after" matches what the LLM actually sees.
 function compactDescription(description) {
-  const match = description.match(/^(.*?[.!?])\s/);
-  const firstSentence = match?.[1] ?? description;
-  if (firstSentence.length > 80) {
-    return firstSentence.slice(0, 77) + "...";
+  const COMPACT_BUDGET = 160;
+  const text = description.trim();
+  if (text.length <= COMPACT_BUDGET) {
+    return /[.!?]$/.test(text) ? text : text + ".";
   }
-  return /[.!?]$/.test(firstSentence) ? firstSentence : firstSentence + ".";
+  const boundary = /[.!?](?=\s)/g;
+  let cutEnd = 0;
+  for (let m = boundary.exec(text); m !== null; m = boundary.exec(text)) {
+    if (m.index + 1 > COMPACT_BUDGET) break;
+    cutEnd = m.index + 1;
+  }
+  if (cutEnd > 0) return text.slice(0, cutEnd);
+  const head = text.slice(0, COMPACT_BUDGET - 1);
+  const lastSpace = head.lastIndexOf(" ");
+  return (lastSpace > 40 ? head.slice(0, lastSpace) : head).trimEnd() + "…";
 }
 
 function estTokens(s) {

--- a/src/cross/tools.ts
+++ b/src/cross/tools.ts
@@ -21,8 +21,8 @@ export function registerCrossTools(mcpServer: McpServer, config: AirMcpConfig): 
     {
       title: "Summarize Context",
       description:
-        "Collect context from all enabled Apple apps and ask the client's LLM to produce a concise briefing. " +
-        "Uses MCP Sampling — works with any LLM the client is using. No API keys required.",
+        "Gather recent context from enabled Apple apps and produce a concise briefing via MCP sampling — read-only; the connected client must support sampling. " +
+        "Works with whatever LLM the client is using; no API keys required.",
       inputSchema: {
         focus: z
           .string()

--- a/src/notes/tools.ts
+++ b/src/notes/tools.ts
@@ -365,7 +365,8 @@ export function registerNoteTools(server: McpServer, config: AirMcpConfig): void
     "create_folder",
     {
       title: "Create Folder",
-      description: "Create a new folder. Optionally specify which account to create it in.",
+      description:
+        "Create a new folder in Apple Notes — a non-destructive write. Optionally specify which account to create it in.",
       inputSchema: {
         name: z.string().max(500).describe("Folder name"),
         account: z.string().max(500).optional().describe("Account name (e.g. 'iCloud'). Defaults to primary account."),

--- a/src/reminders/tools.ts
+++ b/src/reminders/tools.ts
@@ -243,7 +243,7 @@ export function registerReminderTools(server: McpServer, _config: AirMcpConfig):
     {
       title: "Update Reminder",
       description:
-        "Update reminder properties. Only specified fields are changed. Set dueDate to null to clear it. Recurrence rules cannot be modified via automation.",
+        "Update fields of an existing reminder in Apple Reminders — a write to user data; only the fields you pass change. Set dueDate to null to clear it. Recurrence rules cannot be modified via automation.",
       inputSchema: {
         id: z.string().max(500).describe("Reminder ID"),
         title: z.string().max(500).optional().describe("New title"),

--- a/src/semantic/tools.ts
+++ b/src/semantic/tools.ts
@@ -21,9 +21,8 @@ export function registerSemanticTools(server: McpServer, config: AirMcpConfig): 
     {
       title: "Build Semantic Index",
       description:
-        "Index data from enabled Apple apps (Notes, Calendar, Reminders, Mail, Photos, Finder) into the local " +
-        "vector store for semantic search. Run this once, then use semantic_search. Replaces any existing " +
-        "index. Requires Swift bridge (npm run swift-build).",
+        "Build the local vector index over enabled Apple apps for semantic search — replaces any existing index; embeddings need GEMINI_API_KEY or the Swift bridge. " +
+        "Covers Notes, Calendar, Reminders, Mail, Photos, and Finder. Run once, then use semantic_search.",
       inputSchema: {
         sources: z
           .array(z.enum(["notes", "calendar", "reminders", "mail", "photos", "finder"]))
@@ -96,7 +95,7 @@ export function registerSemanticTools(server: McpServer, config: AirMcpConfig): 
     {
       title: "Find Related Items",
       description:
-        "Given a note, event, reminder, or email ID, find semantically related items across all indexed Apple apps. " +
+        "Find items semantically related to a note, event, reminder, or email ID across indexed Apple apps — read-only; requires semantic_index to be built first. " +
         "Discovers cross-app connections (e.g., a calendar event related to notes and reminders about the same topic).",
       inputSchema: {
         id: z.string().max(500).describe("Item ID (as stored in the vector index)"),

--- a/src/shared/tool-filter.ts
+++ b/src/shared/tool-filter.ts
@@ -11,8 +11,8 @@
  *
  * This is the pragmatic implementation of SEP-1821 filtering:
  * rather than hacking SDK internals to intercept the tools/list handler,
- * we reduce per-tool token cost at registration time by truncating
- * descriptions to their first sentence.
+ * we reduce per-tool token cost at registration time by sending only as
+ * many leading complete sentences as fit a fixed character budget.
  *
  * The full descriptions are preserved in the tool registry for
  * discover_tools / semantic search so search quality is unaffected.
@@ -25,20 +25,43 @@ export function isCompactMode(): boolean {
   return COMPACT_MODE;
 }
 
+/** Character budget for the compacted description sent over the wire. */
+const COMPACT_BUDGET = 160;
+
 /**
  * Shorten a tool description for compact mode.
- * Takes the first sentence only and caps at 80 characters.
+ *
+ * Keeps as many leading COMPLETE sentences as fit COMPACT_BUDGET, so the
+ * wire description never ends in a mid-word cut — agents (and registry
+ * quality scorers) always see whole sentences. A boundary is sentence
+ * punctuation followed by whitespace, so "etc.)", "e.g.," and version
+ * numbers don't split. Only when the first sentence alone exceeds the
+ * budget does it fall back to a word-boundary cut with an ellipsis.
  * Returns the original description unchanged when compact mode is off.
+ *
+ * History: the previous form kept the first sentence but hard-capped it at
+ * 80 chars with a mid-word slice(0,77)+"..." — every tool whose first
+ * sentence ran past 80 shipped broken prose over the wire, which registry
+ * quality scoring flagged catalog-wide. Whole sentences within a slightly
+ * larger budget keep the token savings without the broken text.
  */
 export function compactDescription(description: string): string {
   if (!COMPACT_MODE) return description;
-  // Find first sentence boundary: punctuation (.!?) followed by whitespace
-  const match = description.match(/^(.*?[.!?])\s/);
-  const firstSentence = match?.[1] ?? description;
-  // Cap at 80 chars
-  return firstSentence.length > 80
-    ? firstSentence.slice(0, 77) + "..."
-    : /[.!?]$/.test(firstSentence)
-      ? firstSentence
-      : firstSentence + ".";
+  const text = description.trim();
+  if (text.length <= COMPACT_BUDGET) {
+    return /[.!?]$/.test(text) ? text : text + ".";
+  }
+  // Find the last sentence boundary that still fits the budget.
+  const boundary = /[.!?](?=\s)/g;
+  let cutEnd = 0;
+  for (let m = boundary.exec(text); m !== null; m = boundary.exec(text)) {
+    if (m.index + 1 > COMPACT_BUDGET) break;
+    cutEnd = m.index + 1;
+  }
+  if (cutEnd > 0) return text.slice(0, cutEnd);
+  // First sentence alone exceeds the budget (or no sentence punctuation):
+  // cut at the last word boundary, never mid-word.
+  const head = text.slice(0, COMPACT_BUDGET - 1);
+  const lastSpace = head.lastIndexOf(" ");
+  return (lastSpace > 40 ? head.slice(0, lastSpace) : head).trimEnd() + "…";
 }

--- a/src/shortcuts/tools.ts
+++ b/src/shortcuts/tools.ts
@@ -134,7 +134,7 @@ export function registerShortcutsTools(server: McpServer, _config: AirMcpConfig)
     {
       title: "Create Shortcut",
       description:
-        "Create a new Siri Shortcut by name. Uses UI automation to open the Shortcuts app and create a new empty shortcut. The shortcut must be further configured in the Shortcuts app.",
+        "Create a new empty Siri Shortcut by name — drives the Shortcuts app via UI automation (needs Accessibility permission; the app opens and takes focus). The shortcut must be further configured in the Shortcuts app.",
       inputSchema: {
         name: z.string().max(500).describe("Name for the new shortcut"),
       },

--- a/src/skills/builtins/clipboard-url-to-reading.yaml
+++ b/src/skills/builtins/clipboard-url-to-reading.yaml
@@ -1,11 +1,10 @@
 name: clipboard-url-to-reading
 title: "Clipboard URL → Reading List"
 description: >-
-  Listens for clipboard changes and, when a URL is on the pasteboard,
-  pushes it into Safari's Reading List. Combines the `pasteboard_changed`
-  event trigger with `on_error: continue` so non-URL clipboard content
-  doesn't spam the user with errors — Safari's validator rejects the
-  non-URL and the skill quietly moves on.
+  Watch the clipboard and add any copied URL to Safari's Reading List —
+  writes to Reading List; non-URL clipboard content is ignored. Combines
+  the `pasteboard_changed` event trigger with `on_error: continue` so
+  Safari's validator rejects non-URLs and the skill quietly moves on.
 expose_as: tool
 trigger:
   event: pasteboard_changed

--- a/src/skills/builtins/daily-journal.yaml
+++ b/src/skills/builtins/daily-journal.yaml
@@ -1,12 +1,11 @@
 name: daily-journal
 title: "Daily Journal → Memory"
 description: >-
-  Captures today's events + open reminders, summarises them on-device,
-  and persists the summary as a context-memory `episode` tagged
-  `journal`. Demonstrates inputs + parallel + retry + the
-  newly-exposed `memory_put` tool working together so ai_agent can
-  later recall "what did I do last Tuesday?" via `memory_query`.
-  DESTRUCTIVE: writes a memory entry (non-destructive to Apple apps).
+  Summarise today's events and open reminders on-device and save the
+  result as a context-memory `episode` tagged `journal` — writes one
+  memory entry. Nothing is written to Apple apps. Demonstrates inputs +
+  parallel + retry + `memory_put` so ai_agent can later recall "what did
+  I do last Tuesday?" via `memory_query`.
 expose_as: tool
 inputs:
   note:

--- a/src/skills/builtins/focus-block-planner.yaml
+++ b/src/skills/builtins/focus-block-planner.yaml
@@ -1,12 +1,12 @@
 name: focus-block-planner
 title: "Focus Block Planner"
 description: >-
-  Walks today's open reminders and drops a calendar time-block for each
-  one. Uses `loop` with `on_error: continue` so a single failed event
-  creation (e.g. conflicting calendar, missing permission) doesn't abort
-  the rest of the plan — the skill result reports which reminders got
-  blocked and which didn't. DESTRUCTIVE: creates calendar events; each
-  insertion is gated by HITL approval.
+  Create a calendar time-block event for each of today's open reminders —
+  writes calendar events (each creation HITL-gated); reminders are only
+  read. Uses `loop` with `on_error: continue` so a single failed event
+  creation (conflicting calendar, missing permission) doesn't abort the
+  rest of the plan — the skill result reports which reminders got blocked
+  and which didn't.
 expose_as: tool
 steps:
   # 1) Pull the open-reminder backlog. `limit: 8` keeps the loop small

--- a/src/skills/builtins/focus-guardian.yaml
+++ b/src/skills/builtins/focus-guardian.yaml
@@ -1,9 +1,9 @@
 name: focus-guardian
 title: "Focus Mode Guardian"
 description: >-
-  Auto-snapshots today's events and open reminders whenever the system
-  focus mode changes (entering/leaving Do Not Disturb, Work, Personal, etc.)
-  so the AI has fresh context right after you change mode. Showcases the
+  Snapshot today's events and open reminders whenever macOS Focus mode
+  changes (Do Not Disturb, Personal, etc.) — read-only, nothing is written.
+  Gives the AI fresh context right after a mode switch; showcases the
   `focus_mode_changed` event trigger plus parallel data gathering.
 expose_as: tool
 trigger:

--- a/src/skills/builtins/project-digest.yaml
+++ b/src/skills/builtins/project-digest.yaml
@@ -1,10 +1,9 @@
 name: project-digest
 title: "Project Digest"
 description: >-
-  Semantic-search the user's indexed Apple data for a topic, then loop
-  over each match to pull semantically-related items — effectively a
-  cross-app "everything about this project" view. Demonstrates the
-  Skills DSL's loop construct and conditional execution.
+  Semantic-search indexed Apple data for a topic and expand each hit with
+  related items — a read-only cross-app digest; needs semantic_index first.
+  Demonstrates the Skills DSL's loop construct and conditional execution.
 expose_as: tool
 steps:
   # 1) Seed search: semantic_search returns { query, results[], total, ... }.

--- a/src/skills/builtins/sender-to-tasks.yaml
+++ b/src/skills/builtins/sender-to-tasks.yaml
@@ -1,13 +1,12 @@
 name: sender-to-tasks
 title: "Sender → Tasks"
 description: >-
-  Scans mail for a keyword and turns each hit into a reminder so nothing
-  in the inbox goes unresolved. Accepts runtime inputs so the same skill
-  handles newsletter triage, a specific sender, or any ad-hoc query
-  without editing YAML. Loop + `on_error: continue` means the rest of
-  the batch still gets queued even if one reminder-create fails (HITL
-  denial, Reminders permission, etc.). DESTRUCTIVE: creates reminders;
-  each insertion is gated by HITL approval.
+  Scan Mail for a keyword or sender and create one reminder per matching
+  message — writes reminders (each creation HITL-gated); mail is only read.
+  Accepts runtime inputs so the same skill handles newsletter triage, a
+  specific sender, or any ad-hoc query without editing YAML. Loop +
+  `on_error: continue` means the rest of the batch still gets queued even
+  if one reminder-create fails (HITL denial, Reminders permission, etc.).
 expose_as: tool
 inputs:
   query:

--- a/src/system/tools.ts
+++ b/src/system/tools.ts
@@ -322,7 +322,7 @@ export function registerSystemTools(server: McpServer, _config: AirMcpConfig): v
     {
       title: "Capture Screenshot",
       description:
-        "Take a screenshot and save to the specified path. Supports full screen, window, or selection capture.",
+        "Capture the screen to an image file at the given path — writes a file; needs macOS Screen Recording permission. Supports full screen, window, or selection capture.",
       inputSchema: {
         path: zFilePath.describe("Absolute file path to save the screenshot (e.g. '/tmp/screenshot.png')"),
         region: z

--- a/src/weather/tools.ts
+++ b/src/weather/tools.ts
@@ -69,7 +69,8 @@ export function registerWeatherTools(server: McpServer, _config: AirMcpConfig): 
     "get_hourly_forecast",
     {
       title: "Get Hourly Forecast",
-      description: "Get hourly weather forecast for a location.",
+      description:
+        "Get the hour-by-hour weather forecast (temperature, precipitation, wind) for a latitude/longitude via the Open-Meteo API — read-only, no API key needed.",
       inputSchema: {
         latitude: z.number().min(-90).max(90).describe("Latitude coordinate"),
         longitude: z.number().min(-180).max(180).describe("Longitude coordinate"),

--- a/swift/Sources/AirMCPKit/Generated/MCPIntents.swift
+++ b/swift/Sources/AirMCPKit/Generated/MCPIntents.swift
@@ -1920,7 +1920,7 @@ public struct CreateEventIntent: AppIntent {
 // Tool: create_folder
 public struct CreateFolderIntent: AppIntent {
     nonisolated(unsafe) public static var title: LocalizedStringResource = "Create Folder"
-    nonisolated(unsafe) public static var description = IntentDescription("Create a new folder. Optionally specify which account to create it in.")
+    nonisolated(unsafe) public static var description = IntentDescription("Create a new folder in Apple Notes — a non-destructive write. Optionally specify which account to create it in.")
     nonisolated(unsafe) public static var openAppWhenRun: Bool = false
 
     public init() {}
@@ -2050,7 +2050,7 @@ public struct CreateReminderListIntent: AppIntent {
 // Tool: create_shortcut
 public struct CreateShortcutIntent: AppIntent {
     nonisolated(unsafe) public static var title: LocalizedStringResource = "Create Shortcut"
-    nonisolated(unsafe) public static var description = IntentDescription("Create a new Siri Shortcut by name. Uses UI automation to open the Shortcuts app and create a new empty shortcut. The shortcut must be further configured in the Shortcuts app.")
+    nonisolated(unsafe) public static var description = IntentDescription("Create a new empty Siri Shortcut by name — drives the Shortcuts app via UI automation (needs Accessibility permission; the app opens and takes focus). The shortcut must be further configured in the Shortcuts app.")
     nonisolated(unsafe) public static var openAppWhenRun: Bool = false
 
     public init() {}
@@ -2256,7 +2256,7 @@ public struct ExportShortcutIntent: AppIntent {
 // Tool: find_related
 public struct FindRelatedIntent: AppIntent {
     nonisolated(unsafe) public static var title: LocalizedStringResource = "Find Related Items"
-    nonisolated(unsafe) public static var description = IntentDescription("Given a note, event, reminder, or email ID, find semantically related items across all indexed Apple apps. Discovers cross-app connections (e.g., a calendar event related to notes and reminders about the same topic).")
+    nonisolated(unsafe) public static var description = IntentDescription("Find items semantically related to a note, event, reminder, or email ID across indexed Apple apps — read-only; requires semantic_index to be built first. Discovers cross-app connections (e.g., a calendar event related to notes and reminders about the same topic).")
     nonisolated(unsafe) public static var openAppWhenRun: Bool = false
 
     public init() {}
@@ -2673,7 +2673,7 @@ public struct GetFrontmostAppIntent: AppIntent {
 // Tool: get_hourly_forecast
 public struct GetHourlyForecastIntent: AppIntent {
     nonisolated(unsafe) public static var title: LocalizedStringResource = "Get Hourly Forecast"
-    nonisolated(unsafe) public static var description = IntentDescription("Get hourly weather forecast for a location.")
+    nonisolated(unsafe) public static var description = IntentDescription("Get the hour-by-hour weather forecast (temperature, precipitation, wind) for a latitude/longitude via the Open-Meteo API — read-only, no API key needed.")
     nonisolated(unsafe) public static var openAppWhenRun: Bool = false
 
     public init() {}
@@ -6662,7 +6662,7 @@ public struct SkillCalendarAlertIntent: AppIntent {
 // Tool: skill_clipboard-url-to-reading
 public struct SkillClipboardUrlToReadingIntent: AppIntent {
     nonisolated(unsafe) public static var title: LocalizedStringResource = "Clipboard URL → Reading List"
-    nonisolated(unsafe) public static var description = IntentDescription("[Skill] Listens for clipboard changes and, when a URL is on the pasteboard, pushes it into Safari's Reading List. Combines the `pasteboard_changed` event trigger with `on_error: continue` so non-URL clipboard content doesn't spam the user with errors — Safari's validator rejects the non-URL and the skill quietly moves on.")
+    nonisolated(unsafe) public static var description = IntentDescription("[Skill] Watch the clipboard and add any copied URL to Safari's Reading List — writes to Reading List; non-URL clipboard content is ignored. Combines the `pasteboard_changed` event trigger with `on_error: continue` so Safari's validator rejects non-URLs and the skill quietly moves on.")
     nonisolated(unsafe) public static var openAppWhenRun: Bool = false
 
     public init() {}
@@ -6679,7 +6679,7 @@ public struct SkillClipboardUrlToReadingIntent: AppIntent {
 // Tool: skill_daily-journal
 public struct SkillDailyJournalIntent: AppIntent {
     nonisolated(unsafe) public static var title: LocalizedStringResource = "Daily Journal → Memory"
-    nonisolated(unsafe) public static var description = IntentDescription("[Skill] Captures today's events + open reminders, summarises them on-device, and persists the summary as a context-memory `episode` tagged `journal`. Demonstrates inputs + parallel + retry + the newly-exposed `memory_put` tool working together so ai_agent can later recall \"what did I do last Tuesday?\" via `memory_query`. DESTRUCTIVE: writes a memory entry (non-destructive to Apple apps).")
+    nonisolated(unsafe) public static var description = IntentDescription("[Skill] Summarise today's events and open reminders on-device and save the result as a context-memory `episode` tagged `journal` — writes one memory entry. Nothing is written to Apple apps. Demonstrates inputs + parallel + retry + `memory_put` so ai_agent can later recall \"what did I do last Tuesday?\" via `memory_query`.")
     nonisolated(unsafe) public static var openAppWhenRun: Bool = false
 
     public init() {}
@@ -6716,7 +6716,7 @@ public struct SkillEveningWinddownIntent: AppIntent {
 // Tool: skill_focus-block-planner
 public struct SkillFocusBlockPlannerIntent: AppIntent {
     nonisolated(unsafe) public static var title: LocalizedStringResource = "Focus Block Planner"
-    nonisolated(unsafe) public static var description = IntentDescription("[Skill] Walks today's open reminders and drops a calendar time-block for each one. Uses `loop` with `on_error: continue` so a single failed event creation (e.g. conflicting calendar, missing permission) doesn't abort the rest of the plan — the skill result reports which reminders got blocked and which didn't. DESTRUCTIVE: creates calendar events; each insertion is gated by HITL approval.")
+    nonisolated(unsafe) public static var description = IntentDescription("[Skill] Create a calendar time-block event for each of today's open reminders — writes calendar events (each creation HITL-gated); reminders are only read. Uses `loop` with `on_error: continue` so a single failed event creation (conflicting calendar, missing permission) doesn't abort the rest of the plan — the skill result reports which reminders got blocked and which didn't.")
     nonisolated(unsafe) public static var openAppWhenRun: Bool = false
 
     public init() {}
@@ -6733,7 +6733,7 @@ public struct SkillFocusBlockPlannerIntent: AppIntent {
 // Tool: skill_focus-guardian
 public struct SkillFocusGuardianIntent: AppIntent {
     nonisolated(unsafe) public static var title: LocalizedStringResource = "Focus Mode Guardian"
-    nonisolated(unsafe) public static var description = IntentDescription("[Skill] Auto-snapshots today's events and open reminders whenever the system focus mode changes (entering/leaving Do Not Disturb, Work, Personal, etc.) so the AI has fresh context right after you change mode. Showcases the `focus_mode_changed` event trigger plus parallel data gathering.")
+    nonisolated(unsafe) public static var description = IntentDescription("[Skill] Snapshot today's events and open reminders whenever macOS Focus mode changes (Do Not Disturb, Personal, etc.) — read-only, nothing is written. Gives the AI fresh context right after a mode switch; showcases the `focus_mode_changed` event trigger plus parallel data gathering.")
     nonisolated(unsafe) public static var openAppWhenRun: Bool = false
 
     public init() {}
@@ -6767,7 +6767,7 @@ public struct SkillInboxTriageIntent: AppIntent {
 // Tool: skill_project-digest
 public struct SkillProjectDigestIntent: AppIntent {
     nonisolated(unsafe) public static var title: LocalizedStringResource = "Project Digest"
-    nonisolated(unsafe) public static var description = IntentDescription("[Skill] Semantic-search the user's indexed Apple data for a topic, then loop over each match to pull semantically-related items — effectively a cross-app \"everything about this project\" view. Demonstrates the Skills DSL's loop construct and conditional execution.")
+    nonisolated(unsafe) public static var description = IntentDescription("[Skill] Semantic-search indexed Apple data for a topic and expand each hit with related items — a read-only cross-app digest; needs semantic_index first. Demonstrates the Skills DSL's loop construct and conditional execution.")
     nonisolated(unsafe) public static var openAppWhenRun: Bool = false
 
     public init() {}
@@ -6784,7 +6784,7 @@ public struct SkillProjectDigestIntent: AppIntent {
 // Tool: skill_sender-to-tasks
 public struct SkillSenderToTasksIntent: AppIntent {
     nonisolated(unsafe) public static var title: LocalizedStringResource = "Sender → Tasks"
-    nonisolated(unsafe) public static var description = IntentDescription("[Skill] Scans mail for a keyword and turns each hit into a reminder so nothing in the inbox goes unresolved. Accepts runtime inputs so the same skill handles newsletter triage, a specific sender, or any ad-hoc query without editing YAML. Loop + `on_error: continue` means the rest of the batch still gets queued even if one reminder-create fails (HITL denial, Reminders permission, etc.). DESTRUCTIVE: creates reminders; each insertion is gated by HITL approval.")
+    nonisolated(unsafe) public static var description = IntentDescription("[Skill] Scan Mail for a keyword or sender and create one reminder per matching message — writes reminders (each creation HITL-gated); mail is only read. Accepts runtime inputs so the same skill handles newsletter triage, a specific sender, or any ad-hoc query without editing YAML. Loop + `on_error: continue` means the rest of the batch still gets queued even if one reminder-create fails (HITL denial, Reminders permission, etc.).")
     nonisolated(unsafe) public static var openAppWhenRun: Bool = false
 
     public init() {}
@@ -6897,7 +6897,7 @@ public struct SuggestNextToolsIntent: AppIntent {
 // Tool: summarize_context
 public struct SummarizeContextIntent: AppIntent {
     nonisolated(unsafe) public static var title: LocalizedStringResource = "Summarize Context"
-    nonisolated(unsafe) public static var description = IntentDescription("Collect context from all enabled Apple apps and ask the client's LLM to produce a concise briefing. Uses MCP Sampling — works with any LLM the client is using. No API keys required.")
+    nonisolated(unsafe) public static var description = IntentDescription("Gather recent context from enabled Apple apps and produce a concise briefing via MCP sampling — read-only; the connected client must support sampling. Works with whatever LLM the client is using; no API keys required.")
     nonisolated(unsafe) public static var openAppWhenRun: Bool = false
 
     public init() {}

--- a/tests/tool-filter.test.js
+++ b/tests/tool-filter.test.js
@@ -1,0 +1,69 @@
+// Wire-description contract for compact mode (src/shared/tool-filter.ts).
+//
+// Compact mode is ON by default (AIRMCP_COMPACT_TOOLS unset in the test env),
+// and what these tests pin is the shape of what every MCP client actually
+// receives in tools/list: complete sentences within the budget, never a
+// mid-word cut. The old implementation (first sentence hard-capped at 80
+// chars, sliced to 77+"...") shipped broken prose for every tool whose first
+// sentence ran past 80 — registry quality scoring flagged it catalog-wide.
+
+import { describe, test, expect } from "@jest/globals";
+import { compactDescription } from "../dist/shared/tool-filter.js";
+
+const BUDGET = 160;
+
+describe("compactDescription (compact mode on)", () => {
+  test("short description passes through, gaining terminal punctuation", () => {
+    expect(compactDescription("Create a new folder")).toBe("Create a new folder.");
+    expect(compactDescription("Get all calendar events for today.")).toBe(
+      "Get all calendar events for today.",
+    );
+  });
+
+  test("keeps as many whole sentences as fit the budget", () => {
+    const s1 = "First sentence about the tool purpose.";
+    const s2 = "Second sentence with extra details for discovery.";
+    const s3 = "x".repeat(120) + ".";
+    const out = compactDescription(`${s1} ${s2} ${s3}`);
+    expect(out).toBe(`${s1} ${s2}`);
+    expect(out.length).toBeLessThanOrEqual(BUDGET);
+  });
+
+  test("over-budget tail is dropped at a sentence boundary, not mid-word", () => {
+    const s1 = "A complete leading sentence that fits the budget on its own.";
+    const s2 = "This trailing sentence is long enough that including it would push the total well past the one-sixty character budget for the wire description.";
+    const out = compactDescription(`${s1} ${s2}`);
+    expect(out).toBe(s1);
+  });
+
+  test("never cuts mid-word and never emits '...'", () => {
+    const words = Array.from({ length: 60 }, (_, i) => `word${i}`).join(" ");
+    const out = compactDescription(words);
+    expect(out.length).toBeLessThanOrEqual(BUDGET);
+    expect(out.endsWith("…")).toBe(true);
+    expect(out).not.toMatch(/\.\.\./);
+    const lastWord = out.slice(0, -1).trim().split(" ").pop();
+    expect(words.split(" ")).toContain(lastWord);
+  });
+
+  test("abbreviation-style punctuation does not split a sentence", () => {
+    // "etc.)" — the '.' is followed by ')', not whitespace → not a boundary.
+    const s1 =
+      "[Skill] Snapshot today's events and open reminders whenever macOS Focus mode changes (Do Not Disturb, Personal, etc.) — read-only, nothing is written.";
+    const s2 =
+      "Gives the AI fresh context right after a mode switch; showcases the focus_mode_changed event trigger plus parallel data gathering.";
+    const out = compactDescription(`${s1} ${s2}`);
+    expect(out).toBe(s1);
+    expect(out.endsWith("…")).toBe(false);
+  });
+
+  test("real fixture: find_related first sentence survives whole", () => {
+    const desc =
+      "Find items semantically related to a note, event, reminder, or email ID across indexed Apple apps — read-only; requires semantic_index to be built first. " +
+      "Discovers cross-app connections (e.g., a calendar event related to notes and reminders about the same topic).";
+    const out = compactDescription(desc);
+    expect(out).toBe(
+      "Find items semantically related to a note, event, reminder, or email ID across indexed Apple apps — read-only; requires semantic_index to be built first.",
+    );
+  });
+});


### PR DESCRIPTION
Glama's TDQS scored the catalog C (avg 3.5/5, lowest 1.9/5) and the listing's
quality badge B. Root cause: compactDescription() kept the first sentence but
hard-capped it at 80 chars with slice(0,77)+"..." — every tool whose first
sentence ran past 80 shipped mid-word-truncated prose over the wire ("ending
with '...', indicating truncation" per the judge), and several short
descriptions disclosed nothing about behavior.

Mechanism (src/shared/tool-filter.ts, mirror synced in
scripts/measure-tool-tokens.mjs): keep as many leading COMPLETE sentences as
fit a 160-char budget; a boundary is sentence punctuation followed by
whitespace, so "etc.)", "e.g.," and version numbers don't split; only a first
sentence longer than the whole budget falls back to a word-boundary cut with
an ellipsis. Compact mode stays ON by default; AIRMCP_COMPACT_TOOLS=false
still returns full descriptions.

Content: front-load purpose + behavior in sentence one for the 14 lowest-
scoring definitions — 6 skill YAMLs (read/write nature + HITL gating now
disclosed up front instead of a tail "DESTRUCTIVE:" note the old cap never
let clients see) and 8 tools (update_reminder / create_folder /
capture_screenshot / create_shortcut / get_hourly_forecast enriched from
bare one-liners; semantic_index now front-loads "replaces any existing
index" and the real embedding requirement — GEMINI_API_KEY or the Swift
bridge, not bridge-only; find_related / summarize_context disclose read-only
+ prerequisites). event_subscribe and spotlight_clear needed no text change —
the mechanism fix alone un-truncates them.

Verified on a clean-room boot of the rebuilt dist: all 111 starter wire
descriptions are complete sentences <=160 chars, zero "..." endings.
New tests/tool-filter.test.js pins the wire contract (whole sentences,
word-boundary fallback, abbreviation safety, no mid-word cuts); suite 1929
pass. docs/tool-manifest.json + MCPIntents.swift regenerated — counts
unchanged (272 registerTool / 285 manifest / 232 intents; stats:check clean).
