### PR TITLE
fix: speech_availability stops overclaiming authorization (TCC responsible-process)

### DIFF
--- a/docs/tool-manifest.json
+++ b/docs/tool-manifest.json
@@ -12413,7 +12413,7 @@
     {
       "name": "speech_availability",
       "title": "Speech Recognition Status",
-      "description": "Check if on-device speech recognition is available and authorized.",
+      "description": "Report whether this device supports on-device speech recognition. A true result is DEVICE capability only — NOT proof the caller is authorized: macOS gates transcription by Speech Recognition permission on the responsible process (the signed AirMCP app), so only a successful transcribe_audio confirms authorization.",
       "inputSchema": {
         "$schema": "http://json-schema.org/draft-07/schema#",
         "type": "object",
@@ -12861,7 +12861,7 @@
     {
       "name": "transcribe_audio",
       "title": "Transcribe Audio",
-      "description": "Transcribe an audio file to text using Apple's on-device speech recognition. Supports most audio formats (m4a, mp3, wav, caf).",
+      "description": "Transcribe an audio file to text using Apple's on-device speech recognition. Supports most audio formats (m4a, mp3, wav, caf). Requires the responsible process to hold macOS Speech Recognition permission (the signed AirMCP app surface); from an unentitled CLI caller it aborts with a permission error.",
       "inputSchema": {
         "$schema": "http://json-schema.org/draft-07/schema#",
         "type": "object",

--- a/src/speech/tools.ts
+++ b/src/speech/tools.ts
@@ -10,7 +10,8 @@ export function registerSpeechTools(server: McpServer, _config: AirMcpConfig): v
     {
       title: "Transcribe Audio",
       description:
-        "Transcribe an audio file to text using Apple's on-device speech recognition. Supports most audio formats (m4a, mp3, wav, caf).",
+        "Transcribe an audio file to text using Apple's on-device speech recognition. Supports most audio formats (m4a, mp3, wav, caf). " +
+        "Requires the responsible process to hold macOS Speech Recognition permission (the signed AirMCP app surface); from an unentitled CLI caller it aborts with a permission error.",
       inputSchema: {
         path: z.string().max(1000).describe("Absolute path to the audio file"),
         language: z
@@ -39,7 +40,8 @@ export function registerSpeechTools(server: McpServer, _config: AirMcpConfig): v
     "speech_availability",
     {
       title: "Speech Recognition Status",
-      description: "Check if on-device speech recognition is available and authorized.",
+      description:
+        "Report whether this device supports on-device speech recognition. A true result is DEVICE capability only — NOT proof the caller is authorized: macOS gates transcription by Speech Recognition permission on the responsible process (the signed AirMCP app), so only a successful transcribe_audio confirms authorization.",
       inputSchema: {},
       annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: false },
     },
@@ -48,7 +50,19 @@ export function registerSpeechTools(server: McpServer, _config: AirMcpConfig): v
       if (bridgeErr) return errSwift(`Swift bridge required: ${bridgeErr}`);
       try {
         const result = await runSwift<{ available: boolean; supportsOnDevice: boolean }>("speech-availability", "{}");
-        return ok(result);
+        // `available`/`supportsOnDevice` report DEVICE capability only — not that
+        // the current responsible process is permitted. macOS TCC gates on-device
+        // transcription against the responsible process: the signed AirMCP app
+        // (NSSpeechRecognitionUsageDescription + a user-granted permission) can
+        // transcribe; a generic CLI parent (terminal/node) is not entitled and
+        // transcribe_audio aborts with a permission error. So availability is
+        // necessary but NOT sufficient — only a successful transcribe_audio proves
+        // the caller is authorized. Travel the caveat with the result so callers
+        // never read `available:true` as "transcription will work".
+        return ok({
+          ...result,
+          note: "available/supportsOnDevice = device capability only; transcription also requires the responsible process (the signed AirMCP app) to hold macOS Speech Recognition permission — a generic CLI caller is not entitled and transcribe_audio will fail. available:true does not guarantee transcription succeeds.",
+        });
       } catch (e) {
         return errSwiftFor("check speech availability", e);
       }

--- a/swift/Sources/AirMCPKit/Generated/MCPIntents.swift
+++ b/swift/Sources/AirMCPKit/Generated/MCPIntents.swift
@@ -7073,7 +7073,7 @@ public struct SmartClipboardIntent: AppIntent {
 // Tool: speech_availability
 public struct SpeechAvailabilityIntent: AppIntent {
     nonisolated(unsafe) public static var title: LocalizedStringResource = "Speech Recognition Status"
-    nonisolated(unsafe) public static var description = IntentDescription("Check if on-device speech recognition is available and authorized.")
+    nonisolated(unsafe) public static var description = IntentDescription("Report whether this device supports on-device speech recognition. A true result is DEVICE capability only — NOT proof the caller is authorized: macOS gates transcription by Speech Recognition permission on the responsible process (the signed AirMCP app), so only a successful transcribe_audio confirms authorization.")
     nonisolated(unsafe) public static var openAppWhenRun: Bool = false
 
     public init() {}
@@ -7309,7 +7309,7 @@ public struct ToggleFocusModeIntent: AppIntent {
 // Tool: transcribe_audio
 public struct TranscribeAudioIntent: AppIntent {
     nonisolated(unsafe) public static var title: LocalizedStringResource = "Transcribe Audio"
-    nonisolated(unsafe) public static var description = IntentDescription("Transcribe an audio file to text using Apple's on-device speech recognition. Supports most audio formats (m4a, mp3, wav, caf).")
+    nonisolated(unsafe) public static var description = IntentDescription("Transcribe an audio file to text using Apple's on-device speech recognition. Supports most audio formats (m4a, mp3, wav, caf). Requires the responsible process to hold macOS Speech Recognition permission (the signed AirMCP app surface); from an unentitled CLI caller it aborts with a permission error.")
     nonisolated(unsafe) public static var openAppWhenRun: Bool = false
 
     public init() {}

--- a/tests/speech-tools.test.js
+++ b/tests/speech-tools.test.js
@@ -58,6 +58,19 @@ describe('Speech tools registration', () => {
       expect(typeof config.description).toBe('string');
     }
   });
+
+  test('speech descriptions do not overclaim authorization (responsible-process caveat)', () => {
+    const avail = server.tools.get('speech_availability').config.description;
+    const transcribe = server.tools.get('transcribe_audio').config.description;
+    // availability must NOT promise plain "available and authorized" — it can
+    // only report DEVICE capability; authorization is per responsible process
+    // and only confirmed by a successful transcribe_audio.
+    expect(avail).not.toMatch(/available and authorized/i);
+    expect(avail).toMatch(/permission|authoriz|responsible process/i);
+    // transcribe must state the permission requirement so a caller isn't
+    // surprised by a TCC abort from an unentitled CLI responsible process.
+    expect(transcribe).toMatch(/permission|responsible process|entitled/i);
+  });
 });
 
 describe('transcribe_audio', () => {
@@ -126,6 +139,12 @@ describe('speech_availability', () => {
     const parsed = JSON.parse(result.content[0].text);
     expect(parsed.available).toBe(true);
     expect(parsed.supportsOnDevice).toBe(true);
+    // Honesty caveat must travel WITH the result: available:true is device
+    // capability only, not proof the responsible process is TCC-authorized.
+    // (Empirically: availability returns true while transcribe_audio aborts
+    // 134 from an unentitled CLI responsible process.)
+    expect(typeof parsed.note).toBe('string');
+    expect(parsed.note).toMatch(/permission|responsible process|not guarantee/i);
   });
 
   test('returns error when swift bridge unavailable', async () => {


### PR DESCRIPTION
A finding from this session's video-prep exploration: `speech_availability` reports `{available:true, supportsOnDevice:true}` and its description claimed the device was "available **and authorized**" — but on-device transcription is gated by macOS **TCC against the responsible process**. A generic CLI caller (the terminal/node parent) is not entitled, so `transcribe_audio` aborts (exit 134) *even when availability reports true*. Verified empirically: Info.plist embedding / ad-hoc signing / `.app` wrapper experiments all hit the same abort with the CLI as responsible process.

So `available:true` was a **runtime-broken promise** — registration-shape capability, not the actual runtime contract (exactly the "registration ≠ runtime" class this repo guards against).

This change (TS-layer, fully verifiable):
- Reworded `speech_availability` + `transcribe_audio` descriptions to state the per-responsible-process Speech-permission requirement (the signed AirMCP app surface, not a generic CLI).
- Travels a caveat `note` with the availability result so a consumer never reads `available:true` as "transcription will work".
- Tests for the note + the de-overclaimed descriptions; regenerated `tool-manifest.json` + `MCPIntents.swift`.

**Not included** (needs on-device macOS/TCC verification → macOS bucket): the deeper Swift fix — `speech-availability` returning the real `SFSpeechRecognizer.authorizationStatus()`, or an app-owned Speech helper/XPC permission path. Writing that blind would re-make the same "claim without runtime proof" mistake.

Verified: typecheck, full suite (2031 tests), gen/manifest/intents, `stats:check`, `mcp:validate`, `npm audit` all green.