### PR TITLE
fix: make CoreLocation requests time out cleanly

### DIFF
--- a/app/Sources/AirMCPApp/Resources/Info.plist
+++ b/app/Sources/AirMCPApp/Resources/Info.plist
@@ -25,6 +25,8 @@
     <string>AirMCP adds a photo to your library only when you ask it to import an image.</string>
     <key>NSContactsUsageDescription</key>
     <string>AirMCP reads and edits contacts you ask it to look up, create, or update.</string>
+    <key>NSLocationWhenInUseUsageDescription</key>
+    <string>AirMCP reads your current location only when you explicitly ask for location-based tools.</string>
     <key>NSServices</key>
     <array>
         <dict>

--- a/swift/Sources/AirMCPKit/LocationService.swift
+++ b/swift/Sources/AirMCPKit/LocationService.swift
@@ -8,48 +8,83 @@ import CoreLocation
 public class LocationFetcher: NSObject, CLLocationManagerDelegate, @unchecked Sendable {
     private var continuation: CheckedContinuation<CLLocation, Error>?
     private var manager: CLLocationManager?
+    private var timeoutWorkItem: DispatchWorkItem?
     private let queue = DispatchQueue(label: "com.airmcp.location")
 
     public override init() { super.init() }
 
     public func fetch(timeout: TimeInterval = 15) async throws -> CLLocation {
-        try await withThrowingTaskGroup(of: CLLocation.self) { group in
-            group.addTask {
-                try await withCheckedThrowingContinuation { cont in
-                    self.queue.sync { self.continuation = cont }
+        try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { cont in
+                DispatchQueue.main.async {
                     let mgr = CLLocationManager()
                     mgr.delegate = self
                     mgr.desiredAccuracy = kCLLocationAccuracyBest
-                    self.manager = mgr
+
+                    let timeoutItem = DispatchWorkItem { [weak self] in
+                        self?.finish(.failure(AirMCPKitError.unsupported("Location request timed out after \(Int(timeout))s")))
+                    }
+
+                    var accepted = false
+                    self.queue.sync {
+                        if self.continuation == nil {
+                            self.continuation = cont
+                            self.manager = mgr
+                            self.timeoutWorkItem = timeoutItem
+                            accepted = true
+                        }
+                    }
+
+                    guard accepted else {
+                        cont.resume(throwing: AirMCPKitError.unsupported("Location request already in progress"))
+                        return
+                    }
+
+                    DispatchQueue.main.asyncAfter(deadline: .now() + max(timeout, 0.1), execute: timeoutItem)
                     mgr.requestLocation()
                 }
             }
-            group.addTask {
-                try await Task.sleep(for: .seconds(timeout))
-                throw AirMCPKitError.unsupported("Location request timed out after \(Int(timeout))s")
-            }
-            guard let result = try await group.next() else {
-                throw AirMCPKitError.unsupported("Location request failed")
-            }
-            group.cancelAll()
-            // Stop delegate callbacks to prevent stale resume attempts
-            self.manager?.delegate = nil
-            self.manager = nil
-            return result
+        } onCancel: {
+            finish(.failure(AirMCPKitError.unsupported("Location request cancelled")))
         }
     }
 
     public func locationManager(_ manager: CLLocationManager, didUpdateLocations locations: [CLLocation]) {
-        queue.sync {
-            continuation?.resume(returning: locations[0])
-            continuation = nil
+        guard let location = locations.first else {
+            finish(.failure(AirMCPKitError.unsupported("Location request returned no locations")))
+            return
         }
+        finish(.success(location))
     }
 
     public func locationManager(_ manager: CLLocationManager, didFailWithError error: Error) {
+        finish(.failure(error))
+    }
+
+    private func finish(_ result: Result<CLLocation, Error>) {
+        var cont: CheckedContinuation<CLLocation, Error>?
+        var mgr: CLLocationManager?
+        var timeoutItem: DispatchWorkItem?
+
         queue.sync {
-            continuation?.resume(throwing: error)
+            cont = continuation
             continuation = nil
+            mgr = manager
+            manager = nil
+            timeoutItem = timeoutWorkItem
+            timeoutWorkItem = nil
+        }
+
+        timeoutItem?.cancel()
+        mgr?.stopUpdatingLocation()
+        mgr?.delegate = nil
+
+        guard let cont else { return }
+        switch result {
+        case .success(let location):
+            cont.resume(returning: location)
+        case .failure(let error):
+            cont.resume(throwing: error)
         }
     }
 }
@@ -60,6 +95,9 @@ public func locationStatusString(_ status: CLAuthorizationStatus) -> String {
     case .restricted: return "restricted"
     case .denied: return "denied"
     case .authorizedAlways: return "authorized_always"
+    #if os(iOS)
+    case .authorizedWhenInUse: return "authorized_when_in_use"
+    #endif
     @unknown default: return "unknown"
     }
 }

--- a/swift/Sources/AirMcpBridge/main.swift
+++ b/swift/Sources/AirMcpBridge/main.swift
@@ -979,7 +979,11 @@ case "location-permission":
     } else {
         status = CLLocationManager.authorizationStatus()
     }
+    #if os(iOS)
+    let authorized = status == .authorizedAlways || status == .authorizedWhenInUse
+    #else
     let authorized = status == .authorizedAlways
+    #endif
     let output = LocationPermissionOutput(status: locationStatusString(status), authorized: authorized)
     do { try writeJSON(output) } catch { writeError("Location permission error: \(error.localizedDescription)") }
 

--- a/swift/Tests/AirMCPKitTests/LocationServiceTests.swift
+++ b/swift/Tests/AirMCPKitTests/LocationServiceTests.swift
@@ -1,0 +1,30 @@
+// AirMCPKit — CoreLocation service tests.
+
+import XCTest
+import CoreLocation
+@testable import AirMCPKit
+
+final class LocationServiceTests: XCTestCase {
+
+    func testLocationStatusIncludesWhenInUseAuthorization() {
+        #if os(iOS)
+        XCTAssertEqual(locationStatusString(.authorizedWhenInUse), "authorized_when_in_use")
+        #endif
+        XCTAssertEqual(locationStatusString(.authorizedAlways), "authorized_always")
+        XCTAssertEqual(locationStatusString(.notDetermined), "not_determined")
+        XCTAssertEqual(locationStatusString(.denied), "denied")
+        XCTAssertEqual(locationStatusString(.restricted), "restricted")
+    }
+
+    func testFetchTimeoutReturnsWithoutHanging() async {
+        let fetcher = LocationFetcher()
+        let started = Date()
+        do {
+            _ = try await fetcher.fetch(timeout: 0.1)
+        } catch {
+            // Permission-denied, unavailable, or timeout are all acceptable in CI.
+            // The contract under test is that fetch returns instead of hanging.
+        }
+        XCTAssertLessThan(Date().timeIntervalSince(started), 2.0)
+    }
+}

--- a/tests/app-info-plist-usage.test.js
+++ b/tests/app-info-plist-usage.test.js
@@ -20,12 +20,12 @@ const plist = readFileSync(PLIST, "utf-8");
 
 // Each entry: the usage-description key a TCC-gated tool family requires.
 // Cross-referenced against the TCC-gated frameworks the Swift bridge actually
-// uses (EventKit, Speech, PhotoKit, Contacts). Speech was the only one that
+// uses (EventKit, Speech, PhotoKit, Contacts, CoreLocation). Speech was the only one that
 // HARD-CRASHED without its key (it calls requestAuthorization); PhotoKit /
 // Contacts degrade gracefully (empty / "Access Denied") but still cannot be
 // granted on the .app surface without a declaration, so the tools stay
 // non-functional there until these are present. (Location/CLLocationManager is
-// tracked separately — it hangs rather than crashes and needs a Swift timeout.)
+// included because get_current_location prompts through CoreLocation.)
 const REQUIRED = [
   "NSCalendarsFullAccessUsageDescription",
   "NSRemindersFullAccessUsageDescription",
@@ -33,6 +33,7 @@ const REQUIRED = [
   "NSPhotoLibraryUsageDescription",
   "NSPhotoLibraryAddUsageDescription",
   "NSContactsUsageDescription",
+  "NSLocationWhenInUseUsageDescription",
 ];
 
 describe("app Info.plist — privacy usage descriptions for TCC-gated tools", () => {


### PR DESCRIPTION
## Summary
- replace the CoreLocation task-group timeout with a continuation-level timeout so get_current_location returns instead of hanging
- add NSLocationWhenInUseUsageDescription to the macOS app Info.plist and guard it in the plist test
- add Swift tests for LocationFetcher timeout behavior and location status string mapping

## Verification
- plutil -lint app/Sources/AirMCPApp/Resources/Info.plist
- npm test -- tests/app-info-plist-usage.test.js tests/location-tools.test.js
- npm run typecheck
- npm run gen:manifest:check
- npm run gen:intents:check
- DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift test --filter LocationServiceTests
- DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift test
- DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift build -c release
- printf '{}' | swift/.build/release/AirMcpBridge get-location (returns in ~3s with CoreLocation permission error instead of hanging)
- npm test
- npm run app-build
- ./scripts/bundle-app.sh verify (exit 0; ad-hoc Gatekeeper/AppIntents warnings expected for local unsigned build)
