### PR TITLE
fix: declare NSSpeechRecognitionUsageDescription in the app Info.plist

### DIFF
--- a/app/Sources/AirMCPApp/Resources/Info.plist
+++ b/app/Sources/AirMCPApp/Resources/Info.plist
@@ -17,6 +17,8 @@
     <string>AirMCP shows your calendar events in the Daily Briefing widget and enables AI-powered calendar management.</string>
     <key>NSRemindersFullAccessUsageDescription</key>
     <string>AirMCP shows your reminders in the Daily Briefing widget and enables AI-powered reminder management.</string>
+    <key>NSSpeechRecognitionUsageDescription</key>
+    <string>AirMCP transcribes audio files you explicitly provide, on-device, to return their text for your automation requests.</string>
     <key>NSServices</key>
     <array>
         <dict>

--- a/tests/app-info-plist-usage.test.js
+++ b/tests/app-info-plist-usage.test.js
@@ -1,0 +1,43 @@
+import { describe, test, expect } from "@jest/globals";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { join } from "node:path";
+
+// The macOS app's Info.plist MUST declare a usage description for every
+// privacy-gated (TCC) capability any tool touches. If the declaration is
+// MISSING, macOS does not return "permission denied" — it HARD-ABORTS the
+// process (SIGABRT / exit 134, "attempted to access privacy-sensitive data
+// without a usage description") the instant the API is touched, BEFORE the
+// Swift code's graceful `.notAuthorized` path can run.
+//
+// This is a registration-vs-runtime guard: `transcribe_audio` was a registered,
+// shipping tool whose NSSpeechRecognitionUsageDescription was absent repo-wide,
+// so it crashed on EVERY surface (confirmed via the on-disk crash report's
+// TCC termination block) until the key was added here. This test fails loudly
+// if any required privacy declaration is dropped again.
+const ROOT = fileURLToPath(new URL("..", import.meta.url));
+const PLIST = join(ROOT, "app", "Sources", "AirMCPApp", "Resources", "Info.plist");
+const plist = readFileSync(PLIST, "utf-8");
+
+// Each entry: the usage-description key a TCC-gated tool family requires.
+const REQUIRED = [
+  "NSCalendarsFullAccessUsageDescription",
+  "NSRemindersFullAccessUsageDescription",
+  "NSSpeechRecognitionUsageDescription",
+];
+
+describe("app Info.plist — privacy usage descriptions for TCC-gated tools", () => {
+  for (const key of REQUIRED) {
+    test(`declares ${key} (missing → TCC 134 abort, not a graceful error)`, () => {
+      expect(plist).toContain(`<key>${key}</key>`);
+    });
+  }
+
+  test("each declaration carries a non-empty explanatory string", () => {
+    for (const key of REQUIRED) {
+      const m = plist.match(new RegExp(`<key>${key}</key>\\s*<string>([^<]+)</string>`));
+      expect(m).not.toBeNull();
+      expect(m[1].trim().length).toBeGreaterThan(10);
+    }
+  });
+});


### PR DESCRIPTION
**Empirical finding this session.** `transcribe_audio`'s `NSSpeechRecognitionUsageDescription` was absent from the **entire repo**, so the bundled `.app` (not just the CLI bridge) **HARD-ABORTS** — SIGABRT / exit 134, TCC *"attempted to access privacy-sensitive data without a usage description"* — the instant it touches `SFSpeechRecognizer`, **before** the Swift code's graceful `.notAuthorized` path can run. Confirmed verbatim in the on-disk crash report's TCC `termination` block.

This PR adds the missing key (matching the existing Calendar/Reminders usage descriptions already in the plist) + a static guard test so the declaration can't be dropped again.

### Scope — stated honestly (this does NOT make transcription "work")
- ✅ **Fixes the `.app` declaration** — necessary; the key was verified missing repo-wide; `plutil -lint` OK; guard test added.
- ⚠️ **`.app` end-to-end is owner-verify** — that the `.app`, once launched as a GUI app and granted Speech permission, then transcribes successfully needs on-device macOS verification. I can't grant a TCC permission or launch the GUI app.
- ❌ **Headless / CLI / Codex path is NOT fixable by code** — macOS attributes the Speech TCC check to the **responsible process** (the launching parent — verified `responsibleProc=claude`), not the helper binary. An embed-the-plist-in-the-binary attempt **still aborted 134** (reverted). Giving the headless pipeline transcription needs an **app-owned XPC service** (responsible = the granted `.app`) — a separate, macOS-gated piece.

Because the end-to-end is owner-verify, I'm leaving this as **draft** for you to confirm on a real `.app` before merge.