### PR TITLE
fix(hitl): elicitation fallback for managed clients when the approval socket is unreachable

### DIFF
--- a/docs/rfc/0008-elicitation.md
+++ b/docs/rfc/0008-elicitation.md
@@ -1,11 +1,12 @@
 # RFC 0008 — MCP Elicitation for destructive tools
 
-- **Status**: Phase 1 Implemented (May 2026 — `tryElicitApproval` in `src/shared/hitl-guard.ts`). Phase 2 Draft.
+- **Status**: Phase 1 Implemented (May 2026 — `tryElicitApproval` in `src/shared/hitl-guard.ts`) · Phase 1.5 Implemented (June 2026 — managed-client headless fallback). Phase 2 Draft.
 - **Author**: heznpc + Claude
 - **Created**: 2026-05-07
 - **Target**: v2.13.0 (Phase 1 — confirmation prompts ✅) · v3.0.0 (Phase 2 — form/URL elicit)
 - **Amendment**:
   - 2026-05-07 — Phase 1 lands: capability gate + `AIRMCP_ELICITATION_DISABLE` env opt-out folded into the existing HITL guard's elicitation path. The previous draft assumed a fresh wrapper at the tool-registry layer; on review the `installHitlGuard` interceptor was already wiring `inner.elicitInput()` for destructive tools — the gap was just the negotiated-capability check + env switch. No new wrapper layer needed.
+  - 2026-06-10 — Phase 1.5: managed-client headless fallback. The managed-client elicitation skip (added to avoid double prompts) combined with the socket channel's deny-on-unreachable meant the default `npx airmcp` + Claude-family setup hard-denied every gated tool unless the menubar app was running — issue #28's reporter resolved it by turning HITL off entirely, i.e. the safety feature was being disabled by its own UX. Channel order for managed clients is now **socket (if reachable) → elicitation → deny with an actionable hint**; non-managed clients keep elicitation → socket → deny. Per-call granularity is unchanged in every path (CLAUDE.md escalation reviewed: this changes the approval *channel*, never the *granularity*). Implementation: `HitlClient.isReachable()` probe + `NOT_HANDLED` sentinel in the guard; new telemetry channel value `"unavailable"` for the no-channel deny.
 - **Related**: [`@modelcontextprotocol/sdk` 1.29.0 elicitInput API](https://github.com/modelcontextprotocol/typescript-sdk),
   [MCP Elicitation spec (draft)](https://modelcontextprotocol.io/specification/draft/client/elicitation),
   [GitHub Copilot blog — MCP elicitation](https://github.blog/ai-and-ml/github-copilot/building-smarter-interactions-with-mcp-elicitation-from-clunky-tool-calls-to-seamless-user-experiences/),

--- a/src/shared/hitl-guard.ts
+++ b/src/shared/hitl-guard.ts
@@ -4,6 +4,9 @@ import type { HitlClient } from "./hitl.js";
 import { errPermission } from "./result.js";
 import { traceApproval } from "./telemetry.js";
 
+/** Sentinel: elicitation offered no channel for this call — caller falls back. */
+const NOT_HANDLED = Symbol("hitl-elicitation-not-handled");
+
 interface ToolAnnotations {
   readOnlyHint?: boolean;
   destructiveHint?: boolean;
@@ -133,9 +136,20 @@ async function tryElicitApproval(
  * Monkey-patches server.registerTool so every subsequent registration
  * goes through HITL approval when the policy requires it.
  *
- * Approval priority:
- * 1. MCP Elicitation (form mode) — works with any MCP client that supports it
- * 2. Socket-based HITL — fallback for clients without elicitation support
+ * Channel order (per-call approval is preserved in every path — only the
+ * channel that answers differs by what is actually available):
+ * - non-managed clients: MCP elicitation → socket HITL → deny
+ * - managed clients:     socket HITL (if reachable) → MCP elicitation →
+ *                        deny with an actionable message
+ *
+ * Managed clients (the Claude family + AIRMCP_MANAGED_CLIENTS) run their own
+ * per-call permission prompt, so elicitation is skipped while the socket can
+ * answer — the menubar app stays the explicit approver when it is running.
+ * But in the default headless setup (`npx airmcp`, no companion app) nothing
+ * listens on that socket, and the old order hard-denied every gated tool out
+ * of the box — issue #28's reporter resolved it by setting hitl level "off",
+ * i.e. the safety feature got disabled by its own UX. Falling back to
+ * elicitation keeps a human in the loop instead (RFC 0008 Phase 1.5).
  */
 export function installHitlGuard(server: McpServer, hitlClient: HitlClient, config: AirMcpConfig): void {
   const original = server.registerTool.bind(server);
@@ -158,22 +172,44 @@ export function installHitlGuard(server: McpServer, hitlClient: HitlClient, conf
       const destructive = annotations.destructiveHint ?? false;
       const managed = isManagedClient(server);
 
-      // Skip MCP elicitation for clients with their own permission system
-      // (e.g. Claude Code) to avoid double-approval UX.
-      if (!managed) {
+      // Resolve the call through MCP elicitation. Returns NOT_HANDLED when the
+      // client offers no elicitation channel, so the caller can fall back.
+      const viaElicitation = async (): Promise<unknown> => {
         const elicitResult = await tryElicitApproval(server, name, toolArgs, destructive);
-        if (elicitResult !== undefined) {
-          if (telemetryEnabled) {
-            traceApproval(name, elicitResult ? "approved" : "denied", "elicitation", { destructive, managed });
-          }
-          if (!elicitResult) {
-            return errPermission(`Action denied: "${name}" was rejected via MCP elicitation.`);
-          }
-          return (callback as (...a: unknown[]) => unknown)(...args);
+        if (elicitResult === undefined) return NOT_HANDLED;
+        if (telemetryEnabled) {
+          traceApproval(name, elicitResult ? "approved" : "denied", "elicitation", { destructive, managed });
         }
+        if (!elicitResult) {
+          return errPermission(`Action denied: "${name}" was rejected via MCP elicitation.`);
+        }
+        return (callback as (...a: unknown[]) => unknown)(...args);
+      };
+
+      if (!managed) {
+        // Elicitation first — managed clients skip it here to avoid a double
+        // prompt on top of their own per-call permission UX.
+        const handled = await viaElicitation();
+        if (handled !== NOT_HANDLED) return handled;
+      } else if (!(await hitlClient.isReachable())) {
+        // Managed client, but nothing is listening on the approval socket
+        // (headless `npx airmcp` without the menubar app). Elicitation is the
+        // only channel that can still put a human in the loop — use it.
+        const handled = await viaElicitation();
+        if (handled !== NOT_HANDLED) return handled;
+        // No approval channel exists at all: deny this call, and say how to fix it.
+        if (telemetryEnabled) {
+          traceApproval(name, "denied", "unavailable", { destructive, managed });
+        }
+        return errPermission(
+          `Action denied: "${name}" requires per-call approval, but no approval channel is available. ` +
+            `Start the AirMCP menubar app, use an MCP client that supports elicitation, ` +
+            `or adjust hitl.whitelist / hitl.level in ~/.config/airmcp/config.json.`,
+        );
       }
 
-      // Fallback: socket-based HITL (separate channel — always available)
+      // Socket-based HITL (managed client with the app reachable, or fallback
+      // for non-managed clients without elicitation support).
       const approved = await hitlClient.requestApproval(
         name,
         toolArgs,

--- a/src/shared/hitl.ts
+++ b/src/shared/hitl.ts
@@ -28,6 +28,22 @@ export class HitlClient {
 
   constructor(private config: HitlConfig) {}
 
+  /**
+   * Probe whether anything is listening on the approval socket without
+   * sending a request. The HITL guard uses this to pick a channel for
+   * managed clients: socket when the menubar app is up, MCP elicitation
+   * otherwise (RFC 0008 §3.4 / Phase 1.5). A successful probe leaves the
+   * connection open for the subsequent requestApproval call.
+   */
+  async isReachable(): Promise<boolean> {
+    try {
+      await this.ensureConnected();
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
   async requestApproval(
     tool: string,
     args: Record<string, unknown>,

--- a/src/shared/telemetry.ts
+++ b/src/shared/telemetry.ts
@@ -54,7 +54,7 @@ function getTracer(): Tracer | null | Promise<Tracer | null> {
 export async function traceApproval(
   toolName: string,
   decision: "approved" | "denied" | "skipped",
-  channel: "elicitation" | "socket",
+  channel: "elicitation" | "socket" | "unavailable",
   attrs?: { destructive?: boolean; managed?: boolean },
 ): Promise<void> {
   const t = await getTracer();

--- a/tests/hitl-client.test.js
+++ b/tests/hitl-client.test.js
@@ -705,4 +705,29 @@ describe('HitlClient', () => {
     expect(receivedRequest.openWorld).toBe(true);
     expect(receivedRequest.destructive).toBe(false);
   });
+
+  test('isReachable returns false when nothing listens on the socket path', async () => {
+    const client = new HitlClient({
+      socketPath: join(tmpdir(), `airmcp-missing-${randomUUID()}.sock`),
+      level: 'all',
+      timeout: 1,
+    });
+    cleanups.push(() => client.dispose());
+
+    await expect(client.isReachable()).resolves.toBe(false);
+  });
+
+  test('isReachable returns true when a listener is up, and the connection is reused', async () => {
+    const { server, socketPath } = await createTestSocket((req, conn) => {
+      conn.write(JSON.stringify({ id: req.id, type: 'hitl_response', approved: true }) + '\n');
+    });
+    cleanups.push(() => server.close());
+
+    const client = new HitlClient({ socketPath, level: 'all', timeout: 5 });
+    cleanups.push(() => client.dispose());
+
+    await expect(client.isReachable()).resolves.toBe(true);
+    // The probe's connection serves the subsequent approval request.
+    await expect(client.requestApproval('probe_then_ask', {}, false, false)).resolves.toBe(true);
+  });
 });

--- a/tests/hitl-guard.test.js
+++ b/tests/hitl-guard.test.js
@@ -53,10 +53,13 @@ function makeConfig(level, whitelist = []) {
   };
 }
 
-function makeMockHitlClient(autoApprove = true) {
+function makeMockHitlClient(autoApprove = true, reachable = true) {
   const calls = [];
   return {
     calls,
+    isReachable() {
+      return Promise.resolve(reachable);
+    },
     requestApproval(tool, args, destructive, openWorld) {
       calls.push({ tool, args, destructive, openWorld });
       return Promise.resolve(autoApprove);
@@ -287,6 +290,91 @@ describe('managed client detection', () => {
 
     expect(elicitCalls).toHaveLength(1); // not managed → elicitation attempted
     expect(hitl.calls).toHaveLength(0);
+  });
+});
+
+// ---------- managed client headless fallback (RFC 0008 Phase 1.5) ----------
+
+describe('managed client headless fallback', () => {
+  test('managed + socket unreachable + elicitation support → elicitation approves, tool runs', async () => {
+    const { server, registrations, elicitCalls } = makeMockServer({
+      clientName: 'claude-code',
+      withElicitation: true,
+    });
+    const hitl = makeMockHitlClient(true, /* reachable */ false);
+    const config = makeConfig('all');
+
+    installHitlGuard(server, hitl, config);
+
+    const original = () => 'ran';
+    server.registerTool('headless_tool', { annotations: { destructiveHint: true } }, original);
+    const result = await registrations[0].callback({ id: 1 });
+
+    expect(elicitCalls).toHaveLength(1); // elicitation used as the fallback channel
+    expect(hitl.calls).toHaveLength(0);  // the unreachable socket is never asked
+    expect(result).toBe('ran');
+  });
+
+  test('managed + socket unreachable + elicitation denial blocks the tool', async () => {
+    const registrations = [];
+    const server = {
+      registerTool(name, toolConfig, callback) {
+        registrations.push({ name, toolConfig, callback });
+      },
+      server: {
+        getClientVersion: () => ({ name: 'claude-desktop', version: '1.0' }),
+        elicitInput: jest.fn(async () => ({ action: 'reject', content: {} })),
+      },
+    };
+    const hitl = makeMockHitlClient(true, false);
+    const config = makeConfig('all');
+
+    installHitlGuard(server, hitl, config);
+
+    let ran = false;
+    server.registerTool('headless_denied', { annotations: { destructiveHint: true } }, () => { ran = true; });
+    const result = await registrations[0].callback({});
+
+    expect(ran).toBe(false);
+    expect(result).toHaveProperty('isError', true);
+    expect(hitl.calls).toHaveLength(0);
+  });
+
+  test('managed + socket unreachable + no elicitation → actionable deny, tool never runs', async () => {
+    const { server, registrations } = makeMockServer({ clientName: 'claude-cowork' }); // no elicitInput
+    const hitl = makeMockHitlClient(true, false);
+    const config = makeConfig('all');
+
+    installHitlGuard(server, hitl, config);
+
+    let ran = false;
+    server.registerTool('no_channel_tool', { annotations: { destructiveHint: true } }, () => { ran = true; });
+    const result = await registrations[0].callback({});
+
+    expect(ran).toBe(false);
+    expect(result).toHaveProperty('isError', true);
+    expect(result.content[0].text).toContain('no approval channel');
+    expect(result.content[0].text).toContain('menubar');
+    expect(hitl.calls).toHaveLength(0); // the doomed socket is not asked
+  });
+
+  test('managed + socket reachable keeps using the socket (no double prompt)', async () => {
+    const { server, registrations, elicitCalls } = makeMockServer({
+      clientName: 'claude-code',
+      withElicitation: true,
+    });
+    const hitl = makeMockHitlClient(true, true);
+    const config = makeConfig('all');
+
+    installHitlGuard(server, hitl, config);
+
+    const original = () => 'socket_ok';
+    server.registerTool('app_running_tool', { annotations: { destructiveHint: true } }, original);
+    const result = await registrations[0].callback({});
+
+    expect(elicitCalls).toHaveLength(0); // elicitation still skipped — app is the approver
+    expect(hitl.calls).toHaveLength(1);
+    expect(result).toBe('socket_ok');
   });
 });
 


### PR DESCRIPTION
The flagship per-call HITL had a hole in the dominant deployment. Managed
clients (the Claude family) skip MCP elicitation to avoid double prompts, and
the socket channel denies when unreachable — so a default `npx airmcp` setup
(no menubar app, hitl level destructive-only) hard-denied every gated tool out
of the box. Issue #28's reporter resolved it by setting hitl level "off": the
safety feature was being disabled by its own UX. WWDC26 session 347 now tells
every agentic developer to ship per-call confirmation — ours has to actually
work where agents run.

Channel order now adapts to what is available, with per-call granularity
unchanged in every path (this changes the approval channel, never the
granularity — CLAUDE.md escalation reviewed):

  non-managed: elicitation → socket → deny                    (unchanged)
  managed:     socket (if reachable) → elicitation → deny
               with an actionable hint (menubar app / elicitation-capable
               client / hitl.whitelist / hitl.level)

Implementation: HitlClient.isReachable() probes the socket without sending a
request (a successful probe leaves the connection open for the approval call);
the guard uses a NOT_HANDLED sentinel so a tool legitimately returning
undefined can never double-execute; telemetry gains an "unavailable" channel
value for the no-channel deny. When the menubar app IS running, managed
clients still use the socket exclusively — no double prompt.

Tests: 6 new behavior tests — managed+unreachable approves/denies via
elicitation (socket never asked), no-channel deny carries the actionable
message and never runs the tool, reachable socket keeps today's exact
behavior; isReachable false on dead path / true with a live listener whose
connection is reused. Suite: 1935 pass. RFC 0008 amended (Phase 1.5).
