### PR TITLE
[codex] Harden Safari internal URL guard

### DIFF
--- a/src/safari/tools.ts
+++ b/src/safari/tools.ts
@@ -1,4 +1,5 @@
 import type { McpServer } from "../shared/mcp.js";
+import { isIP } from "node:net";
 import { z } from "zod";
 import { runJxa } from "../shared/jxa.js";
 import { getOsVersion, type AirMcpConfig } from "../shared/config.js";
@@ -26,24 +27,66 @@ import {
   addToReadingListScript,
 } from "./scripts.js";
 
+function ipv4MappedIpv6ToDotted(host: string): string | null {
+  const dotted = host.match(/^::ffff:(\d{1,3}(?:\.\d{1,3}){3})$/i)?.[1];
+  if (dotted && isIP(dotted) === 4) return dotted;
+
+  const hex = host.match(/^::ffff:([0-9a-f]{1,4}):([0-9a-f]{1,4})$/i);
+  const highGroup = hex?.[1];
+  const lowGroup = hex?.[2];
+  if (!highGroup || !lowGroup) return null;
+
+  const high = Number.parseInt(highGroup, 16);
+  const low = Number.parseInt(lowGroup, 16);
+  if (!Number.isInteger(high) || !Number.isInteger(low) || high > 0xffff || low > 0xffff) return null;
+
+  return `${(high >> 8) & 0xff}.${high & 0xff}.${(low >> 8) & 0xff}.${low & 0xff}`;
+}
+
+function ipv4Octets(host: string): [number, number, number, number] | null {
+  if (isIP(host) !== 4) return null;
+  const parts = host.split(".").map((part) => Number(part));
+  if (parts.length !== 4 || parts.some((part) => !Number.isInteger(part) || part < 0 || part > 255)) {
+    return null;
+  }
+  return [parts[0]!, parts[1]!, parts[2]!, parts[3]!];
+}
+
 function validateExternalHttpUrl(url: string): string | null {
   try {
     const parsed = new URL(url);
     if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
       return `Only http:// and https:// URLs are allowed. Got: ${parsed.protocol}`;
     }
-    const host = parsed.hostname.toLowerCase().replace(/^\[|\]$/g, "");
-    // Loopback (entire 127.0.0.0/8 range, IPv6 ::1, "localhost")
-    if (host === "localhost" || host === "::1" || /^127(?:\.\d{1,3}){3}$/.test(host)) {
+    const host = parsed.hostname
+      .toLowerCase()
+      .replace(/^\[|\]$/g, "")
+      .replace(/\.$/, "");
+    const ipHost = ipv4MappedIpv6ToDotted(host) ?? host;
+    const octets = ipv4Octets(ipHost);
+    const [firstOctet, secondOctet] = octets ?? [-1, -1, -1, -1];
+
+    // Loopback (entire 127.0.0.0/8 range, IPv6 ::1, localhost aliases)
+    if (
+      host === "localhost" ||
+      host.endsWith(".localhost") ||
+      host === "localhost.localdomain" ||
+      host === "::1" ||
+      firstOctet === 127
+    ) {
       return "Opening localhost URLs is not allowed.";
     }
     // RFC1918 private networks
-    if (host.startsWith("10.") || host.startsWith("192.168.") || /^172\.(1[6-9]|2\d|3[01])\./.test(host)) {
+    if (
+      firstOctet === 10 ||
+      (firstOctet === 192 && secondOctet === 168) ||
+      (firstOctet === 172 && secondOctet >= 16 && secondOctet <= 31)
+    ) {
       return "Opening internal network URLs is not allowed.";
     }
     // Link-local: 169.254.0.0/16 — includes cloud metadata endpoints
     // (169.254.169.254 on AWS/GCP/Azure) and IPv6 fe80::/10.
-    if (host.startsWith("169.254.") || host.startsWith("fe80:") || host.startsWith("fe80::")) {
+    if ((firstOctet === 169 && secondOctet === 254) || host.startsWith("fe80:") || host.startsWith("fe80::")) {
       return "Opening link-local / cloud metadata URLs is not allowed.";
     }
     // IPv6 unique local addresses fc00::/7 (fc00:: – fdff::)
@@ -51,7 +94,7 @@ function validateExternalHttpUrl(url: string): string | null {
       return "Opening IPv6 unique-local URLs is not allowed.";
     }
     // Unspecified address / mDNS
-    if (host === "0.0.0.0" || host === "::" || host.endsWith(".local")) {
+    if (host === "::" || host.endsWith(".local") || (firstOctet === 0 && secondOctet === 0)) {
       return "Opening unspecified or mDNS URLs is not allowed.";
     }
     return null;

--- a/tests/safari-tools.test.js
+++ b/tests/safari-tools.test.js
@@ -125,6 +125,25 @@ describe('Safari tool gating', () => {
     expect(mockRunJxa).not.toHaveBeenCalled();
   });
 
+  test.each([
+    ['open_url', 'http://[::ffff:127.0.0.1]:3847/mcp?leak=secret', 'localhost'],
+    ['open_url', 'http://[::ffff:192.168.0.1]/private?leak=secret', 'internal network'],
+    ['open_url', 'http://localhost.:3847/mcp?leak=secret', 'localhost'],
+    ['add_to_reading_list', 'http://foo.localhost:3847/mcp?leak=secret', 'localhost'],
+    ['add_to_reading_list', 'http://localhost.localdomain:3847/mcp?leak=secret', 'localhost'],
+    ['add_to_reading_list', 'http://[::ffff:169.254.169.254]/latest/meta-data?leak=secret', 'link-local'],
+  ])('%s blocks internal or localhost alias destination %s before Safari automation runs', async (toolName, url, message) => {
+    mockRunJxa.mockReset();
+    const server = createMockServer();
+    registerSafariTools(server, {});
+
+    const result = await server.callTool(toolName, { url });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain(message);
+    expect(mockRunJxa).not.toHaveBeenCalled();
+  });
+
   test('add_to_reading_list blocks internal destinations before Safari automation runs', async () => {
     mockRunJxa.mockReset();
     const server = createMockServer();


### PR DESCRIPTION
## Summary
- Normalize IPv4-mapped IPv6 host literals before Safari internal URL checks.
- Block localhost aliases such as `foo.localhost`, `localhost.`, and `localhost.localdomain` before JXA runs.
- Add runtime regression coverage for `open_url` and `add_to_reading_list` bypass forms.

## Root Cause
`new URL()` normalizes `http://[::ffff:127.0.0.1]` to a hostname like `[::ffff:7f00:1]`. The previous guard used string prefix checks, so mapped loopback/private/link-local destinations could avoid the internal URL block.

## Validation
- `npm run typecheck`
- `npm test -- --runInBand tests/safari-tools.test.js`
- `npm test -- --runInBand`
- `npm run gen:manifest:check`
- `npm run gen:intents:check`
- `npm run stats:check`
- `npm run mcp:validate`
- `npm run build:mcpb:check`
- `npm audit --audit-level=high`
- `npm run lint`
- `npm run swift-build`
- `npm run app-build`
