### PR TITLE
fix: close location cancellation and llms caveat gaps

### DIFF
--- a/app/Sources/AirMCPApp/Resources/Info.plist
+++ b/app/Sources/AirMCPApp/Resources/Info.plist
@@ -27,6 +27,8 @@
     <string>AirMCP reads and edits contacts you ask it to look up, create, or update.</string>
     <key>NSLocationWhenInUseUsageDescription</key>
     <string>AirMCP reads your current location only when you explicitly ask for location-based tools.</string>
+    <key>NSHealthShareUsageDescription</key>
+    <string>AirMCP reads aggregated HealthKit summaries only when you explicitly ask for health-related tools.</string>
     <key>NSServices</key>
     <array>
         <dict>

--- a/scripts/gen-llms-txt.mjs
+++ b/scripts/gen-llms-txt.mjs
@@ -6,7 +6,7 @@
  */
 
 import { readFileSync, writeFileSync, readdirSync } from "node:fs";
-import { join, dirname, basename } from "node:path";
+import { join, dirname, basename, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..");
@@ -51,19 +51,26 @@ const HEADLINE_TOOL_COUNT = (() => {
 })();
 
 // Extract tool registrations from a file
-function extractTools(filePath) {
+export function decodeStringLiteralExpression(expr) {
+  return [...expr.matchAll(/"((?:\\.|[^"\\])*)"/g)].map((m) => JSON.parse(`"${m[1]}"`)).join("");
+}
+
+export function extractTools(filePath) {
   const content = readFileSync(filePath, "utf-8");
   const tools = [];
-  // Match tool name and title (robust: handles multi-line descriptions)
-  const re = /server\.registerTool\(\s*\n?\s*"([^"]+)",\s*\n?\s*\{[\s\S]*?title:\s*"([^"]+)",[\s\S]*?description:\s*(?:"([^"]*)"|\s*\n\s*"([^"]*)")/g;
+  // Match tool name, title, and a string-literal description expression.
+  // Descriptions often wrap across lines as `"first " + "second"`; parse the
+  // full literal expression so honesty caveats do not disappear from llms-full.
+  const re =
+    /server\.registerTool\(\s*\n?\s*"([^"]+)",\s*\n?\s*\{[\s\S]*?title:\s*"([^"]+)",[\s\S]*?description:\s*((?:"(?:\\.|[^"\\])*"\s*(?:\+\s*)?)+)/g;
   let m;
   while ((m = re.exec(content)) !== null) {
-    tools.push({ name: m[1], title: m[2], description: m[3] || m[4] || "" });
+    tools.push({ name: m[1], title: m[2], description: decodeStringLiteralExpression(m[3]) });
   }
   // Fallback: count any missed registrations
-  const allNames = [...content.matchAll(/server\.registerTool\(\s*\n?\s*"([^"]+)"/g)].map(m => m[1]);
+  const allNames = [...content.matchAll(/server\.registerTool\(\s*\n?\s*"([^"]+)"/g)].map((m) => m[1]);
   for (const name of allNames) {
-    if (!tools.find(t => t.name === name)) {
+    if (!tools.find((t) => t.name === name)) {
       tools.push({ name, title: name.replace(/_/g, " "), description: "" });
     }
   }
@@ -84,16 +91,35 @@ function extractPrompts(filePath) {
 
 // Module display names
 const MODULE_NAMES = {
-  notes: "Notes", reminders: "Reminders", calendar: "Calendar",
-  contacts: "Contacts", mail: "Mail", messages: "Messages",
-  music: "Music", finder: "Finder", safari: "Safari",
-  system: "System", photos: "Photos", shortcuts: "Shortcuts",
-  intelligence: "Apple Intelligence", tv: "TV", ui: "UI Automation",
-  screen: "Screen Capture", maps: "Maps", podcasts: "Podcasts",
-  weather: "Weather", pages: "Pages", numbers: "Numbers",
-  keynote: "Keynote", location: "Location", bluetooth: "Bluetooth",
-  google: "Google Workspace", semantic: "Semantic Search",
-  cross: "Cross-Module", apps: "App Management", shared: "Setup",
+  notes: "Notes",
+  reminders: "Reminders",
+  calendar: "Calendar",
+  contacts: "Contacts",
+  mail: "Mail",
+  messages: "Messages",
+  music: "Music",
+  finder: "Finder",
+  safari: "Safari",
+  system: "System",
+  photos: "Photos",
+  shortcuts: "Shortcuts",
+  intelligence: "Apple Intelligence",
+  tv: "TV",
+  ui: "UI Automation",
+  screen: "Screen Capture",
+  maps: "Maps",
+  podcasts: "Podcasts",
+  weather: "Weather",
+  pages: "Pages",
+  numbers: "Numbers",
+  keynote: "Keynote",
+  location: "Location",
+  bluetooth: "Bluetooth",
+  google: "Google Workspace",
+  semantic: "Semantic Search",
+  cross: "Cross-Module",
+  apps: "App Management",
+  shared: "Setup",
 };
 
 // Collect all tools by module for the per-module breakdown.
@@ -107,18 +133,15 @@ const MODULE_NAMES = {
 // as the fresh-checkout fallback when the manifest isn't present.
 const TOOL_REGEX = /server\.registerTool\(/g;
 const PROMPT_REGEX = /server\.prompt\(/g;
-const modules = {};
-let totalTools = 0;
-let totalPrompts = 0;
-function walkDir(dir) {
+function walkDir(dir, modules, counts) {
   for (const entry of readdirSync(dir, { withFileTypes: true })) {
     const full = join(dir, entry.name);
-    if (entry.isDirectory()) walkDir(full);
+    if (entry.isDirectory()) walkDir(full, modules, counts);
     else if (entry.name.endsWith(".ts")) {
       const modDir = basename(dirname(full));
       const content = readFileSync(full, "utf-8");
-      totalTools += (content.match(TOOL_REGEX) || []).length;
-      totalPrompts += (content.match(PROMPT_REGEX) || []).length;
+      counts.totalTools += (content.match(TOOL_REGEX) || []).length;
+      counts.totalPrompts += (content.match(PROMPT_REGEX) || []).length;
       const tools = extractTools(full);
       if (tools.length > 0) {
         const key = modDir === "src" ? "core" : modDir;
@@ -134,13 +157,17 @@ function walkDir(dir) {
     }
   }
 }
-walkDir(SRC);
-const moduleCount = CANONICAL_MODULE_COUNT ?? Object.keys(modules).length;
-const headlineTools = HEADLINE_TOOL_COUNT ?? totalTools;
 
-// Generate llms.txt (summary)
-const REPO = "https://github.com/heznpc/AirMCP";
-let llmsTxt = `# AirMCP
+export function generateLlmsText() {
+  const modules = {};
+  const counts = { totalTools: 0, totalPrompts: 0 };
+  walkDir(SRC, modules, counts);
+  const moduleCount = CANONICAL_MODULE_COUNT ?? Object.keys(modules).length;
+  const headlineTools = HEADLINE_TOOL_COUNT ?? counts.totalTools;
+
+  // Generate llms.txt (summary)
+  const REPO = "https://github.com/heznpc/AirMCP";
+  let llmsTxt = `# AirMCP
 
 > MCP server for the entire Apple ecosystem. ${headlineTools} tools across ${moduleCount} modules.
 
@@ -156,65 +183,74 @@ let llmsTxt = `# AirMCP
 
 `;
 
-for (const [key, mod] of Object.entries(modules).sort(([a], [b]) => a.localeCompare(b))) {
-  const name = MODULE_NAMES[key] || key;
-  llmsTxt += `- **${name}** (${mod.tools.length} tools): ${mod.tools.map(t => t.name).join(", ")}\n`;
-}
+  for (const [key, mod] of Object.entries(modules).sort(([a], [b]) => a.localeCompare(b))) {
+    const name = MODULE_NAMES[key] || key;
+    llmsTxt += `- **${name}** (${mod.tools.length} tools): ${mod.tools.map((t) => t.name).join(", ")}\n`;
+  }
 
-// Generate llms-full.txt (complete reference)
-let fullTxt = `# AirMCP — Full Tool Reference
+  // Generate llms-full.txt (complete reference)
+  let fullTxt = `# AirMCP — Full Tool Reference
 
-> ${headlineTools} tools, ${totalPrompts} prompts across ${moduleCount} modules.
+> ${headlineTools} tools, ${counts.totalPrompts} prompts across ${moduleCount} modules.
 > Auto-generated from source by scripts/gen-llms-txt.mjs
 
 `;
 
-for (const [key, mod] of Object.entries(modules).sort(([a], [b]) => a.localeCompare(b))) {
-  const name = MODULE_NAMES[key] || key;
-  if (mod.tools.length > 0) {
-    fullTxt += `## ${name}\n\n`;
-    for (const tool of mod.tools) {
-      fullTxt += `### ${tool.name}\n\n${tool.description}\n\n`;
+  for (const [key, mod] of Object.entries(modules).sort(([a], [b]) => a.localeCompare(b))) {
+    const name = MODULE_NAMES[key] || key;
+    if (mod.tools.length > 0) {
+      fullTxt += `## ${name}\n\n`;
+      for (const tool of mod.tools) {
+        fullTxt += `### ${tool.name}\n\n${tool.description}\n\n`;
+      }
+    }
+    if (mod.prompts.length > 0) {
+      fullTxt += `### Prompts\n\n`;
+      for (const prompt of mod.prompts) {
+        fullTxt += `- **${prompt.name}**: ${prompt.description}\n`;
+      }
+      fullTxt += "\n";
     }
   }
-  if (mod.prompts.length > 0) {
-    fullTxt += `### Prompts\n\n`;
-    for (const prompt of mod.prompts) {
-      fullTxt += `- **${prompt.name}**: ${prompt.description}\n`;
-    }
-    fullTxt += "\n";
-  }
+
+  return { llmsTxt, fullTxt, headlineTools, totalPrompts: counts.totalPrompts, moduleCount };
 }
 
 const llmsPath = join(ROOT, "llms.txt");
 const llmsFullPath = join(ROOT, "llms-full.txt");
 const checkMode = process.argv.includes("--check");
 
-if (checkMode) {
-  // Drift guard: regenerate llms.txt in-memory and diff against checked-in
-  // file. CI runs this so any tool/prompt/module addition without
-  // `npm run llms` fails the build instead of silently shipping a stale
-  // catalog (the long-standing "258 tools / 30 modules" drift bug that
-  // survived multiple releases). llms-full.txt is `.gitignore`d
-  // (oversize for review diffs) so we skip it in check mode and only
-  // pin the public-facing llms.txt summary.
-  let existing = "";
-  try {
-    existing = readFileSync(llmsPath, "utf-8");
-  } catch {
-    console.error(`[gen-llms --check] ${llmsPath} missing — run \`npm run llms\``);
-    process.exit(1);
+function main() {
+  const { llmsTxt, fullTxt, headlineTools, totalPrompts, moduleCount } = generateLlmsText();
+
+  if (checkMode) {
+    // Drift guard: regenerate llms.txt in-memory and diff against checked-in
+    // file. CI runs this so any tool/prompt/module addition without
+    // `npm run llms` fails the build instead of silently shipping a stale
+    // catalog (the long-standing "258 tools / 30 modules" drift bug that
+    // survived multiple releases). llms-full.txt is `.gitignore`d
+    // (oversize for review diffs) so we skip it in check mode and only
+    // pin the public-facing llms.txt summary.
+    let existing = "";
+    try {
+      existing = readFileSync(llmsPath, "utf-8");
+    } catch {
+      console.error(`[gen-llms --check] ${llmsPath} missing — run \`npm run llms\``);
+      process.exit(1);
+    }
+    if (existing !== llmsTxt) {
+      console.error(`[gen-llms --check] STALE: ${llmsPath} — run \`npm run llms\``);
+      process.exit(1);
+    }
+    console.log(`[gen-llms --check] OK — ${headlineTools} tools / ${totalPrompts} prompts / ${moduleCount} modules`);
+  } else {
+    writeFileSync(llmsPath, llmsTxt);
+    writeFileSync(llmsFullPath, fullTxt);
+    console.log(`Generated llms.txt (${llmsTxt.length} bytes) and llms-full.txt (${fullTxt.length} bytes)`);
+    console.log(`${headlineTools} tools, ${totalPrompts} prompts across ${moduleCount} modules`);
   }
-  if (existing !== llmsTxt) {
-    console.error(`[gen-llms --check] STALE: ${llmsPath} — run \`npm run llms\``);
-    process.exit(1);
-  }
-  console.log(
-    `[gen-llms --check] OK — ${headlineTools} tools / ${totalPrompts} prompts / ${moduleCount} modules`,
-  );
-} else {
-  writeFileSync(llmsPath, llmsTxt);
-  writeFileSync(llmsFullPath, fullTxt);
-  console.log(`Generated llms.txt (${llmsTxt.length} bytes) and llms-full.txt (${fullTxt.length} bytes)`);
-  console.log(`${headlineTools} tools, ${totalPrompts} prompts across ${moduleCount} modules`);
+}
+
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  main();
 }

--- a/swift/Sources/AirMCPKit/LocationService.swift
+++ b/swift/Sources/AirMCPKit/LocationService.swift
@@ -9,44 +9,69 @@ public class LocationFetcher: NSObject, CLLocationManagerDelegate, @unchecked Se
     private var continuation: CheckedContinuation<CLLocation, Error>?
     private var manager: CLLocationManager?
     private var timeoutWorkItem: DispatchWorkItem?
+    private var activeRequestID: UUID?
     private let queue = DispatchQueue(label: "com.airmcp.location")
 
     public override init() { super.init() }
 
     public func fetch(timeout: TimeInterval = 15) async throws -> CLLocation {
-        try await withTaskCancellationHandler {
+        let requestID = UUID()
+        let timeoutSeconds = max(timeout, 0.1)
+        return try await withTaskCancellationHandler {
             try await withCheckedThrowingContinuation { cont in
+                var accepted = false
+                queue.sync {
+                    if continuation == nil {
+                        continuation = cont
+                        activeRequestID = requestID
+                        accepted = true
+                    }
+                }
+
+                guard accepted else {
+                    cont.resume(throwing: AirMCPKitError.unsupported("Location request already in progress"))
+                    return
+                }
+
+                if Task.isCancelled {
+                    finish(.failure(AirMCPKitError.unsupported("Location request cancelled")))
+                    return
+                }
+
                 DispatchQueue.main.async {
-                    let mgr = CLLocationManager()
-                    mgr.delegate = self
-                    mgr.desiredAccuracy = kCLLocationAccuracyBest
-
-                    let timeoutItem = DispatchWorkItem { [weak self] in
-                        self?.finish(.failure(AirMCPKitError.unsupported("Location request timed out after \(Int(timeout))s")))
-                    }
-
-                    var accepted = false
-                    self.queue.sync {
-                        if self.continuation == nil {
-                            self.continuation = cont
-                            self.manager = mgr
-                            self.timeoutWorkItem = timeoutItem
-                            accepted = true
-                        }
-                    }
-
-                    guard accepted else {
-                        cont.resume(throwing: AirMCPKitError.unsupported("Location request already in progress"))
-                        return
-                    }
-
-                    DispatchQueue.main.asyncAfter(deadline: .now() + max(timeout, 0.1), execute: timeoutItem)
-                    mgr.requestLocation()
+                    self.startRequest(id: requestID, timeoutSeconds: timeoutSeconds)
                 }
             }
         } onCancel: {
             finish(.failure(AirMCPKitError.unsupported("Location request cancelled")))
         }
+    }
+
+    private func startRequest(id: UUID, timeoutSeconds: TimeInterval) {
+        let mgr = CLLocationManager()
+        mgr.delegate = self
+        mgr.desiredAccuracy = kCLLocationAccuracyBest
+
+        let timeoutItem = DispatchWorkItem { [weak self] in
+            self?.finish(.failure(AirMCPKitError.unsupported("Location request timed out after \(timeoutSeconds)s")))
+        }
+
+        var shouldStart = false
+        queue.sync {
+            if continuation != nil, activeRequestID == id, manager == nil {
+                manager = mgr
+                timeoutWorkItem = timeoutItem
+                shouldStart = true
+            }
+        }
+
+        guard shouldStart else {
+            mgr.delegate = nil
+            return
+        }
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + timeoutSeconds, execute: timeoutItem)
+        mgr.requestLocation()
     }
 
     public func locationManager(_ manager: CLLocationManager, didUpdateLocations locations: [CLLocation]) {
@@ -73,11 +98,16 @@ public class LocationFetcher: NSObject, CLLocationManagerDelegate, @unchecked Se
             manager = nil
             timeoutItem = timeoutWorkItem
             timeoutWorkItem = nil
+            activeRequestID = nil
         }
 
         timeoutItem?.cancel()
-        mgr?.stopUpdatingLocation()
-        mgr?.delegate = nil
+        if let mgr {
+            DispatchQueue.main.async {
+                mgr.stopUpdatingLocation()
+                mgr.delegate = nil
+            }
+        }
 
         guard let cont else { return }
         switch result {

--- a/swift/Tests/AirMCPKitTests/LocationServiceTests.swift
+++ b/swift/Tests/AirMCPKitTests/LocationServiceTests.swift
@@ -27,4 +27,24 @@ final class LocationServiceTests: XCTestCase {
         }
         XCTAssertLessThan(Date().timeIntervalSince(started), 2.0)
     }
+
+    func testCancelledFetchReturnsPromptly() async {
+        let fetcher = LocationFetcher()
+        let started = Date()
+        let task = Task {
+            try await fetcher.fetch(timeout: 10)
+        }
+
+        task.cancel()
+
+        do {
+            _ = try await task.value
+            XCTFail("Cancelled location fetch should not succeed")
+        } catch {
+            // The contract under test is that cancellation resumes the checked
+            // continuation promptly, even if the main-queue request has not started.
+        }
+
+        XCTAssertLessThan(Date().timeIntervalSince(started), 2.0)
+    }
 }

--- a/tests/app-info-plist-usage.test.js
+++ b/tests/app-info-plist-usage.test.js
@@ -1,5 +1,5 @@
 import { describe, test, expect } from "@jest/globals";
-import { readFileSync } from "node:fs";
+import { readFileSync, readdirSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { join } from "node:path";
 
@@ -18,25 +18,70 @@ const ROOT = fileURLToPath(new URL("..", import.meta.url));
 const PLIST = join(ROOT, "app", "Sources", "AirMCPApp", "Resources", "Info.plist");
 const plist = readFileSync(PLIST, "utf-8");
 
-// Each entry: the usage-description key a TCC-gated tool family requires.
-// Cross-referenced against the TCC-gated frameworks the Swift bridge actually
-// uses (EventKit, Speech, PhotoKit, Contacts, CoreLocation). Speech was the only one that
-// HARD-CRASHED without its key (it calls requestAuthorization); PhotoKit /
-// Contacts degrade gracefully (empty / "Access Denied") but still cannot be
-// granted on the .app surface without a declaration, so the tools stay
-// non-functional there until these are present. (Location/CLLocationManager is
-// included because get_current_location prompts through CoreLocation.)
+function readSwiftFiles(dir) {
+  let out = "";
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) out += readSwiftFiles(full);
+    else if (entry.name.endsWith(".swift")) out += `\n// ${full}\n${readFileSync(full, "utf-8")}`;
+  }
+  return out;
+}
+
+const swiftBridgeSource = [join(ROOT, "swift", "Sources", "AirMCPKit"), join(ROOT, "swift", "Sources", "AirMcpBridge")]
+  .map(readSwiftFiles)
+  .join("\n");
+
+// Each entry maps a TCC-gated Swift framework/API the bridge actually uses to
+// the app Info.plist usage-description keys required for the signed .app
+// surface. This keeps the guard tied to runtime capability use instead of a
+// manually curated key list.
+const PRIVACY_REQUIREMENTS = [
+  {
+    name: "EventKit calendars/reminders",
+    uses: /\bEKEventStore\b|import EventKit/,
+    keys: ["NSCalendarsFullAccessUsageDescription", "NSRemindersFullAccessUsageDescription"],
+  },
+  {
+    name: "Speech",
+    uses: /\bSFSpeechRecognizer\b|import Speech/,
+    keys: ["NSSpeechRecognitionUsageDescription"],
+  },
+  {
+    name: "PhotoKit",
+    uses: /\bPHPhotoLibrary\b|import Photos/,
+    keys: ["NSPhotoLibraryUsageDescription", "NSPhotoLibraryAddUsageDescription"],
+  },
+  {
+    name: "Contacts",
+    uses: /\bCNContactStore\b|import Contacts/,
+    keys: ["NSContactsUsageDescription"],
+  },
+  {
+    name: "CoreLocation",
+    uses: /\bCLLocationManager\b|import CoreLocation/,
+    keys: ["NSLocationWhenInUseUsageDescription"],
+  },
+  {
+    name: "HealthKit read access",
+    uses: /\bHKHealthStore\b|import HealthKit/,
+    // AirMCP requests read-only health access (`toShare: []`), so the share/read
+    // usage string is required; NSHealthUpdateUsageDescription is only for writes.
+    keys: ["NSHealthShareUsageDescription"],
+  },
+];
+
 const REQUIRED = [
-  "NSCalendarsFullAccessUsageDescription",
-  "NSRemindersFullAccessUsageDescription",
-  "NSSpeechRecognitionUsageDescription",
-  "NSPhotoLibraryUsageDescription",
-  "NSPhotoLibraryAddUsageDescription",
-  "NSContactsUsageDescription",
-  "NSLocationWhenInUseUsageDescription",
+  ...new Set(
+    PRIVACY_REQUIREMENTS.flatMap((requirement) => (requirement.uses.test(swiftBridgeSource) ? requirement.keys : [])),
+  ),
 ];
 
 describe("app Info.plist — privacy usage descriptions for TCC-gated tools", () => {
+  test("derives at least one required key from Swift bridge privacy APIs", () => {
+    expect(REQUIRED.length).toBeGreaterThan(0);
+  });
+
   for (const key of REQUIRED) {
     test(`declares ${key} (missing → TCC crash or ungrantable app capability)`, () => {
       expect(plist).toContain(`<key>${key}</key>`);

--- a/tests/gen-llms-txt.test.js
+++ b/tests/gen-llms-txt.test.js
@@ -1,0 +1,52 @@
+import { describe, test, expect, afterEach } from "@jest/globals";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { extractTools, generateLlmsText } from "../scripts/gen-llms-txt.mjs";
+
+const tempDirs = [];
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe("gen-llms-txt", () => {
+  test("extracts concatenated string-literal descriptions without truncation", () => {
+    const dir = mkdtempSync(join(tmpdir(), "airmcp-llms-"));
+    tempDirs.push(dir);
+    const source = join(dir, "tools.ts");
+    writeFileSync(
+      source,
+      `
+server.registerTool(
+  "sample_tool",
+  {
+    title: "Sample Tool",
+    description:
+      "First sentence. " +
+      "Second sentence.",
+    inputSchema: {},
+  },
+  async () => {},
+);
+`,
+    );
+
+    expect(extractTools(source)).toEqual([
+      {
+        name: "sample_tool",
+        title: "Sample Tool",
+        description: "First sentence. Second sentence.",
+      },
+    ]);
+  });
+
+  test("keeps real permission caveats in llms-full output", () => {
+    const { fullTxt } = generateLlmsText();
+
+    expect(fullTxt).toContain("from an unentitled CLI caller it aborts with a permission error");
+    expect(fullTxt).toContain("First use triggers a macOS permission dialog.");
+  });
+});


### PR DESCRIPTION
## Summary
- Fix CoreLocation cancellation races by registering the continuation before hopping to the main queue, handling already-cancelled tasks, and cleaning CLLocationManager on the main queue.
- Preserve concatenated tool descriptions in llms-full generation so permission caveats are not truncated.
- Derive app privacy usage-description requirements from Swift bridge TCC API usage and add the missing read-only HealthKit usage string.

## Review Notes
- The reported macOS `authorizedWhenInUse` issue was rechecked against the installed macOS SDK and is a false positive: `CLAuthorizationStatus.authorizedWhenInUse` is explicitly unavailable on macOS and fails `swiftc` if referenced there.

## Verification
- `plutil -lint app/Sources/AirMCPApp/Resources/Info.plist`
- `npm test -- tests/app-info-plist-usage.test.js tests/gen-llms-txt.test.js`
- `npm run typecheck`
- `npm run gen:manifest:check`
- `npm run gen:intents:check`
- `npm run llms:check`
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift test`
- `npm test` (134 suites / 2043 tests)
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift build -c release`
- `npm run app-build`
- `npm run mcp:validate`
- `./scripts/bundle-app.sh verify` (local ad-hoc signing warnings only)
- `printf '{}' | swift/.build/release/AirMcpBridge get-location` returns in ~2s with a CoreLocation permission error, not a hang
