### PR TITLE
Require token for app-owned runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,7 +241,7 @@ See [docs/shortcuts.md](docs/shortcuts.md) for the full guide + [RFC 0007](docs/
 
 ## Client Setup
 
-Works with any MCP-compatible client. Start AirMCP.app first. Clients with HTTP MCP support can connect directly to `http://127.0.0.1:3847/mcp`; stdio-only clients use `npx -y airmcp connect` as a proxy into the app-owned runtime.
+Works with any MCP-compatible client. Start AirMCP.app first; it owns the local Apple permissions and starts a token-gated HTTP runtime on `http://127.0.0.1:3847/mcp`. Stdio-only clients use `npx -y airmcp connect` as a proxy into that runtime with `AIRMCP_HTTP_TOKEN` set. The app and setup wizard generate the per-install token at `~/Library/Application Support/AirMCP/http-token`.
 
 ### Claude Desktop
 
@@ -252,7 +252,10 @@ Add to `~/Library/Application Support/Claude/claude_desktop_config.json`:
   "mcpServers": {
     "airmcp": {
       "command": "npx",
-      "args": ["-y", "airmcp", "connect", "--url", "http://127.0.0.1:3847/mcp"]
+      "args": ["-y", "airmcp", "connect", "--url", "http://127.0.0.1:3847/mcp"],
+      "env": {
+        "AIRMCP_HTTP_TOKEN": "<token>"
+      }
     }
   }
 }
@@ -261,13 +264,13 @@ Add to `~/Library/Application Support/Claude/claude_desktop_config.json`:
 ### Claude Code
 
 ```bash
-claude mcp add airmcp -- npx -y airmcp connect --url http://127.0.0.1:3847/mcp
+claude mcp add --env AIRMCP_HTTP_TOKEN=<token> airmcp -- npx -y airmcp connect --url http://127.0.0.1:3847/mcp
 ```
 
 ### Codex
 
 ```bash
-codex mcp add airmcp --url http://127.0.0.1:3847/mcp
+codex mcp add --env AIRMCP_HTTP_TOKEN=<token> airmcp -- npx -y airmcp connect --url http://127.0.0.1:3847/mcp
 ```
 
 ### Cursor
@@ -279,7 +282,10 @@ Add to `.cursor/mcp.json`:
   "mcpServers": {
     "airmcp": {
       "command": "npx",
-      "args": ["-y", "airmcp", "connect", "--url", "http://127.0.0.1:3847/mcp"]
+      "args": ["-y", "airmcp", "connect", "--url", "http://127.0.0.1:3847/mcp"],
+      "env": {
+        "AIRMCP_HTTP_TOKEN": "<token>"
+      }
     }
   }
 }
@@ -294,7 +300,10 @@ Add to `~/.codeium/windsurf/mcp_config.json`:
   "mcpServers": {
     "airmcp": {
       "command": "npx",
-      "args": ["-y", "airmcp", "connect", "--url", "http://127.0.0.1:3847/mcp"]
+      "args": ["-y", "airmcp", "connect", "--url", "http://127.0.0.1:3847/mcp"],
+      "env": {
+        "AIRMCP_HTTP_TOKEN": "<token>"
+      }
     }
   }
 }
@@ -302,7 +311,7 @@ Add to `~/.codeium/windsurf/mcp_config.json`:
 
 ### Other MCP Clients
 
-Any client that supports the MCP stdio transport can use AirMCP. Use `npx -y airmcp connect --url http://127.0.0.1:3847/mcp` as the command when AirMCP.app owns the runtime. Use direct `npx -y airmcp` only when you intentionally want that client process to own a separate server instance.
+Any client that supports the MCP stdio transport can use AirMCP. Use `npx -y airmcp connect --url http://127.0.0.1:3847/mcp` with `AIRMCP_HTTP_TOKEN` set when AirMCP.app owns the runtime. Direct HTTP clients must send `Authorization: Bearer <token>`. Use direct `npx -y airmcp` only when you intentionally want that client process to own a separate server instance.
 
 ### Local Development
 

--- a/app/Sources/AirMCPApp/AppRuntimeToken.swift
+++ b/app/Sources/AirMCPApp/AppRuntimeToken.swift
@@ -1,0 +1,94 @@
+import Darwin
+import Foundation
+import Security
+
+enum AppRuntimeToken {
+    private static let directoryName = "AirMCP"
+    private static let fileName = "http-token"
+
+    static var tokenURL: URL {
+        let base = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first
+            ?? URL(fileURLWithPath: NSHomeDirectory()).appendingPathComponent("Library/Application Support")
+        return base.appendingPathComponent(directoryName, isDirectory: true).appendingPathComponent(fileName)
+    }
+
+    static func ensure() throws -> String {
+        let url = tokenURL
+        let dir = url.deletingLastPathComponent()
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        chmod(dir.path, S_IRWXU)
+
+        if let existing = try? readToken(at: url), !existing.isEmpty {
+            chmod(url.path, S_IRUSR | S_IWUSR)
+            return existing
+        }
+
+        let token = try randomToken()
+        if try writeTokenExclusively(token, to: url) {
+            return token
+        }
+
+        let raced = try readToken(at: url)
+        guard !raced.isEmpty else {
+            throw NSError(
+                domain: "AirMCPAppRuntimeToken",
+                code: 1,
+                userInfo: [NSLocalizedDescriptionKey: "AirMCP app runtime token exists but is empty."]
+            )
+        }
+        chmod(url.path, S_IRUSR | S_IWUSR)
+        return raced
+    }
+
+    private static func readToken(at url: URL) throws -> String {
+        try String(contentsOf: url, encoding: .utf8)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private static func randomToken() throws -> String {
+        var bytes = [UInt8](repeating: 0, count: 32)
+        let status = SecRandomCopyBytes(kSecRandomDefault, bytes.count, &bytes)
+        guard status == errSecSuccess else {
+            throw NSError(
+                domain: NSOSStatusErrorDomain,
+                code: Int(status),
+                userInfo: [NSLocalizedDescriptionKey: "Failed to generate AirMCP app runtime token."]
+            )
+        }
+
+        return Data(bytes)
+            .base64EncodedString()
+            .replacingOccurrences(of: "+", with: "-")
+            .replacingOccurrences(of: "/", with: "_")
+            .replacingOccurrences(of: "=", with: "")
+    }
+
+    private static func writeTokenExclusively(_ token: String, to url: URL) throws -> Bool {
+        let fd = open(url.path, O_WRONLY | O_CREAT | O_EXCL, S_IRUSR | S_IWUSR)
+        if fd == -1 {
+            if errno == EEXIST {
+                return false
+            }
+            throw NSError(
+                domain: NSPOSIXErrorDomain,
+                code: Int(errno),
+                userInfo: [NSLocalizedDescriptionKey: "Failed to create AirMCP app runtime token."]
+            )
+        }
+
+        let data = Data("\(token)\n".utf8)
+        let written = data.withUnsafeBytes { buffer in
+            write(fd, buffer.baseAddress, buffer.count)
+        }
+        close(fd)
+        guard written == data.count else {
+            throw NSError(
+                domain: NSPOSIXErrorDomain,
+                code: Int(errno),
+                userInfo: [NSLocalizedDescriptionKey: "Failed to write AirMCP app runtime token."]
+            )
+        }
+        chmod(url.path, S_IRUSR | S_IWUSR)
+        return true
+    }
+}

--- a/app/Sources/AirMCPApp/ServerManager.swift
+++ b/app/Sources/AirMCPApp/ServerManager.swift
@@ -187,6 +187,15 @@ final class ServerManager {
                     ))
                     return
                 }
+                let token: String
+                do {
+                    token = try AppRuntimeToken.ensure()
+                } catch {
+                    continuation.resume(returning: .failure(
+                        "Failed to prepare app runtime token: \(error.localizedDescription)"
+                    ))
+                    return
+                }
 
                 let process = Process()
                 process.executableURL = URL(fileURLWithPath: npxPath)
@@ -200,7 +209,8 @@ final class ServerManager {
                 process.standardOutput = stdoutPipe ?? FileHandle.nullDevice
                 process.standardError = stderrPipe ?? FileHandle.nullDevice
                 var env = NodeEnvironment.buildEnv()
-                env["AIRMCP_ALLOW_NETWORK"] = "loopback-only"
+                env["AIRMCP_ALLOW_NETWORK"] = "with-token"
+                env["AIRMCP_HTTP_TOKEN"] = token
                 env["AIRMCP_APP_OWNED_RUNTIME"] = "1"
                 process.environment = env
 

--- a/app/Sources/AirMCPApp/SetupManager.swift
+++ b/app/Sources/AirMCPApp/SetupManager.swift
@@ -68,7 +68,7 @@ final class SetupManager {
             try? await Task.sleep(nanoseconds: 500_000_000)
 
             await MainActor.run {
-                AirMcpConstants.copyToClipboard(AirMcpConstants.claudeDesktopConfig)
+                AirMcpConstants.copyToClipboard(AirMcpConstants.claudeDesktopConfig())
                 self?.state = .done
             }
         }

--- a/app/Sources/AirMCPApp/Views/MenuContent.swift
+++ b/app/Sources/AirMCPApp/Views/MenuContent.swift
@@ -164,28 +164,49 @@ enum AirMcpConstants {
     static let appOwnedHealthURL = "http://127.0.0.1:\(appOwnedHttpPort)/health"
     static let keyAutoStart = "autoStartServer"
     static let keyOnboardingCompleted = "onboardingCompleted"
-    static let appOwnedProxyArgs = ["-y", npmPackageName, "connect", "--url", appOwnedHttpURL]
 
-    static var appOwnedProxyEntry: [String: Any] {
+    static var appOwnedProxyArgs: [String] {
+        ["-y", npmPackageName, "connect", "--url", appOwnedHttpURL]
+    }
+
+    static func appOwnedProxyEntry(token: String) -> [String: Any] {
         [
             "command": "npx",
             "args": appOwnedProxyArgs,
+            "env": [
+                "AIRMCP_HTTP_TOKEN": token,
+            ],
         ]
     }
 
-    static let claudeDesktopConfig = """
-    {
-      "mcpServers": {
-        "airmcp": {
-          "command": "npx",
-          "args": ["-y", "\(npmPackageName)", "connect", "--url", "\(appOwnedHttpURL)"]
-        }
-      }
+    static func tokenForConfig() -> String {
+        (try? AppRuntimeToken.ensure()) ?? "<token>"
     }
-    """
 
-    static let claudeCodeConfig = "claude mcp add airmcp -- npx -y \(npmPackageName) connect --url \(appOwnedHttpURL)"
-    static let codexConfig = "codex mcp add airmcp --url \(appOwnedHttpURL)"
+    static func claudeDesktopConfig() -> String {
+        let token = tokenForConfig()
+        return """
+        {
+          "mcpServers": {
+            "airmcp": {
+              "command": "npx",
+              "args": ["-y", "\(npmPackageName)", "connect", "--url", "\(appOwnedHttpURL)"],
+              "env": {
+                "AIRMCP_HTTP_TOKEN": "\(token)"
+              }
+            }
+          }
+        }
+        """
+    }
+
+    static func claudeCodeConfig() -> String {
+        "claude mcp add --env AIRMCP_HTTP_TOKEN=\(tokenForConfig()) airmcp -- npx -y \(npmPackageName) connect --url \(appOwnedHttpURL)"
+    }
+
+    static func codexConfig() -> String {
+        "codex mcp add --env AIRMCP_HTTP_TOKEN=\(tokenForConfig()) airmcp -- npx -y \(npmPackageName) connect --url \(appOwnedHttpURL)"
+    }
 
     static func copyToClipboard(_ text: String) {
         NSPasteboard.general.clearContents()
@@ -618,16 +639,16 @@ struct MenuContent: View {
         .disabled(permissionManager.isRunning)
 
         Button(L("menu.copyClaudeConfig")) {
-            AirMcpConstants.copyToClipboard(AirMcpConstants.claudeDesktopConfig)
+            AirMcpConstants.copyToClipboard(AirMcpConstants.claudeDesktopConfig())
         }
         .keyboardShortcut("c")
 
         Button(L("menu.copyClaudeCodeConfig")) {
-            AirMcpConstants.copyToClipboard(AirMcpConstants.claudeCodeConfig)
+            AirMcpConstants.copyToClipboard(AirMcpConstants.claudeCodeConfig())
         }
 
         Button(L("menu.copyCodexConfig")) {
-            AirMcpConstants.copyToClipboard(AirMcpConstants.codexConfig)
+            AirMcpConstants.copyToClipboard(AirMcpConstants.codexConfig())
         }
 
         Button(L("menu.addWidget")) {

--- a/app/Sources/AirMCPApp/Views/OnboardingView.swift
+++ b/app/Sources/AirMCPApp/Views/OnboardingView.swift
@@ -768,9 +768,28 @@ struct OnboardingView: View {
         guard let codex = NodeEnvironment.findExecutable(named: "codex") else {
             return false
         }
+        guard let token = try? AppRuntimeToken.ensure() else {
+            return false
+        }
 
         _ = runProcess(codex, arguments: ["mcp", "remove", "airmcp"])
-        return runProcess(codex, arguments: ["mcp", "add", "airmcp", "--url", AirMcpConstants.appOwnedHttpURL])
+        return runProcess(
+            codex,
+            arguments: [
+                "mcp",
+                "add",
+                "--env",
+                "AIRMCP_HTTP_TOKEN=\(token)",
+                "airmcp",
+                "--",
+                "npx",
+                "-y",
+                AirMcpConstants.npmPackageName,
+                "connect",
+                "--url",
+                AirMcpConstants.appOwnedHttpURL,
+            ]
+        )
     }
 
     private nonisolated static func runProcess(_ executable: String, arguments: [String]) -> Bool {
@@ -807,8 +826,11 @@ struct OnboardingView: View {
             config = [:]
         }
 
-        // Build the airmcp entry
-        let airmcpEntry = AirMcpConstants.appOwnedProxyEntry
+        // Build the token-gated app-owned runtime entry
+        guard let token = try? AppRuntimeToken.ensure() else {
+            return false
+        }
+        let airmcpEntry = AirMcpConstants.appOwnedProxyEntry(token: token)
 
         // Merge into mcpServers
         var servers = config["mcpServers"] as? [String: Any] ?? [:]

--- a/docs/site/src/content/docs/architecture/overview.md
+++ b/docs/site/src/content/docs/architecture/overview.md
@@ -97,7 +97,7 @@ This is under development in the `ios/` directory.
 AirMCP supports two MCP transports:
 
 - **Streamable HTTP** (`--http` flag) -- Express-based HTTP server with session management. This is the recommended AirMCP.app-owned local runtime on `127.0.0.1:3847`.
-- **Stdio** (default) -- communicates via stdin/stdout. Direct stdio is useful for development; stdio-only clients should use `npx -y airmcp connect --url http://127.0.0.1:3847/mcp` to proxy into the app-owned runtime.
+- **Stdio** (default) -- communicates via stdin/stdout. Direct stdio is useful for development; stdio-only clients should use `npx -y airmcp connect --url http://127.0.0.1:3847/mcp` with `AIRMCP_HTTP_TOKEN` set to proxy into the app-owned runtime.
 
 ### Module System
 

--- a/docs/site/src/content/docs/getting-started/configuration.md
+++ b/docs/site/src/content/docs/getting-started/configuration.md
@@ -151,7 +151,7 @@ Clients connect with:
 Authorization: Bearer my-secret-token
 ```
 
-Using `--bind-all` without `AIRMCP_HTTP_TOKEN` prints a security warning. On a trusted local network this may be acceptable, but for any internet-facing deployment, always set a token.
+Using `--bind-all` without `AIRMCP_HTTP_TOKEN` is rejected at startup. Use `AIRMCP_ALLOW_NETWORK=with-token` with a token for trusted network exposure, or `with-token+origin` / `with-oauth+origin` for browser-facing clients.
 
 ## Starter Modules
 

--- a/docs/site/src/content/docs/getting-started/installation.md
+++ b/docs/site/src/content/docs/getting-started/installation.md
@@ -26,7 +26,7 @@ This will:
 
 ## Manual Setup
 
-If you prefer manual configuration, start AirMCP.app first. HTTP-capable clients connect to `http://127.0.0.1:3847/mcp`; stdio-only clients use `npx -y airmcp connect` as a proxy into that app-owned runtime.
+If you prefer manual configuration, start AirMCP.app first. It owns the local Apple permissions and starts a token-gated runtime on `http://127.0.0.1:3847/mcp`. Stdio-only clients use `npx -y airmcp connect` as a proxy into that runtime with `AIRMCP_HTTP_TOKEN` set. The app and setup wizard generate the per-install token at `~/Library/Application Support/AirMCP/http-token`.
 
 ### Claude Desktop
 
@@ -37,7 +37,10 @@ Edit `~/Library/Application Support/Claude/claude_desktop_config.json`:
   "mcpServers": {
     "airmcp": {
       "command": "npx",
-      "args": ["-y", "airmcp", "connect", "--url", "http://127.0.0.1:3847/mcp"]
+      "args": ["-y", "airmcp", "connect", "--url", "http://127.0.0.1:3847/mcp"],
+      "env": {
+        "AIRMCP_HTTP_TOKEN": "<token>"
+      }
     }
   }
 }
@@ -52,7 +55,10 @@ Edit `~/.claude/mcp.json`:
   "mcpServers": {
     "airmcp": {
       "command": "npx",
-      "args": ["-y", "airmcp", "connect", "--url", "http://127.0.0.1:3847/mcp"]
+      "args": ["-y", "airmcp", "connect", "--url", "http://127.0.0.1:3847/mcp"],
+      "env": {
+        "AIRMCP_HTTP_TOKEN": "<token>"
+      }
     }
   }
 }
@@ -67,7 +73,10 @@ Edit `~/.cursor/mcp.json`:
   "mcpServers": {
     "airmcp": {
       "command": "npx",
-      "args": ["-y", "airmcp", "connect", "--url", "http://127.0.0.1:3847/mcp"]
+      "args": ["-y", "airmcp", "connect", "--url", "http://127.0.0.1:3847/mcp"],
+      "env": {
+        "AIRMCP_HTTP_TOKEN": "<token>"
+      }
     }
   }
 }
@@ -82,7 +91,10 @@ Edit `~/.codeium/windsurf/mcp_config.json`:
   "mcpServers": {
     "airmcp": {
       "command": "npx",
-      "args": ["-y", "airmcp", "connect", "--url", "http://127.0.0.1:3847/mcp"]
+      "args": ["-y", "airmcp", "connect", "--url", "http://127.0.0.1:3847/mcp"],
+      "env": {
+        "AIRMCP_HTTP_TOKEN": "<token>"
+      }
     }
   }
 }

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -62,13 +62,13 @@ Use a workflow id with `--prompt`, `--siri`, `--tools`, `--modules`, `--safety`,
 For Codex:
 
 ```bash
-codex mcp add airmcp --url http://127.0.0.1:3847/mcp
+codex mcp add --env AIRMCP_HTTP_TOKEN=<token> airmcp -- npx -y airmcp connect --url http://127.0.0.1:3847/mcp
 ```
 
 For Claude Code:
 
 ```bash
-claude mcp add airmcp -- npx -y airmcp connect --url http://127.0.0.1:3847/mcp
+claude mcp add --env AIRMCP_HTTP_TOKEN=<token> airmcp -- npx -y airmcp connect --url http://127.0.0.1:3847/mcp
 ```
 
 For Siri and Shortcuts, see [shortcuts.md](shortcuts.md). The default AppShortcuts are workflow-first; `Ask AirMCP` is a separate FoundationModels preview shortcut that only appears in opt-in builds with `AIRMCP_ENABLE_FOUNDATION_MODELS`.

--- a/src/cli/codex-mcp.ts
+++ b/src/cli/codex-mcp.ts
@@ -1,6 +1,7 @@
 import { execFileSync } from "node:child_process";
 import { NPM_PACKAGE_NAME } from "../shared/config.js";
 import { IDENTITY } from "../shared/constants.js";
+import { ensureAppRuntimeToken } from "../shared/app-runtime-token.js";
 
 export const CODEX_APP_OWNED_URL = `http://127.0.0.1:${IDENTITY.HTTP_PORT}/mcp`;
 export type CodexAirmcpRuntimeShape = "app-owned" | "direct" | "unknown" | "missing";
@@ -37,7 +38,11 @@ export function isCodexAirmcpConfigured(): boolean {
 export function codexAirmcpRuntimeShape(): CodexAirmcpRuntimeShape {
   const config = getCodexAirmcpConfig();
   if (!config) return "missing";
-  if (config.includes(CODEX_APP_OWNED_URL) || config.includes("transport: streamable-http")) {
+  if (
+    config.includes(CODEX_APP_OWNED_URL) &&
+    config.includes("transport: stdio") &&
+    config.includes("AIRMCP_HTTP_TOKEN")
+  ) {
     return "app-owned";
   }
   if (config.includes("transport: stdio") || config.includes("command: npx")) {
@@ -47,17 +52,41 @@ export function codexAirmcpRuntimeShape(): CodexAirmcpRuntimeShape {
 }
 
 export function configureCodexAirmcp(): "already-configured" | "configured" {
+  const token = ensureAppRuntimeToken();
   if (isCodexAirmcpConfigured()) {
     runCodex(["mcp", "remove", "airmcp"]);
   }
-  runCodex(["mcp", "add", "airmcp", "--url", CODEX_APP_OWNED_URL]);
+  runCodex([
+    "mcp",
+    "add",
+    "--env",
+    `AIRMCP_HTTP_TOKEN=${token}`,
+    "airmcp",
+    "--",
+    "npx",
+    "-y",
+    NPM_PACKAGE_NAME,
+    "connect",
+    "--url",
+    CODEX_APP_OWNED_URL,
+  ]);
   return "configured";
 }
 
 export function codexManualSetupCommand(): string {
-  return `codex mcp add airmcp --url ${CODEX_APP_OWNED_URL}`;
+  return "codex mcp add --env AIRMCP_HTTP_TOKEN=<token> airmcp -- npx -y airmcp connect --url " + CODEX_APP_OWNED_URL;
 }
 
-export function stdioProxyArgs(): string[] {
-  return ["-y", NPM_PACKAGE_NAME, "connect", "--url", CODEX_APP_OWNED_URL];
+export function stdioProxyEntry(token = ensureAppRuntimeToken()): {
+  command: string;
+  args: string[];
+  env: Record<string, string>;
+} {
+  return {
+    command: "npx",
+    args: ["-y", NPM_PACKAGE_NAME, "connect", "--url", CODEX_APP_OWNED_URL],
+    env: {
+      AIRMCP_HTTP_TOKEN: token,
+    },
+  };
 }

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -33,10 +33,12 @@ interface FileConfig {
 function clientRuntimeShape(entry: unknown): "app-owned" | "direct" | "unknown" {
   if (!entry || typeof entry !== "object") return "unknown";
   const record = entry as Record<string, unknown>;
-  if (record.url === CODEX_APP_OWNED_URL) return "app-owned";
   const command = typeof record.command === "string" ? record.command : "";
   const args = Array.isArray(record.args) ? record.args.filter((arg): arg is string => typeof arg === "string") : [];
-  if (args.includes("connect") && args.includes(CODEX_APP_OWNED_URL)) return "app-owned";
+  const env = record.env && typeof record.env === "object" ? (record.env as Record<string, unknown>) : {};
+  const hasToken = typeof env.AIRMCP_HTTP_TOKEN === "string" && env.AIRMCP_HTTP_TOKEN.length > 0;
+  if (args.includes("connect") && args.includes(CODEX_APP_OWNED_URL) && hasToken) return "app-owned";
+  if (args.includes("connect") && args.includes(CODEX_APP_OWNED_URL)) return "unknown";
   if (command === "npx" && args.some((arg) => arg === "airmcp" || arg.startsWith("airmcp@"))) return "direct";
   return "unknown";
 }
@@ -168,10 +170,7 @@ export async function runDoctor(): Promise<void> {
     if (shape === "app-owned") {
       ok("Codex", `${GREEN}connected${RESET} ${DIM}(AirMCP.app runtime)${RESET}`);
     } else if (shape === "direct") {
-      meh(
-        "Codex",
-        `connected via direct stdio — run: codex mcp remove airmcp && codex mcp add airmcp --url ${CODEX_APP_OWNED_URL}`,
-      );
+      meh("Codex", "connected via direct stdio — rerun init for token-gated AirMCP.app runtime");
     } else if (shape === "missing") {
       meh("Codex", `found but no airmcp entry`);
     } else {

--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -10,7 +10,7 @@ import { readFileSync, writeFileSync, mkdirSync, existsSync, copyFileSync } from
 import { join } from "node:path";
 import { MODULE_NAMES, STARTER_MODULES, MCP_CLIENTS } from "../shared/config.js";
 import { PATHS } from "../shared/constants.js";
-import { codexManualSetupCommand, configureCodexAirmcp, isCodexCliAvailable, stdioProxyArgs } from "./codex-mcp.js";
+import { codexManualSetupCommand, configureCodexAirmcp, isCodexCliAvailable, stdioProxyEntry } from "./codex-mcp.js";
 import { LOGO_LINES, typeLine, sleep, writeOut } from "../shared/banner.js";
 import { isPlainObject } from "../shared/validate.js";
 import { formatError } from "../shared/errors.js";
@@ -450,10 +450,7 @@ export async function runInit(): Promise<void> {
   console.log(` ${GREEN}\u2713${RESET} ${PATHS.CONFIG}`);
 
   // --- Step 3: Auto-detect and patch MCP client configs ---
-  const airmcpEntry = {
-    command: "npx",
-    args: stdioProxyArgs(),
-  };
+  const airmcpEntry = stdioProxyEntry();
 
   let patchedClients = 0;
   const detectedClients: string[] = [];

--- a/src/shared/app-runtime-token.ts
+++ b/src/shared/app-runtime-token.ts
@@ -1,0 +1,50 @@
+import { chmodSync, closeSync, existsSync, mkdirSync, openSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { randomBytes } from "node:crypto";
+import { HOME } from "./constants.js";
+
+export const APP_RUNTIME_TOKEN_PATH = join(HOME, "Library", "Application Support", "AirMCP", "http-token");
+
+function createToken(): string {
+  return randomBytes(32).toString("base64url");
+}
+
+function readTokenFile(): string {
+  return readFileSync(APP_RUNTIME_TOKEN_PATH, "utf8").trim();
+}
+
+function writeTokenExclusively(token: string): boolean {
+  mkdirSync(dirname(APP_RUNTIME_TOKEN_PATH), { recursive: true, mode: 0o700 });
+  try {
+    const fd = openSync(APP_RUNTIME_TOKEN_PATH, "wx", 0o600);
+    try {
+      writeFileSync(fd, `${token}\n`, { encoding: "utf8" });
+    } finally {
+      closeSync(fd);
+    }
+    chmodSync(APP_RUNTIME_TOKEN_PATH, 0o600);
+    return true;
+  } catch (error) {
+    const code = error && typeof error === "object" && "code" in error ? error.code : undefined;
+    if (code === "EEXIST") return false;
+    throw new Error(`Failed to create AirMCP app runtime token at ${APP_RUNTIME_TOKEN_PATH}`, { cause: error });
+  }
+}
+
+export function ensureAppRuntimeToken(): string {
+  if (existsSync(APP_RUNTIME_TOKEN_PATH)) {
+    const existing = readTokenFile();
+    if (existing) {
+      chmodSync(APP_RUNTIME_TOKEN_PATH, 0o600);
+      return existing;
+    }
+  }
+
+  const token = createToken();
+  if (writeTokenExclusively(token)) return token;
+
+  const raced = readTokenFile();
+  if (!raced) throw new Error(`AirMCP app runtime token exists but is empty: ${APP_RUNTIME_TOKEN_PATH}`);
+  chmodSync(APP_RUNTIME_TOKEN_PATH, 0o600);
+  return raced;
+}

--- a/tests/app-runtime-token.test.js
+++ b/tests/app-runtime-token.test.js
@@ -1,0 +1,52 @@
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { jest } from "@jest/globals";
+
+const originalHome = process.env.HOME;
+const tempHomes = [];
+
+async function loadTokenModule(home) {
+  process.env.HOME = home;
+  jest.resetModules();
+  return import("../dist/shared/app-runtime-token.js");
+}
+
+afterEach(() => {
+  process.env.HOME = originalHome;
+  jest.resetModules();
+  for (const home of tempHomes.splice(0)) {
+    rmSync(home, { recursive: true, force: true });
+  }
+});
+
+describe("app runtime token", () => {
+  test("creates a per-install token with private permissions", async () => {
+    const home = mkdtempSync(join(tmpdir(), "airmcp-token-"));
+    tempHomes.push(home);
+
+    const { APP_RUNTIME_TOKEN_PATH, ensureAppRuntimeToken } = await loadTokenModule(home);
+    const token = ensureAppRuntimeToken();
+
+    expect(APP_RUNTIME_TOKEN_PATH).toBe(join(home, "Library", "Application Support", "AirMCP", "http-token"));
+    expect(token).toMatch(/^[A-Za-z0-9_-]{43}$/);
+    expect(readFileSync(APP_RUNTIME_TOKEN_PATH, "utf8").trim()).toBe(token);
+    expect(statSync(APP_RUNTIME_TOKEN_PATH).mode & 0o777).toBe(0o600);
+    expect(statSync(join(home, "Library", "Application Support", "AirMCP")).mode & 0o777).toBe(0o700);
+    expect(ensureAppRuntimeToken()).toBe(token);
+  });
+
+  test("reuses an existing token and repairs file mode", async () => {
+    const home = mkdtempSync(join(tmpdir(), "airmcp-token-"));
+    tempHomes.push(home);
+    const dir = join(home, "Library", "Application Support", "AirMCP");
+    const path = join(dir, "http-token");
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(path, "existing-token\n", { mode: 0o644 });
+
+    const { ensureAppRuntimeToken } = await loadTokenModule(home);
+
+    expect(ensureAppRuntimeToken()).toBe("existing-token");
+    expect(statSync(path).mode & 0o777).toBe(0o600);
+  });
+});

--- a/tests/cli-connect.test.js
+++ b/tests/cli-connect.test.js
@@ -25,10 +25,10 @@ async function getFreePort() {
   return address.port;
 }
 
-function spawnAirMcp(args) {
+function spawnAirMcp(args, envOverrides = {}) {
   const child = spawn(process.execPath, [DIST, ...args], {
     cwd: ROOT,
-    env: cleanBootEnv(),
+    env: { ...cleanBootEnv(), ...envOverrides },
     stdio: ["pipe", "pipe", "pipe"],
   });
   child.stderr.setEncoding("utf8");
@@ -123,12 +123,25 @@ afterEach(async () => {
 });
 
 describe("airmcp connect", () => {
-  test("bridges a stdio client to the app-owned HTTP runtime", async () => {
+  test("bridges a stdio client to the token-gated app-owned HTTP runtime", async () => {
     const port = await getFreePort();
-    const server = spawnAirMcp(["--http", "--port", String(port)]);
+    const token = "test-runtime-token";
+    const server = spawnAirMcp(["--http", "--port", String(port)], {
+      AIRMCP_ALLOW_NETWORK: "with-token",
+      AIRMCP_HTTP_TOKEN: token,
+    });
     await waitForHealth(port, server);
 
-    const proxy = spawnAirMcp(["connect", "--url", `http://127.0.0.1:${port}/mcp`]);
+    const unauthenticated = await fetch(`http://127.0.0.1:${port}/mcp`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ jsonrpc: "2.0", id: 99, method: "initialize" }),
+    });
+    expect(unauthenticated.status).toBe(401);
+
+    const proxy = spawnAirMcp(["connect", "--url", `http://127.0.0.1:${port}/mcp`], {
+      AIRMCP_HTTP_TOKEN: token,
+    });
     const reader = createJsonReader(proxy.stdout);
 
     const initialized = await request(proxy, reader, 1, "initialize", {

--- a/tests/cli-workflows.test.js
+++ b/tests/cli-workflows.test.js
@@ -187,7 +187,12 @@ describe("cli workflows command", () => {
     expect(onboarding).toContain('id: "codex"');
     expect(onboarding).toContain('NodeEnvironment.findExecutable(named: "codex")');
     expect(onboarding).toContain('"mcp", "remove", "airmcp"');
-    expect(onboarding).toContain('"mcp", "add", "airmcp", "--url", AirMcpConstants.appOwnedHttpURL');
+    expect(onboarding).toContain('"mcp",');
+    expect(onboarding).toContain('"add",');
+    expect(onboarding).toContain('"--env"');
+    expect(onboarding).toContain('"AIRMCP_HTTP_TOKEN=\\(token)"');
+    expect(onboarding).toContain('"connect"');
+    expect(onboarding).toContain("AirMcpConstants.appOwnedProxyEntry(token: token)");
   });
 
   test("onboarding final step can copy the selected workflow prompt", () => {

--- a/tests/codex-mcp.test.js
+++ b/tests/codex-mcp.test.js
@@ -1,9 +1,14 @@
 import { beforeEach, describe, expect, jest, test } from "@jest/globals";
 
 const execFileSync = jest.fn();
+const ensureAppRuntimeToken = jest.fn(() => "test-runtime-token");
 
 jest.unstable_mockModule("node:child_process", () => ({
   execFileSync,
+}));
+
+jest.unstable_mockModule("../dist/shared/app-runtime-token.js", () => ({
+  ensureAppRuntimeToken,
 }));
 
 const {
@@ -11,7 +16,7 @@ const {
   codexAirmcpRuntimeShape,
   configureCodexAirmcp,
   isCodexAirmcpConfigured,
-  stdioProxyArgs,
+  stdioProxyEntry,
 } = await import("../dist/cli/codex-mcp.js");
 
 let codexGetOutput;
@@ -43,15 +48,28 @@ describe("codex MCP setup", () => {
     expect(codexAirmcpRuntimeShape()).toBe("direct");
   });
 
-  test("classifies the app-owned HTTP config as the recommended shape", () => {
+  test("does not classify a bare HTTP URL as the recommended token-gated shape", () => {
     codexGetOutput = ["airmcp", "  enabled: true", "  transport: streamable-http", `  url: ${CODEX_APP_OWNED_URL}`].join(
       "\n",
     );
 
+    expect(codexAirmcpRuntimeShape()).toBe("unknown");
+  });
+
+  test("classifies the token-gated proxy config as the recommended shape", () => {
+    codexGetOutput = [
+      "airmcp",
+      "  enabled: true",
+      "  transport: stdio",
+      "  command: npx",
+      "  args: -y airmcp connect --url http://127.0.0.1:3847/mcp",
+      "  env: AIRMCP_HTTP_TOKEN=********",
+    ].join("\n");
+
     expect(codexAirmcpRuntimeShape()).toBe("app-owned");
   });
 
-  test("replaces an existing Codex entry with the app-owned HTTP URL", () => {
+  test("replaces an existing Codex entry with the token-gated app-owned proxy", () => {
     codexGetOutput = "airmcp\n  transport: stdio\n  command: npx\n  args: -y airmcp";
 
     expect(configureCodexAirmcp()).toBe("configured");
@@ -62,12 +80,29 @@ describe("codex MCP setup", () => {
     );
     expect(execFileSync).toHaveBeenCalledWith(
       "codex",
-      ["mcp", "add", "airmcp", "--url", CODEX_APP_OWNED_URL],
+      [
+        "mcp",
+        "add",
+        "--env",
+        "AIRMCP_HTTP_TOKEN=test-runtime-token",
+        "airmcp",
+        "--",
+        "npx",
+        "-y",
+        "airmcp",
+        "connect",
+        "--url",
+        CODEX_APP_OWNED_URL,
+      ],
       expect.objectContaining({ encoding: "utf8" }),
     );
   });
 
-  test("stdio clients use the proxy command rather than launching another server", () => {
-    expect(stdioProxyArgs()).toEqual(["-y", "airmcp", "connect", "--url", CODEX_APP_OWNED_URL]);
+  test("stdio clients use a token-gated proxy command rather than launching another server", () => {
+    expect(stdioProxyEntry("test-token")).toEqual({
+      command: "npx",
+      args: ["-y", "airmcp", "connect", "--url", CODEX_APP_OWNED_URL],
+      env: { AIRMCP_HTTP_TOKEN: "test-token" },
+    });
   });
 });


### PR DESCRIPTION
## Summary
- make AirMCP.app start its app-owned HTTP runtime with `with-token`
- generate and reuse a per-install runtime token for app, CLI init, Codex setup, and copyable configs
- update docs so app-owned runtime examples use the stdio proxy with `AIRMCP_HTTP_TOKEN`
- add runtime tests for token file permissions and token-gated app-owned proxy behavior

## Verification
- `npm test`
- `npm run typecheck`
- `npm run gen:intents:check`
- `npm run gen:manifest:check`
- `npm run mcp:validate`
- `npm run app-build`
- `npm run app:verify` exits 0 with expected ad-hoc signing/AppIntents warnings
