### PR TITLE
fix: declare Photos + Contacts usage descriptions (privacy sweep follow-up to #308)

### DIFF
--- a/app/Sources/AirMCPApp/Resources/Info.plist
+++ b/app/Sources/AirMCPApp/Resources/Info.plist
@@ -19,6 +19,12 @@
     <string>AirMCP shows your reminders in the Daily Briefing widget and enables AI-powered reminder management.</string>
     <key>NSSpeechRecognitionUsageDescription</key>
     <string>AirMCP transcribes audio files you explicitly provide, on-device, to return their text for your automation requests.</string>
+    <key>NSPhotoLibraryUsageDescription</key>
+    <string>AirMCP reads photos you ask it to list, search, classify, or export from your library.</string>
+    <key>NSPhotoLibraryAddUsageDescription</key>
+    <string>AirMCP adds a photo to your library only when you ask it to import an image.</string>
+    <key>NSContactsUsageDescription</key>
+    <string>AirMCP reads and edits contacts you ask it to look up, create, or update.</string>
     <key>NSServices</key>
     <array>
         <dict>

--- a/tests/app-info-plist-usage.test.js
+++ b/tests/app-info-plist-usage.test.js
@@ -20,10 +20,20 @@ const PLIST = join(ROOT, "app", "Sources", "AirMCPApp", "Resources", "Info.plist
 const plist = readFileSync(PLIST, "utf-8");
 
 // Each entry: the usage-description key a TCC-gated tool family requires.
+// Cross-referenced against the TCC-gated frameworks the Swift bridge actually
+// uses (EventKit, Speech, PhotoKit, Contacts). Speech was the only one that
+// HARD-CRASHED without its key (it calls requestAuthorization); PhotoKit /
+// Contacts degrade gracefully (empty / "Access Denied") but still cannot be
+// granted on the .app surface without a declaration, so the tools stay
+// non-functional there until these are present. (Location/CLLocationManager is
+// tracked separately — it hangs rather than crashes and needs a Swift timeout.)
 const REQUIRED = [
   "NSCalendarsFullAccessUsageDescription",
   "NSRemindersFullAccessUsageDescription",
   "NSSpeechRecognitionUsageDescription",
+  "NSPhotoLibraryUsageDescription",
+  "NSPhotoLibraryAddUsageDescription",
+  "NSContactsUsageDescription",
 ];
 
 describe("app Info.plist — privacy usage descriptions for TCC-gated tools", () => {

--- a/tests/app-info-plist-usage.test.js
+++ b/tests/app-info-plist-usage.test.js
@@ -4,11 +4,10 @@ import { fileURLToPath } from "node:url";
 import { join } from "node:path";
 
 // The macOS app's Info.plist MUST declare a usage description for every
-// privacy-gated (TCC) capability any tool touches. If the declaration is
-// MISSING, macOS does not return "permission denied" — it HARD-ABORTS the
-// process (SIGABRT / exit 134, "attempted to access privacy-sensitive data
-// without a usage description") the instant the API is touched, BEFORE the
-// Swift code's graceful `.notAuthorized` path can run.
+// privacy-gated (TCC) capability any tool touches. Missing declarations have
+// API-specific failure modes: Speech hard-aborted (SIGABRT / exit 134) when it
+// called requestAuthorization, while PhotoKit / Contacts degraded gracefully but
+// could not be granted on the .app surface.
 //
 // This is a registration-vs-runtime guard: `transcribe_audio` was a registered,
 // shipping tool whose NSSpeechRecognitionUsageDescription was absent repo-wide,
@@ -38,7 +37,7 @@ const REQUIRED = [
 
 describe("app Info.plist — privacy usage descriptions for TCC-gated tools", () => {
   for (const key of REQUIRED) {
-    test(`declares ${key} (missing → TCC 134 abort, not a graceful error)`, () => {
+    test(`declares ${key} (missing → TCC crash or ungrantable app capability)`, () => {
       expect(plist).toContain(`<key>${key}</key>`);
     });
   }


### PR DESCRIPTION
**Privacy usage-description sweep** prompted by the Speech crash (#308). Cross-referenced every TCC-gated framework the Swift bridge actually uses against the app `Info.plist`, then **probed each bridge command live** to see what really happens:

| bridge command | result | class |
|---|---|---|
| `transcribe-audio` | SIGABRT / 134 | **crash** → fixed in #308 |
| `list-photos` | exit 0, empty result | graceful (no crash) |
| `list-contacts` | exit 1, `"Access Denied"` | graceful (no crash) |
| `get-location` | **hangs** (killed by 4 s watchdog) | separate bug (not a crash) |

**Correcting myself:** I first guessed from static analysis that 4 more tools would 134-crash. The live probe disproved it — **only Speech crashes** (it calls `requestAuthorization`; Photos/Contacts check `authorizationStatus` and degrade gracefully). 

**Still a real (lower-severity) issue:** without the usage descriptions the `.app` can't *request* Photo/Contacts permission at all, so those tools stay non-functional on the `.app` surface (always empty / denied). This PR adds `NSPhotoLibraryUsageDescription`, `NSPhotoLibraryAddUsageDescription`, `NSContactsUsageDescription` + extends the guard test (now 6 required keys).

### Scope, honestly
- ✅ Adds the documented-required keys for frameworks the bridge demonstrably uses; `plutil -lint` OK; guard test green.
- ⚠️ End-to-end (`.app` launched + user grants → tool returns data) is **owner-verify**, same as #308. Draft until confirmed.
- ❌ **`get-location` hang** is NOT fixed here — it's a Swift-side timeout/graceful-fail issue (CLLocationManager blocking), tracked separately. Its exact macOS location key is also unverified, so it was deliberately left out rather than guessed.