### PR TITLE
Route clients through app-owned runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 **Part of:** Human-Controlled AI Systems · Research Program 1 (anchor — Apple-side agent governance).
 
-**Requires**: macOS for the server. The default `npx -y airmcp` loads a curated **starter** module set (~111 tools); `--full` (or `AIRMCP_FULL=true`) enables all 29 modules / 286 tools. Most tools are pure JXA and work on macOS 14+ with no extra setup. **Swift-backed tools** — HealthKit, on-device semantic search, recurring events/reminders, photo import/delete/classify, Vision, Speech, Location, Bluetooth, and Apple Intelligence previews — need the **optional Swift bridge** — build it from a source checkout with `npm run swift-build` (it is shipped in **neither** the npm tarball **nor** the `.mcpb` bundle; the bundled macOS app does carry it); without it those tools return a clear "Swift bridge not found" error and everything else keeps working. FoundationModels-backed Apple Intelligence and `AskAirMCPIntent` additionally require macOS 26+ on Apple Silicon and an opt-in Swift build with `AIRMCP_ENABLE_FOUNDATION_MODELS`.
+**Requires**: macOS for the server. The recommended desktop path is the AirMCP menubar app: it owns the loopback HTTP runtime, while Claude/Codex/Cursor attach to it as clients. The direct CLI server (`npx -y airmcp`) still works for development and loads a curated **starter** module set (~111 tools); `--full` (or `AIRMCP_FULL=true`) enables all 29 modules / 286 tools. Most tools are pure JXA and work on macOS 14+ with no extra setup. **Swift-backed tools** — HealthKit, on-device semantic search, recurring events/reminders, photo import/delete/classify, Vision, Speech, Location, Bluetooth, and Apple Intelligence previews — need the **optional Swift bridge** — build it from a source checkout with `npm run swift-build` (it is shipped in **neither** the npm tarball **nor** the `.mcpb` bundle; the bundled macOS app does carry it); without it those tools return a clear "Swift bridge not found" error and everything else keeps working. FoundationModels-backed Apple Intelligence and `AskAirMCPIntent` additionally require macOS 26+ on Apple Silicon and an opt-in Swift build with `AIRMCP_ENABLE_FOUNDATION_MODELS`.
 
 > Available in multiple languages at the [project landing page](https://heznpc.github.io/AirMCP/).
 
@@ -39,13 +39,13 @@
 - **JXA + Swift 6.2 bridge** — JXA for basic automation, Swift 6 strict concurrency with EventKit/PhotoKit/HealthKit/Vision, plus opt-in FoundationModels previews
 - **Apple Intelligence preview** — On-device summarize / rewrite / proofread / `ai_agent` / `ai_plan_metrics` (planner regression catcher) via Foundation Models. This path is macOS 26+ / Apple Silicon and compile-time opt-in (`AIRMCP_ENABLE_FOUNDATION_MODELS`). WWDC 2026 made the model layer officially pluggable: Foundation Models gained a `LanguageModel` protocol where on-device, Private Cloud Compute, and third-party cloud models back the same session API — Anthropic and Google publish Swift packages for their frontier models ([WWDC26 session 241](https://developer.apple.com/videos/play/wwdc2026/241/), first-party). Apple's own announcement names no Siri backbone vendor — the widely reported Gemini deal is press reporting, not Apple's wording — and AirMCP doesn't bet on one either way: the governance layer (per-call HITL, HMAC-chained audit, scope gate, rate limits) is model-agnostic, and the brains stay in whatever MCP client you connect.
 - **Context memory** — `memory_put`/`query`/`forget`/`stats` + `memory://recent` resource for facts/entities/episodes, surviving restarts
-- **Native menubar app** — SwiftUI companion with onboarding wizard, auto-start, log viewer, update notifications, permission setup, server crash auto-restart. Current release builds are ad-hoc signed; Developer ID codesigning + notarization (Gatekeeper-green) are wired in `.github/workflows/release-app.yml` but gated on Apple signing secrets, so they have not shipped yet.
+- **Native menubar app** — SwiftUI companion with onboarding wizard, auto-start, log viewer, update notifications, permission setup, server crash auto-restart, and app-owned loopback HTTP runtime for clients that should not each launch their own AirMCP server. Current release builds are ad-hoc signed; Developer ID codesigning + notarization (Gatekeeper-green) are wired in `.github/workflows/release-app.yml` but gated on Apple signing secrets, so they have not shipped yet.
 - **One-click setup** — `setup_permissions` tool or menubar app to request all macOS permissions at once
 - **Dual transport** — stdio (default) + HTTP/SSE (`--http`) with token auth, origin allow-list, and startup invariants that refuse to boot misconfigured servers
 
 ## Get Started
 
-Two paths. Claude Desktop users get one-click install via `.mcpb`. Agent-native Mac users use the CLI wizard, which configures detected Claude, Codex, Cursor, and Windsurf clients.
+Two paths. The menubar app is the recommended local runtime: start AirMCP.app once, then point Claude, Codex, Cursor, Windsurf, or other clients at that same loopback server. Claude Desktop users can also get one-click install via `.mcpb`, which is convenient but launches under Claude Desktop rather than the AirMCP.app-owned runtime.
 
 ### Option A — Claude Desktop one-click install (recommended for non-devs)
 
@@ -241,7 +241,7 @@ See [docs/shortcuts.md](docs/shortcuts.md) for the full guide + [RFC 0007](docs/
 
 ## Client Setup
 
-Works with any MCP-compatible client. Examples:
+Works with any MCP-compatible client. Start AirMCP.app first. Clients with HTTP MCP support can connect directly to `http://127.0.0.1:3847/mcp`; stdio-only clients use `npx -y airmcp connect` as a proxy into the app-owned runtime.
 
 ### Claude Desktop
 
@@ -252,7 +252,7 @@ Add to `~/Library/Application Support/Claude/claude_desktop_config.json`:
   "mcpServers": {
     "airmcp": {
       "command": "npx",
-      "args": ["-y", "airmcp"]
+      "args": ["-y", "airmcp", "connect", "--url", "http://127.0.0.1:3847/mcp"]
     }
   }
 }
@@ -261,13 +261,13 @@ Add to `~/Library/Application Support/Claude/claude_desktop_config.json`:
 ### Claude Code
 
 ```bash
-claude mcp add airmcp -- npx -y airmcp
+claude mcp add airmcp -- npx -y airmcp connect --url http://127.0.0.1:3847/mcp
 ```
 
 ### Codex
 
 ```bash
-codex mcp add airmcp -- npx -y airmcp
+codex mcp add airmcp --url http://127.0.0.1:3847/mcp
 ```
 
 ### Cursor
@@ -279,7 +279,7 @@ Add to `.cursor/mcp.json`:
   "mcpServers": {
     "airmcp": {
       "command": "npx",
-      "args": ["-y", "airmcp"]
+      "args": ["-y", "airmcp", "connect", "--url", "http://127.0.0.1:3847/mcp"]
     }
   }
 }
@@ -294,7 +294,7 @@ Add to `~/.codeium/windsurf/mcp_config.json`:
   "mcpServers": {
     "airmcp": {
       "command": "npx",
-      "args": ["-y", "airmcp"]
+      "args": ["-y", "airmcp", "connect", "--url", "http://127.0.0.1:3847/mcp"]
     }
   }
 }
@@ -302,7 +302,7 @@ Add to `~/.codeium/windsurf/mcp_config.json`:
 
 ### Other MCP Clients
 
-Any client that supports the MCP stdio transport can use AirMCP. Use `npx -y airmcp` as the server command.
+Any client that supports the MCP stdio transport can use AirMCP. Use `npx -y airmcp connect --url http://127.0.0.1:3847/mcp` as the command when AirMCP.app owns the runtime. Use direct `npx -y airmcp` only when you intentionally want that client process to own a separate server instance.
 
 ### Local Development
 
@@ -867,6 +867,7 @@ Or edit `~/.config/airmcp/config.json` directly:
 | `npx airmcp --version` | Print version and exit            |
 | `npx airmcp --full`    | Start with all 29 modules enabled |
 | `npx airmcp --http`    | Start as HTTP server (port 3847)  |
+| `npx airmcp connect`   | Proxy stdio clients to AirMCP.app |
 
 ## Configuration
 
@@ -1051,7 +1052,7 @@ Modules with OS requirements (e.g., Intelligence requires macOS 26+) are automat
 
 ### Platform Constraints (macOS 26+)
 
-- **Safari bookmarks/reading list** — Apple removed JXA bookmark scripting classes in macOS 26. The plist fallback (`~/Library/Safari/Bookmarks.plist`) requires Full Disk Access, which TCC blocks for MCP server processes. Investigating Shortcuts-based or WebExtension bridge approaches.
+- **Safari bookmarks/reading list** — Apple removed JXA bookmark scripting classes in macOS 26. The plist fallback (`~/Library/Safari/Bookmarks.plist`) requires Full Disk Access, which TCC blocks for headless/direct MCP server processes. The app-owned runtime is the intended permission boundary, but signed-app runtime verification is still required for this surface. Investigating Shortcuts-based or WebExtension bridge approaches.
 - **Safari `add_bookmark`** — Legacy JXA `make new bookmark` no longer supported in macOS 26. No programmatic alternative available yet.
 - **Podcasts** — Apple removed the Podcasts JXA scripting dictionary entirely in macOS 26. All 6 Podcasts tools return errors. Investigating Shortcuts bridge or Media framework alternatives.
 

--- a/app/Sources/AirMCPApp/ServerManager.swift
+++ b/app/Sources/AirMCPApp/ServerManager.swift
@@ -48,7 +48,7 @@ final class ServerManager {
 
     func checkStatus() {
         Task.detached {
-            let isRunning = Self.pgrepAirMcp()
+            let isRunning = await Self.httpServerHealthy()
             let newStatus: Status = isRunning ? .running : .stopped
             await MainActor.run { [weak self] in
                 guard let self else { return }
@@ -190,10 +190,19 @@ final class ServerManager {
 
                 let process = Process()
                 process.executableURL = URL(fileURLWithPath: npxPath)
-                process.arguments = ["-y", AirMcpConstants.npmPackageName]
+                process.arguments = [
+                    "-y",
+                    AirMcpConstants.npmPackageName,
+                    "--http",
+                    "--port",
+                    "\(AirMcpConstants.appOwnedHttpPort)",
+                ]
                 process.standardOutput = stdoutPipe ?? FileHandle.nullDevice
                 process.standardError = stderrPipe ?? FileHandle.nullDevice
-                process.environment = NodeEnvironment.buildEnv()
+                var env = NodeEnvironment.buildEnv()
+                env["AIRMCP_ALLOW_NETWORK"] = "loopback-only"
+                env["AIRMCP_APP_OWNED_RUNTIME"] = "1"
+                process.environment = env
 
                 do {
                     try process.run()
@@ -218,17 +227,13 @@ final class ServerManager {
 
     // MARK: - Process Utilities
 
-    private nonisolated static func pgrepAirMcp() -> Bool {
-        let process = Process()
-        process.executableURL = URL(fileURLWithPath: "/usr/bin/pgrep")
-        process.arguments = ["-f", "node.*airmcp"]
-        process.standardOutput = FileHandle.nullDevice
-        process.standardError = FileHandle.nullDevice
-
+    private nonisolated static func httpServerHealthy() async -> Bool {
+        guard let url = URL(string: AirMcpConstants.appOwnedHealthURL) else { return false }
+        var request = URLRequest(url: url)
+        request.timeoutInterval = 1.0
         do {
-            try process.run()
-            process.waitUntilExit()
-            return process.terminationStatus == 0
+            let (_, response) = try await URLSession.shared.data(for: request)
+            return (response as? HTTPURLResponse)?.statusCode == 200
         } catch {
             return false
         }
@@ -237,7 +242,7 @@ final class ServerManager {
     private nonisolated static func pkillAirMcp() {
         let process = Process()
         process.executableURL = URL(fileURLWithPath: "/usr/bin/pkill")
-        process.arguments = ["-f", "node.*airmcp"]
+        process.arguments = ["-f", "airmcp.*--http.*--port \(AirMcpConstants.appOwnedHttpPort)"]
         process.standardOutput = FileHandle.nullDevice
         process.standardError = FileHandle.nullDevice
 

--- a/app/Sources/AirMCPApp/Views/MenuContent.swift
+++ b/app/Sources/AirMCPApp/Views/MenuContent.swift
@@ -159,22 +159,33 @@ private let featuredWorkflows: [WorkflowInfo] = [
 enum AirMcpConstants {
     static let npmPackageName = "airmcp"
     static let mcpProtocolVersion = "2025-03-26"
+    static let appOwnedHttpPort = 3847
+    static let appOwnedHttpURL = "http://127.0.0.1:\(appOwnedHttpPort)/mcp"
+    static let appOwnedHealthURL = "http://127.0.0.1:\(appOwnedHttpPort)/health"
     static let keyAutoStart = "autoStartServer"
     static let keyOnboardingCompleted = "onboardingCompleted"
+    static let appOwnedProxyArgs = ["-y", npmPackageName, "connect", "--url", appOwnedHttpURL]
+
+    static var appOwnedProxyEntry: [String: Any] {
+        [
+            "command": "npx",
+            "args": appOwnedProxyArgs,
+        ]
+    }
 
     static let claudeDesktopConfig = """
     {
       "mcpServers": {
         "airmcp": {
           "command": "npx",
-          "args": ["-y", "\(npmPackageName)"]
+          "args": ["-y", "\(npmPackageName)", "connect", "--url", "\(appOwnedHttpURL)"]
         }
       }
     }
     """
 
-    static let claudeCodeConfig = "claude mcp add airmcp -- npx -y \(npmPackageName)"
-    static let codexConfig = "codex mcp add airmcp -- npx -y \(npmPackageName)"
+    static let claudeCodeConfig = "claude mcp add airmcp -- npx -y \(npmPackageName) connect --url \(appOwnedHttpURL)"
+    static let codexConfig = "codex mcp add airmcp --url \(appOwnedHttpURL)"
 
     static func copyToClipboard(_ text: String) {
         NSPasteboard.general.clearContents()

--- a/app/Sources/AirMCPApp/Views/OnboardingView.swift
+++ b/app/Sources/AirMCPApp/Views/OnboardingView.swift
@@ -769,11 +769,8 @@ struct OnboardingView: View {
             return false
         }
 
-        if runProcess(codex, arguments: ["mcp", "get", "airmcp"]) {
-            return true
-        }
-
-        return runProcess(codex, arguments: ["mcp", "add", "airmcp", "--", "npx", "-y", AirMcpConstants.npmPackageName])
+        _ = runProcess(codex, arguments: ["mcp", "remove", "airmcp"])
+        return runProcess(codex, arguments: ["mcp", "add", "airmcp", "--url", AirMcpConstants.appOwnedHttpURL])
     }
 
     private nonisolated static func runProcess(_ executable: String, arguments: [String]) -> Bool {
@@ -811,10 +808,7 @@ struct OnboardingView: View {
         }
 
         // Build the airmcp entry
-        let airmcpEntry: [String: Any] = [
-            "command": "npx",
-            "args": ["-y", AirMcpConstants.npmPackageName],
-        ]
+        let airmcpEntry = AirMcpConstants.appOwnedProxyEntry
 
         // Merge into mcpServers
         var servers = config["mcpServers"] as? [String: Any] ?? [:]

--- a/docs/site/src/content/docs/architecture/overview.md
+++ b/docs/site/src/content/docs/architecture/overview.md
@@ -96,8 +96,8 @@ This is under development in the `ios/` directory.
 
 AirMCP supports two MCP transports:
 
-- **Stdio** (default) -- communicates via stdin/stdout. Used by Claude Desktop, Claude Code, Cursor, and most MCP clients.
-- **Streamable HTTP** (`--http` flag) -- Express-based HTTP server with session management. Supports multiple concurrent clients, SSE streaming, and bearer token authentication.
+- **Streamable HTTP** (`--http` flag) -- Express-based HTTP server with session management. This is the recommended AirMCP.app-owned local runtime on `127.0.0.1:3847`.
+- **Stdio** (default) -- communicates via stdin/stdout. Direct stdio is useful for development; stdio-only clients should use `npx -y airmcp connect --url http://127.0.0.1:3847/mcp` to proxy into the app-owned runtime.
 
 ### Module System
 

--- a/docs/site/src/content/docs/getting-started/configuration.md
+++ b/docs/site/src/content/docs/getting-started/configuration.md
@@ -120,6 +120,7 @@ npx airmcp --http             # Start as HTTP server
 npx airmcp --http --port 8080 # Custom port
 npx airmcp --http --bind-all  # Bind to 0.0.0.0 (all interfaces)
 npx airmcp --full             # Enable all modules
+npx airmcp connect            # Proxy stdio clients to AirMCP.app
 npx airmcp init               # Interactive setup wizard
 npx airmcp doctor             # Diagnose installation
 npx airmcp --help             # Show usage guide

--- a/docs/site/src/content/docs/getting-started/installation.md
+++ b/docs/site/src/content/docs/getting-started/installation.md
@@ -11,7 +11,7 @@ description: How to install and set up AirMCP on your Mac.
 
 ## Quick Install
 
-The fastest way to get started is the interactive setup wizard:
+The recommended desktop runtime is AirMCP.app: start the menubar app once, then connect Claude, Codex, Cursor, Windsurf, or another MCP client to the app-owned loopback server. The CLI wizard configures detected clients for that shape:
 
 ```bash
 npx airmcp init
@@ -21,12 +21,12 @@ This will:
 
 1. Ask which modules you want to enable (or choose "all")
 2. Detect installed MCP clients (Claude Desktop, Claude Code, Cursor, Windsurf)
-3. Write the MCP server entry to each client's config file
+3. Write an AirMCP.app-owned runtime entry to each client's config file
 4. Create `~/.config/airmcp/config.json` with your module selection
 
 ## Manual Setup
 
-If you prefer manual configuration, add AirMCP to your MCP client's config file directly.
+If you prefer manual configuration, start AirMCP.app first. HTTP-capable clients connect to `http://127.0.0.1:3847/mcp`; stdio-only clients use `npx -y airmcp connect` as a proxy into that app-owned runtime.
 
 ### Claude Desktop
 
@@ -37,7 +37,7 @@ Edit `~/Library/Application Support/Claude/claude_desktop_config.json`:
   "mcpServers": {
     "airmcp": {
       "command": "npx",
-      "args": ["-y", "airmcp"]
+      "args": ["-y", "airmcp", "connect", "--url", "http://127.0.0.1:3847/mcp"]
     }
   }
 }
@@ -52,7 +52,7 @@ Edit `~/.claude/mcp.json`:
   "mcpServers": {
     "airmcp": {
       "command": "npx",
-      "args": ["-y", "airmcp"]
+      "args": ["-y", "airmcp", "connect", "--url", "http://127.0.0.1:3847/mcp"]
     }
   }
 }
@@ -67,7 +67,7 @@ Edit `~/.cursor/mcp.json`:
   "mcpServers": {
     "airmcp": {
       "command": "npx",
-      "args": ["-y", "airmcp"]
+      "args": ["-y", "airmcp", "connect", "--url", "http://127.0.0.1:3847/mcp"]
     }
   }
 }
@@ -82,7 +82,7 @@ Edit `~/.codeium/windsurf/mcp_config.json`:
   "mcpServers": {
     "airmcp": {
       "command": "npx",
-      "args": ["-y", "airmcp"]
+      "args": ["-y", "airmcp", "connect", "--url", "http://127.0.0.1:3847/mcp"]
     }
   }
 }
@@ -90,38 +90,23 @@ Edit `~/.codeium/windsurf/mcp_config.json`:
 
 ## Enable All Modules
 
-By default, AirMCP enables a starter set of modules (Notes, Reminders, Calendar, Shortcuts, System, Finder, Weather). To enable all 29 modules, use the `--full` flag:
+By default, AirMCP enables a starter set of modules when no config file exists. In the app-owned runtime, use the onboarding module picker or rerun the setup wizard and choose all modules:
 
-```json
-{
-  "mcpServers": {
-    "airmcp": {
-      "command": "npx",
-      "args": ["-y", "airmcp", "--full"]
-    }
-  }
-}
+```bash
+npx airmcp init
 ```
 
-Or set the environment variable:
+Or edit `~/.config/airmcp/config.json` directly:
 
 ```json
 {
-  "mcpServers": {
-    "airmcp": {
-      "command": "npx",
-      "args": ["-y", "airmcp"],
-      "env": {
-        "AIRMCP_FULL": "true"
-      }
-    }
-  }
+  "disabledModules": []
 }
 ```
 
 ## macOS Permissions
 
-AirMCP uses JXA (JavaScript for Automation) to control macOS apps. The first time you use a module, macOS will prompt you to grant Accessibility or Automation permissions to your terminal or MCP client.
+AirMCP uses JXA (JavaScript for Automation) to control macOS apps. In the recommended app-owned runtime, macOS permission prompts should be associated with AirMCP.app rather than every individual AI client. Direct `npx -y airmcp` launches remain useful for development, but the launching terminal or MCP client owns those prompts.
 
 To check permissions, run:
 

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -62,13 +62,13 @@ Use a workflow id with `--prompt`, `--siri`, `--tools`, `--modules`, `--safety`,
 For Codex:
 
 ```bash
-codex mcp add airmcp -- npx -y airmcp
+codex mcp add airmcp --url http://127.0.0.1:3847/mcp
 ```
 
 For Claude Code:
 
 ```bash
-claude mcp add airmcp -- npx -y airmcp
+claude mcp add airmcp -- npx -y airmcp connect --url http://127.0.0.1:3847/mcp
 ```
 
 For Siri and Shortcuts, see [shortcuts.md](shortcuts.md). The default AppShortcuts are workflow-first; `Ask AirMCP` is a separate FoundationModels preview shortcut that only appears in opt-in builds with `AIRMCP_ENABLE_FOUNDATION_MODELS`.

--- a/src/cli/codex-mcp.ts
+++ b/src/cli/codex-mcp.ts
@@ -1,5 +1,9 @@
 import { execFileSync } from "node:child_process";
 import { NPM_PACKAGE_NAME } from "../shared/config.js";
+import { IDENTITY } from "../shared/constants.js";
+
+export const CODEX_APP_OWNED_URL = `http://127.0.0.1:${IDENTITY.HTTP_PORT}/mcp`;
+export type CodexAirmcpRuntimeShape = "app-owned" | "direct" | "unknown" | "missing";
 
 function runCodex(args: string[]): string {
   return execFileSync("codex", args, {
@@ -18,17 +22,42 @@ export function isCodexCliAvailable(): boolean {
   }
 }
 
-export function isCodexAirmcpConfigured(): boolean {
+export function getCodexAirmcpConfig(): string | null {
   try {
-    runCodex(["mcp", "get", "airmcp"]);
-    return true;
+    return runCodex(["mcp", "get", "airmcp"]);
   } catch {
-    return false;
+    return null;
   }
 }
 
+export function isCodexAirmcpConfigured(): boolean {
+  return getCodexAirmcpConfig() !== null;
+}
+
+export function codexAirmcpRuntimeShape(): CodexAirmcpRuntimeShape {
+  const config = getCodexAirmcpConfig();
+  if (!config) return "missing";
+  if (config.includes(CODEX_APP_OWNED_URL) || config.includes("transport: streamable-http")) {
+    return "app-owned";
+  }
+  if (config.includes("transport: stdio") || config.includes("command: npx")) {
+    return "direct";
+  }
+  return "unknown";
+}
+
 export function configureCodexAirmcp(): "already-configured" | "configured" {
-  if (isCodexAirmcpConfigured()) return "already-configured";
-  runCodex(["mcp", "add", "airmcp", "--", "npx", "-y", NPM_PACKAGE_NAME]);
+  if (isCodexAirmcpConfigured()) {
+    runCodex(["mcp", "remove", "airmcp"]);
+  }
+  runCodex(["mcp", "add", "airmcp", "--url", CODEX_APP_OWNED_URL]);
   return "configured";
+}
+
+export function codexManualSetupCommand(): string {
+  return `codex mcp add airmcp --url ${CODEX_APP_OWNED_URL}`;
+}
+
+export function stdioProxyArgs(): string[] {
+  return ["-y", NPM_PACKAGE_NAME, "connect", "--url", CODEX_APP_OWNED_URL];
 }

--- a/src/cli/connect.ts
+++ b/src/cli/connect.ts
@@ -1,0 +1,165 @@
+import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import type { JSONRPCMessage, RequestId } from "@modelcontextprotocol/sdk/types.js";
+import { IDENTITY } from "../shared/constants.js";
+
+const DEFAULT_URL = `http://127.0.0.1:${IDENTITY.HTTP_PORT}/mcp`;
+const INITIALIZE_METHOD = "initialize";
+
+interface ConnectOptions {
+  url: string;
+  token?: string;
+}
+
+function usage(): string {
+  return [
+    "Usage: npx airmcp connect [--url http://127.0.0.1:3847/mcp] [--token <token>]",
+    "",
+    "Connect a stdio-only MCP client to the AirMCP.app-owned local HTTP runtime.",
+    "Start AirMCP.app first, then configure Claude Desktop or other stdio clients",
+    "to run this command instead of launching a second AirMCP server.",
+  ].join("\n");
+}
+
+function parseArgs(args: string[]): ConnectOptions {
+  let url = process.env.AIRMCP_CONNECT_URL ?? DEFAULT_URL;
+  let token = process.env.AIRMCP_HTTP_TOKEN || undefined;
+
+  for (let i = 0; i < args.length; i += 1) {
+    const arg = args[i];
+    if (arg === "--help" || arg === "-h") {
+      console.log(usage());
+      process.exit(0);
+    }
+    if (arg === "--url") {
+      const value = args[i + 1];
+      if (!value) throw new Error("--url requires a value");
+      url = value;
+      i += 1;
+      continue;
+    }
+    if (arg === "--token") {
+      const value = args[i + 1];
+      if (!value) throw new Error("--token requires a value");
+      token = value;
+      i += 1;
+      continue;
+    }
+    throw new Error(`Unknown connect option: ${arg}`);
+  }
+
+  try {
+    const parsed = new URL(url);
+    if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+      throw new Error("URL must use http:// or https://");
+    }
+  } catch (error) {
+    const reason = error instanceof Error ? error.message : String(error);
+    throw new Error(`Invalid --url: ${reason}`, { cause: error });
+  }
+
+  return { url, token };
+}
+
+function isRequest(message: JSONRPCMessage): message is JSONRPCMessage & { id: RequestId; method: string } {
+  return "method" in message && "id" in message && message.id !== undefined;
+}
+
+function isResponse(message: JSONRPCMessage): message is JSONRPCMessage & { id: RequestId; result?: unknown } {
+  return "id" in message && message.id !== undefined && ("result" in message || "error" in message);
+}
+
+function protocolVersionFrom(message: JSONRPCMessage): string | undefined {
+  if (!isResponse(message) || typeof message.result !== "object" || message.result === null) return undefined;
+  const result = message.result as Record<string, unknown>;
+  return typeof result.protocolVersion === "string" ? result.protocolVersion : undefined;
+}
+
+function makeProxyUnavailableResponse(message: JSONRPCMessage, error: unknown): JSONRPCMessage | null {
+  if (!isRequest(message)) return null;
+  const detail = error instanceof Error ? error.message : String(error);
+  return {
+    jsonrpc: "2.0",
+    id: message.id,
+    error: {
+      code: -32000,
+      message: "AirMCP.app local runtime is not reachable. Start AirMCP.app and make sure its server is running.",
+      data: { detail },
+    },
+  };
+}
+
+export async function runConnect(args = process.argv.slice(3)): Promise<void> {
+  const options = parseArgs(args);
+  const stdio = new StdioServerTransport();
+  const requestInit: RequestInit = options.token ? { headers: { Authorization: `Bearer ${options.token}` } } : {};
+  const http = new StreamableHTTPClientTransport(new URL(options.url), { requestInit });
+  const initializeRequestIds = new Set<RequestId>();
+  const keepAlive = setInterval(() => {}, 60_000);
+  let closing = false;
+  let resolveDone: (exitCode: number) => void = () => {};
+  const done = new Promise<number>((resolve) => {
+    resolveDone = resolve;
+  });
+
+  async function closeBoth(exitCode = 0): Promise<void> {
+    if (closing) return;
+    closing = true;
+    clearInterval(keepAlive);
+    await Promise.allSettled([stdio.close(), http.close()]);
+    resolveDone(exitCode);
+  }
+
+  stdio.onerror = (error) => {
+    console.error(`[AirMCP connect] stdio error: ${error.message}`);
+  };
+  http.onerror = (error) => {
+    console.error(`[AirMCP connect] HTTP transport error: ${error.message}`);
+  };
+  stdio.onclose = () => {
+    void closeBoth(0);
+  };
+  http.onclose = () => {
+    void closeBoth(0);
+  };
+  process.once("SIGINT", () => {
+    void closeBoth(130);
+  });
+  process.once("SIGTERM", () => {
+    void closeBoth(143);
+  });
+  process.stdin.once("end", () => {
+    void closeBoth(0);
+  });
+  process.stdin.once("close", () => {
+    void closeBoth(0);
+  });
+
+  stdio.onmessage = (message) => {
+    if (isRequest(message) && message.method === INITIALIZE_METHOD) {
+      initializeRequestIds.add(message.id);
+    }
+    http.send(message).catch((error: unknown) => {
+      console.error(`[AirMCP connect] failed to forward to ${options.url}: ${String(error)}`);
+      const response = makeProxyUnavailableResponse(message, error);
+      if (response) {
+        void stdio.send(response).finally(() => closeBoth(1));
+      } else {
+        void closeBoth(1);
+      }
+    });
+  };
+
+  http.onmessage = (message) => {
+    if (isResponse(message) && initializeRequestIds.delete(message.id)) {
+      const protocolVersion = protocolVersionFrom(message);
+      if (protocolVersion) http.setProtocolVersion?.(protocolVersion);
+    }
+    void stdio.send(message);
+  };
+
+  await http.start();
+  await stdio.start();
+  process.stdin.resume();
+  process.exitCode = await done;
+}

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -11,7 +11,7 @@ import { fileURLToPath } from "node:url";
 import { execFileSync } from "node:child_process";
 import { MODULE_NAMES, STARTER_MODULES, NPM_PACKAGE_NAME, MCP_CLIENTS, getCompatibilityEnv } from "../shared/config.js";
 import { HOME, PATHS } from "../shared/constants.js";
-import { isCodexAirmcpConfigured, isCodexCliAvailable } from "./codex-mcp.js";
+import { CODEX_APP_OWNED_URL, codexAirmcpRuntimeShape, isCodexCliAvailable } from "./codex-mcp.js";
 import { LOGO_LINES, typeLine } from "../shared/banner.js";
 import { esc } from "../shared/esc.js";
 import { MODULE_MANIFEST } from "../shared/modules.js";
@@ -28,6 +28,17 @@ interface FileConfig {
   includeShared?: boolean;
   allowSendMessages?: boolean;
   allowSendMail?: boolean;
+}
+
+function clientRuntimeShape(entry: unknown): "app-owned" | "direct" | "unknown" {
+  if (!entry || typeof entry !== "object") return "unknown";
+  const record = entry as Record<string, unknown>;
+  if (record.url === CODEX_APP_OWNED_URL) return "app-owned";
+  const command = typeof record.command === "string" ? record.command : "";
+  const args = Array.isArray(record.args) ? record.args.filter((arg): arg is string => typeof arg === "string") : [];
+  if (args.includes("connect") && args.includes(CODEX_APP_OWNED_URL)) return "app-owned";
+  if (command === "npx" && args.some((arg) => arg === "airmcp" || arg.startsWith("airmcp@"))) return "direct";
+  return "unknown";
 }
 
 export async function runDoctor(): Promise<void> {
@@ -135,7 +146,14 @@ export async function runDoctor(): Promise<void> {
         const raw = JSON.parse(readFileSync(client.configPath, "utf-8"));
         const servers = raw?.[client.serversKey] ?? {};
         if (servers.airmcp) {
-          ok(client.name, `${GREEN}connected${RESET}`);
+          const shape = clientRuntimeShape(servers.airmcp);
+          if (shape === "app-owned") {
+            ok(client.name, `${GREEN}connected${RESET} ${DIM}(AirMCP.app runtime)${RESET}`);
+          } else if (shape === "direct") {
+            meh(client.name, `connected via direct stdio — rerun init for AirMCP.app runtime`);
+          } else {
+            meh(client.name, `airmcp entry found, runtime shape unknown`);
+          }
         } else {
           meh(client.name, `found but no airmcp entry`);
         }
@@ -146,10 +164,18 @@ export async function runDoctor(): Promise<void> {
   }
   if (isCodexCliAvailable()) {
     anyClientFound = true;
-    if (isCodexAirmcpConfigured()) {
-      ok("Codex", `${GREEN}connected${RESET}`);
-    } else {
+    const shape = codexAirmcpRuntimeShape();
+    if (shape === "app-owned") {
+      ok("Codex", `${GREEN}connected${RESET} ${DIM}(AirMCP.app runtime)${RESET}`);
+    } else if (shape === "direct") {
+      meh(
+        "Codex",
+        `connected via direct stdio — run: codex mcp remove airmcp && codex mcp add airmcp --url ${CODEX_APP_OWNED_URL}`,
+      );
+    } else if (shape === "missing") {
       meh("Codex", `found but no airmcp entry`);
+    } else {
+      meh("Codex", `airmcp entry found, runtime shape unknown`);
     }
   }
   if (!anyClientFound) {

--- a/src/cli/help.ts
+++ b/src/cli/help.ts
@@ -23,6 +23,9 @@ export function runHelp(): void {
   console.log(
     `    ${GREEN}$${RESET} npx airmcp ${BOLD}workflows daily-briefing --preview${RESET} ${DIM}Run a read-only local snapshot${RESET}`,
   );
+  console.log(
+    `    ${GREEN}$${RESET} npx airmcp ${BOLD}connect${RESET}         ${DIM}Proxy stdio clients to AirMCP.app local HTTP${RESET}`,
+  );
   console.log(`    ${GREEN}$${RESET} npx airmcp                  ${DIM}Start MCP server (stdio)${RESET}`);
   console.log(`    ${GREEN}$${RESET} npx airmcp ${BOLD}--http${RESET}          ${DIM}Start as HTTP server${RESET}`);
   console.log(`    ${GREEN}$${RESET} npx airmcp ${BOLD}--full${RESET}          ${DIM}Enable all modules${RESET}`);
@@ -38,6 +41,7 @@ export function runHelp(): void {
   console.log("");
   console.log(`    ${CYAN}init${RESET}       ${DIM}Choose language, select modules, configure MCP clients${RESET}`);
   console.log(`    ${CYAN}doctor${RESET}     ${DIM}Check Node.js, macOS, permissions, clients, modules${RESET}`);
+  console.log(`    ${CYAN}connect${RESET}    ${DIM}Bridge stdio clients into the app-owned local runtime${RESET}`);
   console.log(
     `    ${CYAN}workflows${RESET}  ${DIM}Show target workflows, prompts, modules, Siri phrases, safety notes${RESET}`,
   );

--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -8,9 +8,9 @@
 
 import { readFileSync, writeFileSync, mkdirSync, existsSync, copyFileSync } from "node:fs";
 import { join } from "node:path";
-import { MODULE_NAMES, STARTER_MODULES, NPM_PACKAGE_NAME, MCP_CLIENTS } from "../shared/config.js";
+import { MODULE_NAMES, STARTER_MODULES, MCP_CLIENTS } from "../shared/config.js";
 import { PATHS } from "../shared/constants.js";
-import { configureCodexAirmcp, isCodexCliAvailable } from "./codex-mcp.js";
+import { codexManualSetupCommand, configureCodexAirmcp, isCodexCliAvailable, stdioProxyArgs } from "./codex-mcp.js";
 import { LOGO_LINES, typeLine, sleep, writeOut } from "../shared/banner.js";
 import { isPlainObject } from "../shared/validate.js";
 import { formatError } from "../shared/errors.js";
@@ -452,7 +452,7 @@ export async function runInit(): Promise<void> {
   // --- Step 3: Auto-detect and patch MCP client configs ---
   const airmcpEntry = {
     command: "npx",
-    args: ["-y", NPM_PACKAGE_NAME],
+    args: stdioProxyArgs(),
   };
 
   let patchedClients = 0;
@@ -520,7 +520,7 @@ export async function runInit(): Promise<void> {
     console.log(`  ${DIM}${JSON.stringify({ mcpServers: { airmcp: airmcpEntry } }, null, 2)}${RESET}`);
     console.log("");
     console.log("  Codex CLI:");
-    console.log(`  ${DIM}codex mcp add airmcp -- npx -y ${NPM_PACKAGE_NAME}${RESET}`);
+    console.log(`  ${DIM}${codexManualSetupCommand()}${RESET}`);
   }
 
   // --- Done ---
@@ -529,7 +529,7 @@ export async function runInit(): Promise<void> {
     `  ${GREEN}\u2713${RESET} ${t("setup_complete", lang)} ${BOLD}${enabled.size} modules${RESET}, safety: ${BOLD}${hitlLevel}${RESET}, ${patchedClients} client(s) configured.`,
   );
   if (detectedClients.length > 0) {
-    console.log(`  ${DIM}Restart ${detectedClients.join(", ")} to connect AirMCP.${RESET}`);
+    console.log(`  ${DIM}Start AirMCP.app, then restart ${detectedClients.join(", ")} to connect.${RESET}`);
   }
   console.log("");
   console.log(`  ${DIM}${t("next_steps", lang)}:${RESET}`);

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,6 +20,7 @@ if (
   _sub === "init" ||
   _sub === "doctor" ||
   _sub === "workflows" ||
+  _sub === "connect" ||
   _sub === "--help" ||
   _sub === "-h" ||
   _sub === "help"
@@ -33,6 +34,9 @@ if (
   } else if (_sub === "workflows") {
     const mod = await import("./cli/workflows.js");
     await mod.runWorkflows();
+  } else if (_sub === "connect") {
+    const mod = await import("./cli/connect.js");
+    await mod.runConnect();
   } else {
     const mod = await import("./cli/help.js");
     mod.runHelp();

--- a/tests/cli-connect.test.js
+++ b/tests/cli-connect.test.js
@@ -1,0 +1,149 @@
+import { afterEach, describe, expect, test } from "@jest/globals";
+import { spawn } from "node:child_process";
+import { createServer } from "node:net";
+import { createInterface } from "node:readline";
+import { fileURLToPath } from "node:url";
+import { cleanBootEnv } from "../scripts/lib/clean-boot-env.mjs";
+
+const DIST = fileURLToPath(new URL("../dist/index.js", import.meta.url));
+const ROOT = fileURLToPath(new URL("..", import.meta.url));
+const children = [];
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function getFreePort() {
+  const server = createServer();
+  await new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", resolve);
+  });
+  const address = server.address();
+  await new Promise((resolve, reject) => server.close((error) => (error ? reject(error) : resolve())));
+  if (!address || typeof address === "string") throw new Error("failed to allocate a test port");
+  return address.port;
+}
+
+function spawnAirMcp(args) {
+  const child = spawn(process.execPath, [DIST, ...args], {
+    cwd: ROOT,
+    env: cleanBootEnv(),
+    stdio: ["pipe", "pipe", "pipe"],
+  });
+  child.stderr.setEncoding("utf8");
+  child.stdout.setEncoding("utf8");
+  child.stderrText = "";
+  child.stderr.on("data", (chunk) => {
+    child.stderrText += chunk;
+  });
+  children.push(child);
+  return child;
+}
+
+async function waitForHealth(port, child) {
+  const url = `http://127.0.0.1:${port}/health`;
+  for (let attempt = 0; attempt < 80; attempt += 1) {
+    if (child.exitCode !== null) {
+      throw new Error(`server exited before health check passed: ${child.stderrText}`);
+    }
+    try {
+      const response = await fetch(url);
+      if (response.status === 200) return;
+    } catch {
+      // Retry until the HTTP listener is ready.
+    }
+    await sleep(100);
+  }
+  throw new Error(`server did not become healthy at ${url}: ${child.stderrText}`);
+}
+
+function createJsonReader(stream) {
+  const reader = createInterface({ input: stream });
+  const queue = [];
+  const waiters = [];
+
+  function drain() {
+    for (let i = 0; i < waiters.length; i += 1) {
+      const waiter = waiters[i];
+      const messageIndex = queue.findIndex(waiter.predicate);
+      if (messageIndex === -1) continue;
+      const [message] = queue.splice(messageIndex, 1);
+      waiters.splice(i, 1);
+      clearTimeout(waiter.timer);
+      waiter.resolve(message);
+      i -= 1;
+    }
+  }
+
+  reader.on("line", (line) => {
+    try {
+      queue.push(JSON.parse(line));
+      drain();
+    } catch {
+      // Ignore non-JSON stdout from a failed child; the test will timeout with stderr.
+    }
+  });
+
+  return {
+    read(predicate, timeoutMs = 10_000) {
+      const queuedIndex = queue.findIndex(predicate);
+      if (queuedIndex !== -1) {
+        const [message] = queue.splice(queuedIndex, 1);
+        return Promise.resolve(message);
+      }
+
+      return new Promise((resolve, reject) => {
+        const timer = setTimeout(() => {
+          const waiterIndex = waiters.findIndex((waiter) => waiter.timer === timer);
+          if (waiterIndex !== -1) waiters.splice(waiterIndex, 1);
+          reject(new Error("timed out waiting for JSON-RPC response"));
+        }, timeoutMs);
+        waiters.push({ predicate, resolve, timer });
+        drain();
+      });
+    },
+  };
+}
+
+function writeJson(child, message) {
+  child.stdin.write(`${JSON.stringify(message)}\n`);
+}
+
+async function request(child, reader, id, method, params = {}) {
+  writeJson(child, { jsonrpc: "2.0", id, method, params });
+  return reader.read((message) => message.id === id);
+}
+
+afterEach(async () => {
+  for (const child of children.splice(0)) {
+    if (child.exitCode === null) child.kill();
+  }
+  await sleep(100);
+});
+
+describe("airmcp connect", () => {
+  test("bridges a stdio client to the app-owned HTTP runtime", async () => {
+    const port = await getFreePort();
+    const server = spawnAirMcp(["--http", "--port", String(port)]);
+    await waitForHealth(port, server);
+
+    const proxy = spawnAirMcp(["connect", "--url", `http://127.0.0.1:${port}/mcp`]);
+    const reader = createJsonReader(proxy.stdout);
+
+    const initialized = await request(proxy, reader, 1, "initialize", {
+      protocolVersion: "2025-03-26",
+      capabilities: {},
+      clientInfo: { name: "airmcp-connect-test", version: "0.0.0" },
+    });
+    expect(initialized.error).toBeUndefined();
+    expect(initialized.result.serverInfo.name).toBe("airmcp");
+
+    writeJson(proxy, { jsonrpc: "2.0", method: "notifications/initialized", params: {} });
+    const tools = await request(proxy, reader, 2, "tools/list");
+
+    expect(tools.error).toBeUndefined();
+    expect(Array.isArray(tools.result.tools)).toBe(true);
+    expect(tools.result.tools.length).toBeGreaterThan(100);
+  }, 30_000);
+});

--- a/tests/cli-workflows.test.js
+++ b/tests/cli-workflows.test.js
@@ -186,7 +186,8 @@ describe("cli workflows command", () => {
 
     expect(onboarding).toContain('id: "codex"');
     expect(onboarding).toContain('NodeEnvironment.findExecutable(named: "codex")');
-    expect(onboarding).toContain('"mcp", "add", "airmcp", "--", "npx", "-y"');
+    expect(onboarding).toContain('"mcp", "remove", "airmcp"');
+    expect(onboarding).toContain('"mcp", "add", "airmcp", "--url", AirMcpConstants.appOwnedHttpURL');
   });
 
   test("onboarding final step can copy the selected workflow prompt", () => {

--- a/tests/codex-mcp.test.js
+++ b/tests/codex-mcp.test.js
@@ -1,0 +1,73 @@
+import { beforeEach, describe, expect, jest, test } from "@jest/globals";
+
+const execFileSync = jest.fn();
+
+jest.unstable_mockModule("node:child_process", () => ({
+  execFileSync,
+}));
+
+const {
+  CODEX_APP_OWNED_URL,
+  codexAirmcpRuntimeShape,
+  configureCodexAirmcp,
+  isCodexAirmcpConfigured,
+  stdioProxyArgs,
+} = await import("../dist/cli/codex-mcp.js");
+
+let codexGetOutput;
+
+beforeEach(() => {
+  codexGetOutput = null;
+  execFileSync.mockReset();
+  execFileSync.mockImplementation((_command, args) => {
+    if (args[0] === "--version") return "codex 0.0.0";
+    if (args.join(" ") === "mcp get airmcp") {
+      if (codexGetOutput === null) throw new Error("missing");
+      return codexGetOutput;
+    }
+    return "";
+  });
+});
+
+describe("codex MCP setup", () => {
+  test("classifies stale direct stdio config separately from app-owned runtime", () => {
+    codexGetOutput = [
+      "airmcp",
+      "  enabled: true",
+      "  transport: stdio",
+      "  command: npx",
+      "  args: -y airmcp@2.12.0",
+    ].join("\n");
+
+    expect(isCodexAirmcpConfigured()).toBe(true);
+    expect(codexAirmcpRuntimeShape()).toBe("direct");
+  });
+
+  test("classifies the app-owned HTTP config as the recommended shape", () => {
+    codexGetOutput = ["airmcp", "  enabled: true", "  transport: streamable-http", `  url: ${CODEX_APP_OWNED_URL}`].join(
+      "\n",
+    );
+
+    expect(codexAirmcpRuntimeShape()).toBe("app-owned");
+  });
+
+  test("replaces an existing Codex entry with the app-owned HTTP URL", () => {
+    codexGetOutput = "airmcp\n  transport: stdio\n  command: npx\n  args: -y airmcp";
+
+    expect(configureCodexAirmcp()).toBe("configured");
+    expect(execFileSync).toHaveBeenCalledWith(
+      "codex",
+      ["mcp", "remove", "airmcp"],
+      expect.objectContaining({ encoding: "utf8" }),
+    );
+    expect(execFileSync).toHaveBeenCalledWith(
+      "codex",
+      ["mcp", "add", "airmcp", "--url", CODEX_APP_OWNED_URL],
+      expect.objectContaining({ encoding: "utf8" }),
+    );
+  });
+
+  test("stdio clients use the proxy command rather than launching another server", () => {
+    expect(stdioProxyArgs()).toEqual(["-y", "airmcp", "connect", "--url", CODEX_APP_OWNED_URL]);
+  });
+});


### PR DESCRIPTION
## Summary
- start the menubar-managed server as loopback Streamable HTTP instead of a detached stdio process
- add `npx airmcp connect` as a stdio-to-HTTP proxy for Claude Desktop/Cursor/Windsurf-style clients
- switch Codex setup/onboarding/docs to the app-owned HTTP URL and teach doctor to warn on stale direct stdio config
- add runtime tests for the proxy and Codex config shape

## Verification
- npm test
- npm run typecheck
- npm run gen:intents:check
- npm run gen:manifest:check
- npm run mcp:validate
- npm run app-build
- npm run app:verify (exit 0; local ad-hoc bundle still warns on Gatekeeper/AppIntents registration, as expected without Developer ID signing)