### PR TITLE
fix(hitl): add sensitive approval tier

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 
 ## What this is — at a glance
 
-- **Currently implemented** — 286 tools across 29 modules (a curated **starter** set loads by default; `--full` enables all; Swift-backed tools need the optional bridge, see Requires above); HMAC-chained audit log with tamper-detection test suite; HITL approval per destructive/sensitive call; rate limit (60/min + 10 destructive/hr); `allowNetwork` inbound HTTP exposure policy (RFC 0002); OAuth 2.1 + Resource Indicators (RFC 0005 Steps 1+2 — RS256/ES256 JWT, scope gate, `.well-known/oauth-protected-resource` per RFC 9728); sessionless `.well-known/mcp.json` discovery; 228 Shortcuts/AppIntents auto-generated from the tool manifest; native SwiftUI menubar app (ad-hoc signed; Developer ID notarization pending); Claude Code plugin package (`.claude-plugin/plugin.json` + `.mcp.json` at repo root, with the `.mcp.json` invocation pinned to the same npm version as the manifest so the marketplace SHA-approval and the installed runtime always agree). On every CI run, `npm run mcp:validate` boots the built `dist/index.js` under a pinned [`@modelcontextprotocol/inspector`](https://github.com/modelcontextprotocol/inspector) `--cli` and checks the `tools/list` response for JSON-RPC envelope drift, embedded error envelopes, and zero-tool responses — this is a wire-shape gate, not a substitute for the HMAC / HITL / audit primitives, which have their own tests.
+- **Currently implemented** — 286 tools across 29 modules (a curated **starter** set loads by default; `--full` enables all; Swift-backed tools need the optional bridge, see Requires above); HMAC-chained audit log with tamper-detection test suite; default HITL approval per destructive/sensitive call; rate limit (60/min + 10 destructive/hr); `allowNetwork` inbound HTTP exposure policy (RFC 0002); OAuth 2.1 + Resource Indicators (RFC 0005 Steps 1+2 — RS256/ES256 JWT, scope gate, `.well-known/oauth-protected-resource` per RFC 9728); sessionless `.well-known/mcp.json` discovery; 228 Shortcuts/AppIntents auto-generated from the tool manifest; native SwiftUI menubar app (ad-hoc signed; Developer ID notarization pending); Claude Code plugin package (`.claude-plugin/plugin.json` + `.mcp.json` at repo root, with the `.mcp.json` invocation pinned to the same npm version as the manifest so the marketplace SHA-approval and the installed runtime always agree). On every CI run, `npm run mcp:validate` boots the built `dist/index.js` under a pinned [`@modelcontextprotocol/inspector`](https://github.com/modelcontextprotocol/inspector) `--cli` and checks the `tools/list` response for JSON-RPC envelope drift, embedded error envelopes, and zero-tool responses — this is a wire-shape gate, not a substitute for the HMAC / HITL / audit primitives, which have their own tests.
 - **Planned** — RFC 0005 Step 3 browser PKCE guide; stateless streamable HTTP for horizontal scale per MCP 2026 roadmap; iOS/visionOS exploration (v3.0+); consolidated registry re-publishing across Anthropic MCP Registry, Smithery, PulseMCP, Glama, MCP Market, Cline Marketplace, LobeHub (the `.well-known/mcp.json` endpoint is published, `mcpName` is set, and past ad-hoc registrations exist on some registries but their versions/metadata have drifted out of date — a single self-publishing PR will re-push the current manifest to each); Claude Code Plugin submission to `anthropics/claude-plugins-community` (community marketplace launched 2026-05-22; the plugin package itself — `.claude-plugin/plugin.json` + `.mcp.json` — lives at repo root and is validated by CI; the remaining step is the operator-side submission via `clau.de/plugin-directory-submission`); App Schemas codegen (WWDC 2026 introduced App Schemas — a new agentic layer over App Intents + App Entities, plus a View Annotations API for on-screen awareness and an App Intents Testing framework; the installed SDK exposes the non-deprecated `@AppIntent(schema:)` / `@AppEntity(schema:)` / `@AppEnum(schema:)` macro declarations, and full Xcode can typecheck those macros, but the default Command Line Tools still lack `AppIntentsMacros` / `AppIntentsTesting`; Calendar events, Reminders, and Contacts also lack matching public AssistantSchemas constants in the local SDK, so AirMCP keeps the generated default artifact on plain AppIntents/AppEntities until CI has a schema-capable toolchain and each mapping targets an official schema constant). iOS companion server (`ios/Sources/AirMCPServer`, ~1500 LOC) is **preview**, not GA — macOS is the shipping surface.
 - **Design intent** — Core infra (HITL · audit · rate-limit · HMAC chain · network policy · OAuth scope gate) is the differentiated layer; the tool surface is broad and JXA-thin **by design**. JXA is the bridge, not the product. The interesting code lives in `src/shared/` (audit, rate-limit, HITL, network policy, OAuth gate, structured-content validators) and the Swift bridges (`swift/Sources/AirMCPKit`) for EventKit / HealthKit / PhotoKit / Vision / FoundationModels. Blast-radius unit is one tool call. Adjacent to — not a replacement for — the canonical [Model Context Protocol reference servers](https://github.com/modelcontextprotocol/servers) (Everything, Filesystem, Fetch, Git, Memory, Sequential Thinking, Time); AirMCP fills the Apple-native domain those references leave open. Aligned with Anthropic's three-layer containment doctrine ([*How we contain Claude across products*](https://anthropic.com/engineering/how-we-contain-claude), 2026-05-27 engineering blog): the Environment layer (sandbox / VM / egress controls) and Model layer (system prompts / classifiers) are Anthropic's host-side responsibility; AirMCP implements the **External Content layer** — tool-permission gating + MCP server auditing — for the Apple-native domain, complementary to (not replacing) Claude Code's process-level Seatbelt/bubblewrap sandbox. The same production governance primitives (sensitive-action HITL, scope-gated permissions, real-time tamper-evident audit, rate-limited destructive ops, emergency stop file) that high-stakes vertical MCP servers — financial trading, crypto exchange, supply-chain attestation — build per-deployment are surfaced once here as OSS reference.
 - **Non-goals** — Per-session batched approval that covers "the next N calls" (failure mode this project is built around). Editable or skippable audit entries (the chain is load-bearing). Promising iOS parity on the public surface (preview only). Replacing native Apple apps — AirMCP automates them, it does not reimplement them. Headless / non-Apple platforms beyond what Google Workspace already provides.
@@ -216,7 +216,7 @@ User-authored skills land in `~/.config/airmcp/skills/*.yaml` and hot-reload.
 
 AirMCP runs with access to 286 tools on your machine. A few layers keep a buggy agent plan from turning into an incident:
 
-- **HITL approval** — every destructive tool prompts before firing (via MCP Elicitation or a Unix socket fallback). Per-call, per-scope.
+- **HITL approval** — at the default level, every sensitive or destructive tool prompts before firing (via MCP Elicitation or a Unix socket fallback). Per-call, per-scope.
 - **Rate limit** — 60 tool calls/minute globally, 10 destructive/hour. Token-bucket so bursts are fine; sustained rate isn't.
 - **Emergency stop** — `touch ~/.config/airmcp/emergency-stop` blocks every destructive tool immediately with a 1-second probe cache. No restart needed. `rm` the file to resume.
 - **Audit log** — every tool call lands in `~/.airmcp/audit.jsonl` with PII-scrubbed args, 0600 perms, 10MB rotation. Query it via `audit_log` / `audit_summary` tools. Each entry carries an HMAC chain (single-line tamper detection — `AIRMCP_AUDIT_HMAC_KEY` for cross-machine integrity) and a **correlation ID** that threads the entry, any thrown error, and the OpenTelemetry span (when enabled) for the same call — so a failing tool can be traced across log lines with one `grep`. **Every env knob lives in [docs/environment.md](docs/environment.md)** (77 vars indexed by category).
@@ -906,7 +906,7 @@ Or edit `~/.config/airmcp/config.json` directly:
   "allowSendMessages": false,
   "allowSendMail": false,
   "hitl": {
-    "level": "destructive-only",
+    "level": "sensitive-only",
     "timeout": 30
   }
 }
@@ -914,18 +914,18 @@ Or edit `~/.config/airmcp/config.json` directly:
 
 ### Human-in-the-Loop (HITL)
 
-Require manual approval before destructive operations:
+Require manual approval before sensitive or destructive operations:
 
 ```json
 {
   "hitl": {
-    "level": "destructive-only",
+    "level": "sensitive-only",
     "timeout": 30
   }
 }
 ```
 
-Levels: `off`, `destructive-only`, `all-writes`, `all`
+Levels: `off`, `destructive-only`, `sensitive-only`, `all-writes`, `all`
 
 ### Semantic Search (Optional)
 
@@ -974,7 +974,7 @@ Modules with OS requirements (e.g., Intelligence requires macOS 26+) are automat
 
 - **JXA/AppleScript dependency** — Core automation relies on Apple's scripting dictionaries. While these have been stable for 10+ years, macOS updates can theoretically break individual modules. Circuit breaker (3 failures → 60s auto-disable) isolates failures. UI Automation tools (6 tools) are inherently more brittle and separated into their own module.
 - **Input sanitization** — `run_javascript` blocks `javascript:` and `data:` URL schemes to prevent code injection. `escJxaShell` strips control characters from shell arguments.
-- **Read data exposure** — Destructive operations require HITL approval, but read operations (mail, messages, contacts) are not rate-limited. When connected to cloud LLMs, sensitive data passes through the LLM provider. Mitigations: PII scrubbing in logs, pagination limits, sensitive modules (mail, messages) require explicit opt-in.
+- **Read data exposure** — Sensitive and destructive operations require HITL approval by default, but read operations (mail, messages, contacts) do not. When connected to cloud LLMs, sensitive data passes through the LLM provider. Mitigations: PII scrubbing in logs, pagination limits, sensitive modules (mail, messages) require explicit opt-in.
 - **IPC overhead** — Multi-process path (Client → Node.js → osascript/Swift CLI → macOS app). Each JXA call adds ~50ms overhead. Pagination prevents bulk data transfers. Swift bridge path bypasses JXA for EventKit/PhotoKit operations.
 - **Scope** — 286 tools across 29 modules follow 5 repeating patterns (JXA CRUD, Swift bridge, HTTP API, System Events, CLI wrapper), keeping maintenance proportional to pattern count, not tool count.
 

--- a/app/Sources/AirMCPApp/ConfigManager.swift
+++ b/app/Sources/AirMCPApp/ConfigManager.swift
@@ -3,6 +3,7 @@ import Foundation
 enum HitlLevel: String, Codable, Sendable, CaseIterable {
     case off = "off"
     case destructiveOnly = "destructive-only"
+    case sensitiveOnly = "sensitive-only"
     case allWrites = "all-writes"
     case all = "all"
 }
@@ -16,7 +17,7 @@ final class ConfigManager {
         var whitelist: [String]
         var timeout: Int
 
-        static let `default` = HitlConfig(level: .off, whitelist: [], timeout: 30)
+        static let `default` = HitlConfig(level: .sensitiveOnly, whitelist: [], timeout: 30)
     }
 
     struct Config: Codable, Sendable {
@@ -109,7 +110,7 @@ final class ConfigManager {
     }
 
     var hitlLevel: HitlLevel {
-        get { config.hitl?.level ?? .off }
+        get { config.hitl?.level ?? .sensitiveOnly }
         set {
             if config.hitl == nil { config.hitl = .default }
             config.hitl?.level = newValue

--- a/app/Sources/AirMCPApp/HitlManager.swift
+++ b/app/Sources/AirMCPApp/HitlManager.swift
@@ -13,6 +13,7 @@ final class HitlManager {
         let tool: String
         let args: [String: String]
         let destructive: Bool
+        let sensitive: Bool
         let openWorld: Bool
         let timestamp: Date
     }
@@ -209,6 +210,7 @@ final class HitlManager {
             tool: parsed.tool,
             args: parsed.args,
             destructive: parsed.destructive,
+            sensitive: parsed.sensitive,
             openWorld: parsed.openWorld,
             timestamp: parsed.timestamp
         )
@@ -281,7 +283,13 @@ final class HitlManager {
 
     private func postNotification(for request: ApprovalRequest) {
         let content = UNMutableNotificationContent()
-        content.title = request.destructive ? L("hitl.destructiveAction") : L("hitl.toolConfirmation")
+        if request.destructive {
+            content.title = L("hitl.destructiveAction")
+        } else if request.sensitive {
+            content.title = L("hitl.sensitiveAction")
+        } else {
+            content.title = L("hitl.toolConfirmation")
+        }
         content.body = L("hitl.toolPrefix", request.tool)
         if !request.args.isEmpty {
             let argsPreview = request.args

--- a/app/Sources/AirMCPApp/HitlProtocol.swift
+++ b/app/Sources/AirMCPApp/HitlProtocol.swift
@@ -6,6 +6,7 @@ struct HitlApprovalRequestPayload: Equatable, Sendable {
     let tool: String
     let args: [String: String]
     let destructive: Bool
+    let sensitive: Bool
     let openWorld: Bool
     let timestamp: Date
 }
@@ -40,6 +41,7 @@ enum HitlProtocol {
             tool: tool,
             args: argsDict,
             destructive: json["destructive"] as? Bool ?? false,
+            sensitive: json["sensitive"] as? Bool ?? false,
             openWorld: json["openWorld"] as? Bool ?? false,
             timestamp: timestamp
         )

--- a/app/Sources/AirMCPApp/Resources/en.lproj/Localizable.strings
+++ b/app/Sources/AirMCPApp/Resources/en.lproj/Localizable.strings
@@ -94,6 +94,7 @@
 "settings.hitlLevel" = "Level";
 "settings.hitlOff" = "Off";
 "settings.hitlDestructiveOnly" = "Destructive Only";
+"settings.hitlSensitiveOnly" = "Sensitive Actions";
 "settings.hitlAllWrites" = "All Writes";
 "settings.hitlAll" = "All";
 "settings.hitlTimeout" = "Timeout: %ds";
@@ -224,6 +225,7 @@
 
 /* HITL Notifications */
 "hitl.destructiveAction" = "Destructive Action";
+"hitl.sensitiveAction" = "Sensitive Action";
 "hitl.toolConfirmation" = "Tool Confirmation";
 "hitl.toolPrefix" = "Tool: %@";
 "hitl.approve" = "Approve";

--- a/app/Sources/AirMCPApp/Resources/ko.lproj/Localizable.strings
+++ b/app/Sources/AirMCPApp/Resources/ko.lproj/Localizable.strings
@@ -94,6 +94,7 @@
 "settings.hitlLevel" = "수준";
 "settings.hitlOff" = "끄기";
 "settings.hitlDestructiveOnly" = "파괴적 작업만";
+"settings.hitlSensitiveOnly" = "민감 작업";
 "settings.hitlAllWrites" = "모든 쓰기";
 "settings.hitlAll" = "전체";
 "settings.hitlTimeout" = "타임아웃: %d초";
@@ -224,6 +225,7 @@
 
 /* HITL Notifications */
 "hitl.destructiveAction" = "파괴적 작업";
+"hitl.sensitiveAction" = "민감 작업";
 "hitl.toolConfirmation" = "도구 확인";
 "hitl.toolPrefix" = "도구: %@";
 "hitl.approve" = "승인";

--- a/app/Sources/AirMCPApp/Views/MenuContent.swift
+++ b/app/Sources/AirMCPApp/Views/MenuContent.swift
@@ -573,6 +573,7 @@ struct MenuContent: View {
             )) {
                 Text(L("settings.hitlOff")).tag(HitlLevel.off)
                 Text(L("settings.hitlDestructiveOnly")).tag(HitlLevel.destructiveOnly)
+                Text(L("settings.hitlSensitiveOnly")).tag(HitlLevel.sensitiveOnly)
                 Text(L("settings.hitlAllWrites")).tag(HitlLevel.allWrites)
                 Text(L("settings.hitlAll")).tag(HitlLevel.all)
             }
@@ -742,9 +743,12 @@ struct MenuContent: View {
                 .foregroundStyle(.secondary)
             ForEach(hitlManager.pendingRequests) { request in
                 VStack(alignment: .leading, spacing: 4) {
-                    Label(request.tool, systemImage: request.destructive ? "exclamationmark.triangle" : "questionmark.circle")
+                    Label(
+                        request.tool,
+                        systemImage: request.destructive || request.sensitive ? "exclamationmark.triangle" : "questionmark.circle"
+                    )
                         .font(.caption)
-                        .foregroundStyle(request.destructive ? .orange : .primary)
+                        .foregroundStyle(request.destructive || request.sensitive ? .orange : .primary)
                     HStack {
                         Button(L("hitl.approve")) {
                             hitlManager.respond(id: request.id, approved: true, tool: request.tool)

--- a/docs/PRIVACY_POLICY.md
+++ b/docs/PRIVACY_POLICY.md
@@ -112,7 +112,7 @@ All data returned by AirMCP tools is sent to the connected MCP client (AI model)
 ## Safety Controls
 
 - **Sending email/messages** is disabled by default (`allowSendMail: false`, `allowSendMessages: false`). You must explicitly enable these in config or via environment variables.
-- **Human-in-the-loop (HITL)** approval can be enabled to require confirmation before destructive operations (delete, send, move).
+- **Human-in-the-loop (HITL)** approval can be enabled to require confirmation before sensitive or destructive operations (create, send, delete, move).
 - **Destructive tools** are annotated with `destructiveHint: true` so MCP clients can warn before execution.
 
 ## Transport Modes

--- a/docs/TERMS_OF_SERVICE.md
+++ b/docs/TERMS_OF_SERVICE.md
@@ -20,7 +20,7 @@ AirMCP is open-source software released under the [MIT License](../LICENSE). The
 You are solely responsible for:
 
 - **AI agent actions.** AirMCP enables AI agents to perform actions on your Mac through 286 tools across 29 modules. Any action an AI agent takes through AirMCP is performed on your behalf and at your direction. You are responsible for the outcomes of those actions.
-- **Safety controls.** AirMCP provides a Human-in-the-Loop (HITL) approval system with configurable levels. It is your responsibility to configure an appropriate HITL level for your use case. Running AirMCP with HITL disabled means AI agents can execute destructive actions without confirmation.
+- **Safety controls.** AirMCP provides a Human-in-the-Loop (HITL) approval system with configurable levels. It is your responsibility to configure an appropriate HITL level for your use case. Running AirMCP with HITL disabled means AI agents can execute sensitive or destructive actions without confirmation.
 - **HTTP mode security.** If you enable HTTP mode for remote access, you are responsible for securing it. This includes configuring token-based authentication, restricting network access, and ensuring the server is not exposed to untrusted networks.
 - **Legal compliance.** You must comply with all applicable local, state, national, and international laws when using AirMCP. This includes laws governing privacy, electronic communications, data protection, and computer access.
 

--- a/docs/environment.md
+++ b/docs/environment.md
@@ -65,7 +65,7 @@ If a variable accepts a path, `~` expands to `$HOME`. Booleans are `"true"` / `"
 
 | Variable | Default | Notes |
 |---|---|---|
-| `AIRMCP_HITL_LEVEL` | `destructive-only` | One of `off` / `destructive-only` / `all-writes` / `all`. Picks which tools require approval. |
+| `AIRMCP_HITL_LEVEL` | `sensitive-only` | One of `off` / `destructive-only` / `sensitive-only` / `all-writes` / `all`. Picks which tools require approval. |
 | `AIRMCP_ELICITATION_DISABLE` | (off) | `true` skips MCP elicitation prompts and falls through to socket HITL. Useful for fully-scripted destructive pipelines. |
 | `AIRMCP_MANAGED_CLIENTS` | (empty) | Comma-separated client names. Suppresses elicitation when these clients connect (they have their own approval UI). All Claude products are auto-detected via the `claude` prefix. |
 | `AIRMCP_SHARE_APPROVAL` | (off) | Per-tool share-guard approval flag. |

--- a/docs/rfc/0008-elicitation.md
+++ b/docs/rfc/0008-elicitation.md
@@ -30,7 +30,7 @@ Result of the existing `iwork_mcp` survey + Anthropic SDK 1.29.0 inspection:
 
 ## 2. Goal
 
-Wrap every tool whose `annotations.destructiveHint = true` with a **confirmation elicit** that fires automatically when the client supports elicitation, falls back to the existing HITL guard when it doesn't, and never blocks tools that aren't destructive.
+Wrap every tool selected by the active HITL level with a **confirmation elicit** that fires automatically when the client supports elicitation and falls back to the existing socket HITL guard when it doesn't. At the default `sensitive-only` level this includes tools with `annotations.destructiveHint = true` or `annotations.sensitiveHint = true`.
 
 ### Non-goals (Phase 1)
 

--- a/docs/site/src/content/docs/getting-started/configuration.md
+++ b/docs/site/src/content/docs/getting-started/configuration.md
@@ -17,7 +17,7 @@ The default config file location is `~/.config/airmcp/config.json`. You can over
   "disabledModules": ["tv", "podcasts"],
   "shareApproval": ["notes", "calendar"],
   "hitl": {
-    "level": "destructive-only",
+    "level": "sensitive-only",
     "whitelist": ["list_notes", "search_notes"],
     "timeout": 30
   },
@@ -39,7 +39,7 @@ The default config file location is `~/.config/airmcp/config.json`. You can over
 | `allowSendMail` | boolean | `false` | Allow sending emails via the Mail module |
 | `disabledModules` | string[] | `[]` | List of module names to disable |
 | `shareApproval` | string[] | `[]` | Modules that require share approval before accessing |
-| `hitl.level` | string | `"off"` | Human-in-the-loop level: `off`, `destructive-only`, `all-writes`, `all` |
+| `hitl.level` | string | `"sensitive-only"` | Human-in-the-loop level: `off`, `destructive-only`, `sensitive-only`, `all-writes`, `all` |
 | `hitl.whitelist` | string[] | `[]` | Tool names that bypass HITL confirmation |
 | `hitl.timeout` | number | `30` | Seconds to wait for HITL confirmation |
 | `performance.embeddingProvider` | string | `"auto"` | Embedding provider: `gemini`, `swift`, `hybrid`, `none` |
@@ -65,7 +65,7 @@ The default config file location is `~/.config/airmcp/config.json`. You can over
 | `AIRMCP_ALLOW_SEND_MAIL=true` | Allow sending emails |
 | `AIRMCP_INCLUDE_SHARED=true` | Include shared Notes/folders |
 | `AIRMCP_SHARE_APPROVAL=notes,calendar` | Comma-separated list of modules requiring share approval |
-| `AIRMCP_HITL_LEVEL=destructive-only` | Human-in-the-loop confirmation level |
+| `AIRMCP_HITL_LEVEL=sensitive-only` | Human-in-the-loop confirmation level |
 
 ### HTTP Mode
 

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -12,7 +12,7 @@ AirMCP bridges AI agents to native macOS applications through JXA (JavaScript fo
 2. **Cross-app linking** -- reference related IDs across modules. Mention a note ID in a reminder body; include an event ID in a follow-up note. This creates a traceable graph.
 3. **Batch over loops** -- prefer tools that return lists (`list_reminders`, `scan_notes`) over calling single-item tools repeatedly.
 4. **Check availability** -- not all modules may be enabled. Use `summarize_context` or check tool listing to confirm before attempting operations.
-5. **HITL for mutations** -- human-in-the-loop confirmation is enforced for destructive operations (delete, send, move). Always present a plan before executing writes.
+5. **HITL for sensitive mutations** -- human-in-the-loop confirmation is enforced for sensitive or destructive operations (create, send, delete, move). Always present a plan before executing writes.
 6. **Minimal privilege** -- read-only operations are always safe. Write operations may require user confirmation. Send/delete operations always require confirmation.
 
 ## Module Quick Reference

--- a/docs/tool-manifest.json
+++ b/docs/tool-manifest.json
@@ -41,6 +41,7 @@
       "annotations": {
         "readOnlyHint": false,
         "destructiveHint": false,
+        "sensitiveHint": false,
         "idempotentHint": true,
         "openWorldHint": false
       },
@@ -82,6 +83,7 @@
       "annotations": {
         "readOnlyHint": false,
         "destructiveHint": false,
+        "sensitiveHint": true,
         "idempotentHint": false,
         "openWorldHint": false
       },
@@ -123,6 +125,7 @@
       "annotations": {
         "readOnlyHint": false,
         "destructiveHint": false,
+        "sensitiveHint": true,
         "idempotentHint": false,
         "openWorldHint": false
       },
@@ -162,6 +165,7 @@
       "annotations": {
         "readOnlyHint": false,
         "destructiveHint": false,
+        "sensitiveHint": true,
         "idempotentHint": false,
         "openWorldHint": false
       },
@@ -196,6 +200,7 @@
       "annotations": {
         "readOnlyHint": false,
         "destructiveHint": false,
+        "sensitiveHint": true,
         "idempotentHint": false,
         "openWorldHint": false
       },
@@ -229,6 +234,7 @@
       "annotations": {
         "readOnlyHint": false,
         "destructiveHint": true,
+        "sensitiveHint": false,
         "idempotentHint": false,
         "openWorldHint": true
       },
@@ -263,6 +269,7 @@
       "annotations": {
         "readOnlyHint": true,
         "destructiveHint": false,
+        "sensitiveHint": false,
         "idempotentHint": false,
         "openWorldHint": false
       },
@@ -302,6 +309,7 @@
       "annotations": {
         "readOnlyHint": true,
         "destructiveHint": false,
+        "sensitiveHint": false,
         "idempotentHint": false,
         "openWorldHint": false
       },
@@ -408,6 +416,7 @@
       "annotations": {
         "readOnlyHint": true,
         "destructiveHint": false,
+        "sensitiveHint": false,
         "idempotentHint": false,
         "openWorldHint": false
       },
@@ -427,6 +436,7 @@
       "annotations": {
         "readOnlyHint": true,
         "destructiveHint": false,
+        "sensitiveHint": false,
         "idempotentHint": true,
         "openWorldHint": false
       },
@@ -531,6 +541,7 @@
       "annotations": {
         "readOnlyHint": true,
         "destructiveHint": false,
+        "sensitiveHint": false,
         "idempotentHint": true,
         "openWorldHint": false
       },
@@ -651,6 +662,7 @@
       "annotations": {
         "readOnlyHint": true,
         "destructiveHint": false,
+        "sensitiveHint": false,
         "idempotentHint": true,
         "openWorldHint": false
       },
@@ -700,6 +712,7 @@
       "annotations": {
         "readOnlyHint": false,
         "destructiveHint": true,
+        "sensitiveHint": false,
         "idempotentHint": false,
         "openWorldHint": false
       },
@@ -725,6 +738,7 @@
       "annotations": {
         "readOnlyHint": true,
         "destructiveHint": false,
+        "sensitiveHint": false,
         "idempotentHint": true,
         "openWorldHint": false
       },
@@ -769,6 +783,7 @@
       "annotations": {
         "readOnlyHint": false,
         "destructiveHint": false,
+        "sensitiveHint": false,
         "idempotentHint": true,
         "openWorldHint": true
       },
@@ -795,6 +810,7 @@
       "annotations": {
         "readOnlyHint": false,
         "destructiveHint": false,
+        "sensitiveHint": false,
         "idempotentHint": true,
         "openWorldHint": true
       },
@@ -834,6 +850,7 @@
       "annotations": {
         "readOnlyHint": false,
         "destructiveHint": true,
+        "sensitiveHint": false,
         "idempotentHint": false,
         "openWorldHint": false
       },
@@ -859,6 +876,7 @@
       "annotations": {
         "readOnlyHint": false,
         "destructiveHint": false,
+        "sensitiveHint": false,
         "idempotentHint": true,
         "openWorldHint": true
       },
@@ -895,6 +913,7 @@
       "annotations": {
         "readOnlyHint": true,
         "destructiveHint": false,
+        "sensitiveHint": false,
         "idempotentHint": true,
         "openWorldHint": false
       },
@@ -931,6 +950,7 @@
       "annotations": {
         "readOnlyHint": false,
         "destructiveHint": true,
+        "sensitiveHint": false,
         "idempotentHint": true,
         "openWorldHint": false
       },
@@ -950,6 +970,7 @@
       "annotations": {
         "readOnlyHint": true,
         "destructiveHint": false,
+        "sensitiveHint": false,
         "idempotentHint": true,
         "openWorldHint": false
       },
@@ -982,6 +1003,7 @@
       "annotations": {
         "readOnlyHint": true,
         "destructiveHint": false,
+        "sensitiveHint": false,
         "idempotentHint": true,
         "openWorldHint": false
       },
@@ -1015,6 +1037,7 @@
       "annotations": {
         "readOnlyHint": false,
         "destructiveHint": false,
+        "sensitiveHint": true,
         "idempotentHint": true,
         "openWorldHint": false
       },
@@ -1044,6 +1067,7 @@
       "annotations": {
         "readOnlyHint": false,
         "destructiveHint": false,
+        "sensitiveHint": false,
         "idempotentHint": true,
         "openWorldHint": false
       },
@@ -1072,6 +1096,7 @@
       "annotations": {
         "readOnlyHint": false,
         "destructiveHint": false,
+        "sensitiveHint": true,
         "idempotentHint": false,
         "openWorldHint": false
       },
@@ -1132,6 +1157,7 @@
       "annotations": {
         "readOnlyHint": false,
         "destructiveHint": false,
+        "sensitiveHint": true,
         "idempotentHint": false,
         "openWorldHint": false
       },
@@ -1161,6 +1187,7 @@
       "annotations": {
         "readOnlyHint": false,
         "destructiveHint": false,
+        "sensitiveHint": true,
         "idempotentHint": true,
         "openWorldHint": false
       },
@@ -1221,6 +1248,7 @@
       "annotations": {
         "readOnlyHint": false,
         "destructiveHint": false,
+        "sensitiveHint": true,
         "idempotentHint": false,
         "openWorldHint": false
       },
@@ -1254,6 +1282,7 @@
       "annotations": {
         "readOnlyHint": false,
         "destructiveHint": false,
+        "sensitiveHint": true,
         "idempotentHint": true,
         "openWorldHint": false
       },
@@ -1287,6 +1316,7 @@
       "annotations": {
         "readOnlyHint": false,
         "destructiveHint": false,
+        "sensitiveHint": true,
         "idempotentHint": false,
         "openWorldHint": false
       },
@@ -1315,6 +1345,7 @@
       "annotations": {
         "readOnlyHint": false,
         "destructiveHint": false,
+        "sensitiveHint": true,
         "idempotentHint": false,
         "openWorldHint": false
       },
@@ -1418,6 +1449,7 @@
       "annotations": {
         "readOnlyHint": false,
         "destructiveHint": false,
+        "sensitiveHint": true,
         "idempotentHint": false,
         "openWorldHint": false
       },
@@ -1514,6 +1546,7 @@
       "annotations": {
         "readOnlyHint": false,
         "destructiveHint": false,
+        "sensitiveHint": true,
         "idempotentHint": false,
         "openWorldHint": false
       },
@@ -1563,6 +1596,7 @@
       "annotations": {
         "readOnlyHint": false,
         "destructiveHint": false,
+        "sensitiveHint": true,
         "idempotentHint": false,
         "openWorldHint": false
       },
@@ -1591,6 +1625,7 @@
       "annotations": {
         "readOnlyHint": false,
         "destructiveHint": false,
+        "sensitiveHint": true,
         "idempotentHint": false,
         "openWorldHint": false
       },
@@ -1619,6 +1654,7 @@
       "annotations": {
         "readOnlyHint": false,
         "destructiveHint": false,
+        "sensitiveHint": true,
         "idempotentHint": false,
         "openWorldHint": true
       },
@@ -1647,6 +1683,7 @@
       "annotations": {
         "readOnlyHint": false,
         "destructiveHint": true,
+        "sensitiveHint": false,
         "idempotentHint": true,
         "openWorldHint": false
       },
@@ -1675,6 +1712,7 @@
       "annotations": {
         "readOnlyHint": false,
         "destructiveHint": true,
+        "sensitiveHint": false,
         "idempotentHint": true,
         "openWorldHint": false
       },
@@ -1703,6 +1741,7 @@
       "annotations": {
         "readOnlyHint": false,
         "destructiveHint": true,
+        "sensitiveHint": false,
         "idempotentHint": true,
         "openWorldHint": false
       },
@@ -1733,6 +1772,7 @@
       "annotations": {
         "readOnlyHint": false,
         "destructiveHint": true,
+        "sensitiveHint": false,
         "idempotentHint": false,
         "openWorldHint": false
       },
@@ -1761,6 +1801,7 @@
       "annotations": {
         "readOnlyHint": false,
         "destructiveHint": true,
+        "sensitiveHint": false,
         "idempotentHint": false,
         "openWorldHint": false
       },
@@ -1789,6 +1830,7 @@
       "annotations": {
         "readOnlyHint": false,
         "destructiveHint": true,
+        "sensitiveHint": false,
         "idempotentHint": true,
         "openWorldHint": false
       },
@@ -1817,6 +1859,7 @@
       "annotations": {
         "readOnlyHint": false,
         "destructiveHint": true,
+        "sensitiveHint": false,
         "idempotentHint": true,
         "openWorldHint": false
       },
@@ -1845,6 +1888,7 @@
       "annotations": {
         "readOnlyHint": false,
         "destructiveHint": true,
+        "sensitiveHint": false,
         "idempotentHint": false,
         "openWorldHint": false
       },
@@ -1874,6 +1918,7 @@
       "annotations": {
         "readOnlyHint": false,
         "destructiveHint": false,
+        "sensitiveHint": false,
         "idempotentHint": true,
         "openWorldHint": false
       },
@@ -1952,6 +1997,7 @@
       "annotations": {
         "readOnlyHint": true,
         "destructiveHint": false,
+        "sensitiveHint": false,
         "idempotentHint": true,
         "openWorldHint": false
       },
@@ -1993,6 +2039,7 @@
       "annotations": {
         "readOnlyHint": false,
         "destructiveHint": false,
+        "sensitiveHint": false,
         "idempotentHint": true,
         "openWorldHint": false
       },
@@ -2027,6 +2074,7 @@
       "annotations": {
         "readOnlyHint": false,
         "destructiveHint": false,
+        "sensitiveHint": false,
         "idempotentHint": false,
         "openWorldHint": false
       },
@@ -2055,6 +2103,7 @@
       "annotations": {
         "readOnlyHint": false,
         "destructiveHint": false,
+        "sensitiveHint": false,
         "idempotentHint": false,
         "openWorldHint": true
       },
@@ -2074,6 +2123,7 @@
       "annotations": {
         "readOnlyHint": true,
         "destructiveHint": false,
+        "sensitiveHint": false,
         "idempotentHint": true,
         "openWorldHint": false
       },
@@ -2093,6 +2143,7 @@
       "annotations": {
         "readOnlyHint": true,
         "destructiveHint": false,
+        "sensitiveHint": false,
         "idempotentHint": false,
         "openWorldHint": false
       },
@@ -2128,6 +2179,7 @@
       "annotations": {
         "readOnlyHint": false,
         "destructiveHint": false,
+        "sensitiveHint": false,
         "idempotentHint": true,
         "openWorldHint": false
       },
@@ -2168,6 +2220,7 @@
       "annotations": {
         "readOnlyHint": true,
         "destructiveHint": false,
+        "sensitiveHint": false,
         "idempotentHint": true,
         "openWorldHint": false
       },
@@ -2202,6 +2255,7 @@
       "annotations": {
         "readOnlyHint": false,
         "destructiveHint": false,
+        "sensitiveHint": false,
         "idempotentHint": true,
         "openWorldHint": false
       },
@@ -2237,6 +2291,7 @@
       "annotations": {
         "readOnlyHint": false,
         "destructiveHint": true,
+        "sensitiveHint": false,
         "idempotentHint": false,
         "openWorldHint": false
       },
@@ -2277,6 +2332,7 @@
       "annotations": {
         "readOnlyHint": true,
         "destructiveHint": false,
+        "sensitiveHint": false,
         "idempotentHint": false,
         "openWorldHint": false
       },
@@ -2335,6 +2391,7 @@
       "annotations": {
         "readOnlyHint": true,
         "destructiveHint": false,
+        "sensitiveHint": false,
         "idempotentHint": false,
         "openWorldHint": false
       },
@@ -2374,6 +2431,7 @@
       "annotations": {
         "readOnlyHint": true,
         "destructiveHint": false,
+        "sensitiveHint": false,
         "idempotentHint": false,
         "openWorldHint": false
       },
@@ -2403,6 +2461,7 @@
       "annotations": {
         "readOnlyHint": true,
         "destructiveHint": false,
+        "sensitiveHint": false,
         "idempotentHint": true,
         "openWorldHint": true
       },
@@ -2473,6 +2532,7 @@
       "annotations": {
         "readOnlyHint": true,
         "destructiveHint": false,
+        "sensitiveHint": false,
         "idempotentHint": true,
         "openWorldHint": false
       },
@@ -2492,6 +2552,7 @@
       "annotations": {
         "readOnlyHint": true,
         "destructiveHint": false,
+        "sensitiveHint": false,
         "idempotentHint": true,
         "openWorldHint": false
       },
@@ -2536,6 +2597,7 @@
       "annotations": {
         "readOnlyHint": true,
         "destructiveHint": false,
+        "sensitiveHint": false,
         "idempotentHint": true,
         "openWorldHint": false
       },
@@ -2575,6 +2637,7 @@
       "annotations": {
         "readOnlyHint": true,
         "destructiveHint": false,
+        "sensitiveHint": false,
         "idempotentHint": true,
         "openWorldHint": false
       },
@@ -2594,6 +2657,7 @@
       "annotations": {
         "readOnlyHint": true,
         "destructiveHint": false,
+        "sensitiveHint": false,
         "idempotentHint": false,
         "openWorldHint": false
       },
@@ -2629,6 +2693,7 @@
       "annotations": {
         "readOnlyHint": true,
         "destructiveHint": false,
+        "sensitiveHint": false,
         "idempotentHint": true,
         "openWorldHint": false
       },
@@ -2741,6 +2806,7 @@
       "annotations": {
         "readOnlyHint": true,
         "destructiveHint": false,
+        "sensitiveHint": false,
         "idempotentHint": true,
         "openWorldHint": true
       },
@@ -2784,6 +2850,7 @@
       "annotations": {
         "readOnlyHint": true,
         "destructiveHint": false,
+        "sensitiveHint": false,
         "idempotentHint": true,
         "openWorldHint": true
       },
@@ -2828,6 +2895,7 @@
       "annotations": {
         "readOnlyHint": false,
         "destructiveHint": false,
+        "sensitiveHint": false,
         "idempotentHint": true,
         "openWorldHint": true
       },
@@ -2896,6 +2964,7 @@
       "annotations": {
         "readOnlyHint": true,
         "destructiveHint": false,
+        "sensitiveHint": false,
         "idempotentHint": true,
         "openWorldHint": false
       },
@@ -2935,6 +3004,7 @@
       "annotations": {
         "readOnlyHint": true,
         "destructiveHint": false,
+        "sensitiveHint": false,
         "idempotentHint": true,
         "openWorldHint": false
       },
@@ -2978,6 +3048,7 @@
       "annotations": {
         "readOnlyHint": true,
         "destructiveHint": false,
+        "sensitiveHint": false,
         "idempotentHint": true,
         "openWorldHint": true
       },
@@ -2997,6 +3068,7 @@
       "annotations": {
         "readOnlyHint": true,
         "destructiveHint": false,
+        "sensitiveHint": false,
         "idempotentHint": true,
         "openWorldHint": false
       },
@@ -3132,6 +3204,7 @@
       "annotations": {
         "readOnlyHint": true,
         "destructiveHint": false,
+        "sensitiveHint": false,
         "idempotentHint": true,
         "openWorldHint": false
       },
@@ -3190,6 +3263,7 @@
       "annotations": {
         "readOnlyHint": true,
         "destructiveHint": false,
+        "sensitiveHint": false,
         "idempotentHint": true,
         "openWorldHint": false
       },
@@ -3274,6 +3348,7 @@
       "annotations": {
         "readOnlyHint": true,
         "destructiveHint": false,
+        "sensitiveHint": false,
         "idempotentHint": true,
         "openWorldHint": false
       },
@@ -3318,6 +3393,7 @@
       "annotations": {
         "readOnlyHint": true,
         "destructiveHint": false,
+        "sensitiveHint": false,
         "idempotentHint": true,
         "openWorldHint": false
       },
@@ -3449,6 +3525,7 @@
       "annotations": {
         "readOnlyHint": true,
         "destructiveHint": false,
+        "sensitiveHint": false,
         "idempotentHint": true,
         "openWorldHint": false
       },
@@ -3504,6 +3581,7 @@
       "annotations": {
         "readOnlyHint": true,
         "destructiveHint": false,
+        "sensitiveHint": false,
         "idempotentHint": true,
         "openWorldHint": false
       },
@@ -3587,6 +3665,7 @@
       "annotations": {
         "readOnlyHint": true,
         "destructiveHint": false,
+        "sensitiveHint": false,
         "idempotentHint": true,
         "openWorldHint": false
       },
@@ -3626,6 +3705,7 @@
       "annotations": {
         "readOnlyHint": true,
         "destructiveHint": false,
+        "sensitiveHint": false,
         "idempotentHint": true,
         "openWorldHint": false
       },
@@ -3720,6 +3800,7 @@
       "annotations": {
         "readOnlyHint": true,
         "destructiveHint": false,
+        "sensitiveHint": false,
         "idempotentHint": true,
         "openWorldHint": false
       },
@@ -3759,6 +3840,7 @@
       "annotations": {
         "readOnlyHint": true,
         "destructiveHint": false,
+        "sensitiveHint": false,
         "idempotentHint": true,
         "openWorldHint": false
       },
@@ -3812,6 +3894,7 @@
       "annotations": {
         "readOnlyHint": false,
         "destructiveHint": true,
+        "sensitiveHint": false,
         "idempotentHint": false,
         "openWorldHint": true
       },
@@ -3853,6 +3936,7 @@
       "annotations": {
         "readOnlyHint": true,
         "destructiveHint": false,
+        "sensitiveHint": false,
         "idempotentHint": true,
         "openWorldHint": true
       },
@@ -3882,6 +3966,7 @@
       "annotations": {
         "readOnlyHint": true,
         "destructiveHint": false,
+        "sensitiveHint": false,
         "idempotentHint": true,
         "openWorldHint": true
       },
@@ -3918,6 +4003,7 @@
       "annotations": {
         "readOnlyHint": true,
         "destructiveHint": false,
+        "sensitiveHint": false,
         "idempotentHint": true,
         "openWorldHint": true
       },
@@ -3947,6 +4033,7 @@
       "annotations": {
         "readOnlyHint": true,
         "destructiveHint": false,
+        "sensitiveHint": false,
         "idempotentHint": true,
         "openWorldHint": true
       },
@@ -3982,6 +4069,7 @@
       "annotations": {
         "readOnlyHint": true,
         "destructiveHint": false,
+        "sensitiveHint": false,
         "idempotentHint": true,
         "openWorldHint": true
       },
@@ -4014,6 +4102,7 @@
       "annotations": {
         "readOnlyHint": true,
         "destructiveHint": false,
+        "sensitiveHint": false,
         "idempotentHint": true,
         "openWorldHint": true
       },
@@ -4053,6 +4142,7 @@
       "annotations": {
         "readOnlyHint": true,
         "destructiveHint": false,
+        "sensitiveHint": false,
         "idempotentHint": true,
         "openWorldHint": true
       },
@@ -4099,6 +4189,7 @@
       "annotations": {
         "readOnlyHint": false,
         "destructiveHint": true,
+        "sensitiveHint": false,
         "idempotentHint": false,
         "openWorldHint": true
       },
@@ -4134,6 +4225,7 @@
       "annotations": {
         "readOnlyHint": true,
         "destructiveHint": false,
+        "sensitiveHint": false,
         "idempotentHint": true,
         "openWorldHint": true
       },
@@ -4193,6 +4285,7 @@
       "annotations": {
         "readOnlyHint": false,
         "destructiveHint": true,
+        "sensitiveHint": false,
         "idempotentHint": false,
         "openWorldHint": true
       },
@@ -4228,6 +4321,7 @@
       "annotations": {
         "readOnlyHint": true,
         "destructiveHint": false,
+        "sensitiveHint": false,
         "idempotentHint": true,
         "openWorldHint": true
       },
@@ -4276,6 +4370,7 @@
       "annotations": {
         "readOnlyHint": false,
         "destructiveHint": true,
+        "sensitiveHint": false,
         "idempotentHint": false,
         "openWorldHint": true
       },
@@ -4295,6 +4390,7 @@
       "annotations": {
         "readOnlyHint": true,
         "destructiveHint": false,
+        "sensitiveHint": false,
         "idempotentHint": true,
         "openWorldHint": false
       },
@@ -4334,6 +4430,7 @@
       "annotations": {
         "readOnlyHint": false,
         "destructiveHint": true,
+        "sensitiveHint": false,
         "idempotentHint": false,
         "openWorldHint": true
       },
@@ -4365,6 +4462,7 @@
       "annotations": {
         "readOnlyHint": true,
         "destructiveHint": false,
+        "sensitiveHint": false,
         "idempotentHint": true,
         "openWorldHint": true
       },
@@ -4399,6 +4497,7 @@
       "annotations": {
         "readOnlyHint": false,
         "destructiveHint": false,
+        "sensitiveHint": false,
         "idempotentHint": false,
         "openWorldHint": false
       },
@@ -4428,6 +4527,7 @@
       "annotations": {
         "readOnlyHint": false,
         "destructiveHint": false,
+        "sensitiveHint": false,
         "idempotentHint": false,
         "openWorldHint": false
       },
@@ -4508,6 +4608,7 @@
       "annotations": {
         "readOnlyHint": true,
         "destructiveHint": false,
+        "sensitiveHint": false,
         "idempotentHint": true,
         "openWorldHint": false
       },
@@ -4536,6 +4637,7 @@
       "annotations": {
         "readOnlyHint": false,
         "destructiveHint": false,
+        "sensitiveHint": false,
         "idempotentHint": false,
         "openWorldHint": false
       },
@@ -4569,6 +4671,7 @@
       "annotations": {
         "readOnlyHint": false,
         "destructiveHint": true,
+        "sensitiveHint": false,
         "idempotentHint": false,
         "openWorldHint": false
       },
@@ -4588,6 +4691,7 @@
       "annotations": {
         "readOnlyHint": false,
         "destructiveHint": false,
+        "sensitiveHint": false,
         "idempotentHint": false,
         "openWorldHint": false
       },
@@ -4623,6 +4727,7 @@
       "annotations": {
         "readOnlyHint": false,
         "destructiveHint": true,
+        "sensitiveHint": false,
         "idempotentHint": false,
         "openWorldHint": true
       },
@@ -4658,6 +4763,7 @@
       "annotations": {
         "readOnlyHint": true,
         "destructiveHint": false,
+        "sensitiveHint": false,
         "idempotentHint": true,
         "openWorldHint": false
       },
@@ -4677,6 +4783,7 @@
       "annotations": {
         "readOnlyHint": true,
         "destructiveHint": false,
+        "sensitiveHint": false,
         "idempotentHint": true,
         "openWorldHint": false
       },
@@ -4705,6 +4812,7 @@
       "annotations": {
         "readOnlyHint": true,
         "destructiveHint": false,
+        "sensitiveHint": false,
         "idempotentHint": true,
         "openWorldHint": false
       },
@@ -4746,6 +4854,7 @@
       "annotations": {
         "readOnlyHint": false,
         "destructiveHint": false,
+        "sensitiveHint": false,
         "idempotentHint": true,
         "openWorldHint": false
       },
@@ -4781,6 +4890,7 @@
       "annotations": {
         "readOnlyHint": false,
         "destructiveHint": false,
+        "sensitiveHint": false,
         "idempotentHint": false,
         "openWorldHint": false
       },
@@ -4810,6 +4920,7 @@
       "annotations": {
         "readOnlyHint": false,
         "destructiveHint": false,
+        "sensitiveHint": false,
         "idempotentHint": true,
         "openWorldHint": true
       },
@@ -4871,6 +4982,7 @@
       "annotations": {
         "readOnlyHint": true,
         "destructiveHint": false,
+        "sensitiveHint": false,
         "idempotentHint": true,
         "openWorldHint": false
       },
@@ -4890,6 +5002,7 @@
       "annotations": {
         "readOnlyHint": true,
         "destructiveHint": false,
+        "sensitiveHint": false,
         "idempotentHint": true,
         "openWorldHint": false
       },
@@ -4991,6 +5104,7 @@
       "annotations": {
         "readOnlyHint": true,
         "destructiveHint": false,
+        "sensitiveHint": false,
         "idempotentHint": true,
         "openWorldHint": false
       },
@@ -5066,6 +5180,7 @@
       "annotations": {
         "readOnlyHint": true,
         "destructiveHint": false,
+        "sensitiveHint": false,
         "idempotentHint": true,
         "openWorldHint": false
       },
@@ -5121,6 +5236,7 @@
       "annotations": {
         "readOnlyHint": true,
         "destructiveHint": false,
+        "sensitiveHint": false,
         "idempotentHint": true,
         "openWorldHint": false
       },
@@ -5183,6 +5299,7 @@
       "annotations": {
         "readOnlyHint": true,
         "destructiveHint": false,
+        "sensitiveHint": false,
         "idempotentHint": true,
         "openWorldHint": false
       },
@@ -5298,6 +5415,7 @@
       "annotations": {
         "readOnlyHint": true,
         "destructiveHint": false,
+        "sensitiveHint": false,
         "idempotentHint": true,
         "openWorldHint": false
       },
@@ -5394,6 +5512,7 @@
       "annotations": {
         "readOnlyHint": true,
         "destructiveHint": false,
+        "sensitiveHint": false,
         "idempotentHint": true,
         "openWorldHint": false
       },
@@ -5472,6 +5591,7 @@
       "annotations": {
         "readOnlyHint": true,
         "destructiveHint": false,
+        "sensitiveHint": false,
         "idempotentHint": true,
         "openWorldHint": false
       },
@@ -5581,6 +5701,7 @@
       "annotations": {
         "readOnlyHint": true,
         "destructiveHint": false,
+        "sensitiveHint": false,
         "idempotentHint": true,
         "openWorldHint": false
       },
@@ -5685,6 +5806,7 @@
       "annotations": {
         "readOnlyHint": true,
         "destructiveHint": false,
+        "sensitiveHint": false,
         "idempotentHint": true,
         "openWorldHint": false
       },
@@ -5744,6 +5866,7 @@
       "annotations": {
         "readOnlyHint": true,
         "destructiveHint": false,
+        "sensitiveHint": false,
         "idempotentHint": true,
         "openWorldHint": false
       },
@@ -5841,6 +5964,7 @@
       "annotations": {
         "readOnlyHint": true,
         "destructiveHint": false,
+        "sensitiveHint": false,
         "idempotentHint": true,
         "openWorldHint": false
       },
@@ -5888,6 +6012,7 @@
       "annotations": {
         "readOnlyHint": true,
         "destructiveHint": false,
+        "sensitiveHint": false,
         "idempotentHint": true,
         "openWorldHint": false
       },
@@ -5939,6 +6064,7 @@
       "annotations": {
         "readOnlyHint": true,
         "destructiveHint": false,
+        "sensitiveHint": false,
         "idempotentHint": true,
         "openWorldHint": false
       },
@@ -6049,6 +6175,7 @@
       "annotations": {
         "readOnlyHint": true,
         "destructiveHint": false,
+        "sensitiveHint": false,
         "idempotentHint": true,
         "openWorldHint": false
       },
@@ -6144,6 +6271,7 @@
       "annotations": {
         "readOnlyHint": true,
         "destructiveHint": false,
+        "sensitiveHint": false,
         "idempotentHint": true,
         "openWorldHint": false
       },
@@ -6229,6 +6357,7 @@
       "annotations": {
         "readOnlyHint": true,
         "destructiveHint": false,
+        "sensitiveHint": false,
         "idempotentHint": true,
         "openWorldHint": false
       },
@@ -6352,6 +6481,7 @@
       "annotations": {
         "readOnlyHint": true,
         "destructiveHint": false,
+        "sensitiveHint": false,
         "idempotentHint": true,
         "openWorldHint": false
       },
@@ -6407,6 +6537,7 @@
       "annotations": {
         "readOnlyHint": true,
         "destructiveHint": false,
+        "sensitiveHint": false,
         "idempotentHint": true,
         "openWorldHint": false
       },
@@ -6442,6 +6573,7 @@
       "annotations": {
         "readOnlyHint": true,
         "destructiveHint": false,
+        "sensitiveHint": false,
         "idempotentHint": true,
         "openWorldHint": false
       },
@@ -6461,6 +6593,7 @@
       "annotations": {
         "readOnlyHint": true,
         "destructiveHint": false,
+        "sensitiveHint": false,
         "idempotentHint": true,
         "openWorldHint": false
       },
@@ -6512,6 +6645,7 @@
       "annotations": {
         "readOnlyHint": true,
         "destructiveHint": false,
+        "sensitiveHint": false,
         "idempotentHint": true,
         "openWorldHint": false
       },
@@ -6563,6 +6697,7 @@
       "annotations": {
         "readOnlyHint": true,
         "destructiveHint": false,
+        "sensitiveHint": false,
         "idempotentHint": true,
         "openWorldHint": false
       },
@@ -6673,6 +6808,7 @@
       "annotations": {
         "readOnlyHint": true,
         "destructiveHint": false,
+        "sensitiveHint": false,
         "idempotentHint": true,
         "openWorldHint": false
       },
@@ -6736,6 +6872,7 @@
       "annotations": {
         "readOnlyHint": true,
         "destructiveHint": false,
+        "sensitiveHint": false,
         "idempotentHint": true,
         "openWorldHint": false
       },
@@ -6774,6 +6911,7 @@
       "annotations": {
         "readOnlyHint": true,
         "destructiveHint": false,
+        "sensitiveHint": false,
         "idempotentHint": true,
         "openWorldHint": false
       },
@@ -6829,6 +6967,7 @@
       "annotations": {
         "readOnlyHint": true,
         "destructiveHint": false,
+        "sensitiveHint": false,
         "idempotentHint": true,
         "openWorldHint": false
       },
@@ -6966,6 +7105,7 @@
       "annotations": {
         "readOnlyHint": true,
         "destructiveHint": false,
+        "sensitiveHint": false,
         "idempotentHint": true,
         "openWorldHint": false
       },
@@ -6985,6 +7125,7 @@
       "annotations": {
         "readOnlyHint": true,
         "destructiveHint": false,
+        "sensitiveHint": false,
         "idempotentHint": true,
         "openWorldHint": false
       },
@@ -7004,6 +7145,7 @@
       "annotations": {
         "readOnlyHint": true,
         "destructiveHint": false,
+        "sensitiveHint": false,
         "idempotentHint": true,
         "openWorldHint": true
       },
@@ -7043,6 +7185,7 @@
       "annotations": {
         "readOnlyHint": true,
         "destructiveHint": false,
+        "sensitiveHint": false,
         "idempotentHint": false,
         "openWorldHint": true
       },
@@ -7062,6 +7205,7 @@
       "annotations": {
         "readOnlyHint": true,
         "destructiveHint": false,
+        "sensitiveHint": false,
         "idempotentHint": true,
         "openWorldHint": true
       },
@@ -7096,6 +7240,7 @@
       "annotations": {
         "readOnlyHint": false,
         "destructiveHint": false,
+        "sensitiveHint": false,
         "idempotentHint": true,
         "openWorldHint": false
       },
@@ -7156,6 +7301,7 @@
       "annotations": {
         "readOnlyHint": false,
         "destructiveHint": true,
+        "sensitiveHint": false,
         "idempotentHint": true,
         "openWorldHint": false
       },
@@ -7279,6 +7425,7 @@
       "annotations": {
         "readOnlyHint": false,
         "destructiveHint": false,
+        "sensitiveHint": false,
         "idempotentHint": true,
         "openWorldHint": false
       },
@@ -7399,6 +7546,7 @@
       "annotations": {
         "readOnlyHint": true,
         "destructiveHint": false,
+        "sensitiveHint": false,
         "idempotentHint": true,
         "openWorldHint": false
       },
@@ -7465,6 +7613,7 @@
       "annotations": {
         "readOnlyHint": true,
         "destructiveHint": false,
+        "sensitiveHint": false,
         "idempotentHint": true,
         "openWorldHint": false
       },
@@ -7504,6 +7653,7 @@
       "annotations": {
         "readOnlyHint": false,
         "destructiveHint": false,
+        "sensitiveHint": false,
         "idempotentHint": true,
         "openWorldHint": false
       },
@@ -7540,6 +7690,7 @@
       "annotations": {
         "readOnlyHint": false,
         "destructiveHint": true,
+        "sensitiveHint": false,
         "idempotentHint": false,
         "openWorldHint": false
       },
@@ -7580,6 +7731,7 @@
       "annotations": {
         "readOnlyHint": false,
         "destructiveHint": true,
+        "sensitiveHint": false,
         "idempotentHint": false,
         "openWorldHint": false
       },
@@ -7614,6 +7766,7 @@
       "annotations": {
         "readOnlyHint": false,
         "destructiveHint": true,
+        "sensitiveHint": false,
         "idempotentHint": false,
         "openWorldHint": false
       },
@@ -7662,6 +7815,7 @@
       "annotations": {
         "readOnlyHint": false,
         "destructiveHint": false,
+        "sensitiveHint": false,
         "idempotentHint": true,
         "openWorldHint": false
       },
@@ -7681,6 +7835,7 @@
       "annotations": {
         "readOnlyHint": true,
         "destructiveHint": false,
+        "sensitiveHint": false,
         "idempotentHint": true,
         "openWorldHint": false
       },
@@ -7748,6 +7903,7 @@
       "annotations": {
         "readOnlyHint": true,
         "destructiveHint": false,
+        "sensitiveHint": false,
         "idempotentHint": true,
         "openWorldHint": false
       },
@@ -7782,6 +7938,7 @@
       "annotations": {
         "readOnlyHint": false,
         "destructiveHint": false,
+        "sensitiveHint": false,
         "idempotentHint": false,
         "openWorldHint": false
       },
@@ -7815,6 +7972,7 @@
       "annotations": {
         "readOnlyHint": false,
         "destructiveHint": true,
+        "sensitiveHint": false,
         "idempotentHint": false,
         "openWorldHint": false
       },
@@ -7834,6 +7992,7 @@
       "annotations": {
         "readOnlyHint": false,
         "destructiveHint": false,
+        "sensitiveHint": false,
         "idempotentHint": false,
         "openWorldHint": false
       },
@@ -7869,6 +8028,7 @@
       "annotations": {
         "readOnlyHint": false,
         "destructiveHint": true,
+        "sensitiveHint": false,
         "idempotentHint": false,
         "openWorldHint": true
       },
@@ -7934,6 +8094,7 @@
       "annotations": {
         "readOnlyHint": true,
         "destructiveHint": false,
+        "sensitiveHint": false,
         "idempotentHint": true,
         "openWorldHint": false
       },
@@ -8010,6 +8171,7 @@
       "annotations": {
         "readOnlyHint": true,
         "destructiveHint": false,
+        "sensitiveHint": false,
         "idempotentHint": true,
         "openWorldHint": false
       },
@@ -8068,6 +8230,7 @@
       "annotations": {
         "readOnlyHint": true,
         "destructiveHint": false,
+        "sensitiveHint": false,
         "idempotentHint": true,
         "openWorldHint": false
       },
@@ -8126,6 +8289,7 @@
       "annotations": {
         "readOnlyHint": true,
         "destructiveHint": false,
+        "sensitiveHint": false,
         "idempotentHint": true,
         "openWorldHint": false
       },
@@ -8196,6 +8360,7 @@
       "annotations": {
         "readOnlyHint": true,
         "destructiveHint": false,
+        "sensitiveHint": false,
         "idempotentHint": true,
         "openWorldHint": false
       },
@@ -8298,6 +8463,7 @@
       "annotations": {
         "readOnlyHint": true,
         "destructiveHint": false,
+        "sensitiveHint": false,
         "idempotentHint": true,
         "openWorldHint": false
       },
@@ -8339,6 +8505,7 @@
       "annotations": {
         "readOnlyHint": false,
         "destructiveHint": false,
+        "sensitiveHint": false,
         "idempotentHint": false,
         "openWorldHint": false
       },
@@ -8395,6 +8562,7 @@
       "annotations": {
         "readOnlyHint": false,
         "destructiveHint": false,
+        "sensitiveHint": false,
         "idempotentHint": true,
         "openWorldHint": false
       },
@@ -8423,6 +8591,7 @@
       "annotations": {
         "readOnlyHint": false,
         "destructiveHint": false,
+        "sensitiveHint": false,
         "idempotentHint": true,
         "openWorldHint": true
       },
@@ -8451,6 +8620,7 @@
       "annotations": {
         "readOnlyHint": false,
         "destructiveHint": true,
+        "sensitiveHint": false,
         "idempotentHint": false,
         "openWorldHint": true
       },
@@ -8484,6 +8654,7 @@
       "annotations": {
         "readOnlyHint": false,
         "destructiveHint": true,
+        "sensitiveHint": false,
         "idempotentHint": false,
         "openWorldHint": false
       },
@@ -8503,6 +8674,7 @@
       "annotations": {
         "readOnlyHint": false,
         "destructiveHint": false,
+        "sensitiveHint": false,
         "idempotentHint": false,
         "openWorldHint": false
       },
@@ -8538,6 +8710,7 @@
       "annotations": {
         "readOnlyHint": false,
         "destructiveHint": true,
+        "sensitiveHint": false,
         "idempotentHint": false,
         "openWorldHint": true
       },
@@ -8566,6 +8739,7 @@
       "annotations": {
         "readOnlyHint": true,
         "destructiveHint": false,
+        "sensitiveHint": false,
         "idempotentHint": true,
         "openWorldHint": false
       },
@@ -8585,6 +8759,7 @@
       "annotations": {
         "readOnlyHint": true,
         "destructiveHint": false,
+        "sensitiveHint": false,
         "idempotentHint": true,
         "openWorldHint": false
       },
@@ -8614,6 +8789,7 @@
       "annotations": {
         "readOnlyHint": false,
         "destructiveHint": false,
+        "sensitiveHint": false,
         "idempotentHint": false,
         "openWorldHint": false
       },
@@ -8648,6 +8824,7 @@
       "annotations": {
         "readOnlyHint": false,
         "destructiveHint": true,
+        "sensitiveHint": false,
         "idempotentHint": true,
         "openWorldHint": false
       },
@@ -8680,6 +8857,7 @@
       "annotations": {
         "readOnlyHint": false,
         "destructiveHint": false,
+        "sensitiveHint": false,
         "idempotentHint": false,
         "openWorldHint": false
       },
@@ -8713,6 +8891,7 @@
       "annotations": {
         "readOnlyHint": false,
         "destructiveHint": false,
+        "sensitiveHint": false,
         "idempotentHint": false,
         "openWorldHint": false
       },
@@ -8746,6 +8925,7 @@
       "annotations": {
         "readOnlyHint": false,
         "destructiveHint": false,
+        "sensitiveHint": false,
         "idempotentHint": false,
         "openWorldHint": false
       },
@@ -8779,6 +8959,7 @@
       "annotations": {
         "readOnlyHint": false,
         "destructiveHint": false,
+        "sensitiveHint": false,
         "idempotentHint": false,
         "openWorldHint": false
       },
@@ -8798,6 +8979,7 @@
       "annotations": {
         "readOnlyHint": true,
         "destructiveHint": false,
+        "sensitiveHint": false,
         "idempotentHint": true,
         "openWorldHint": false
       },
@@ -8831,6 +9013,7 @@
       "annotations": {
         "readOnlyHint": false,
         "destructiveHint": false,
+        "sensitiveHint": false,
         "idempotentHint": false,
         "openWorldHint": false
       },
@@ -8858,6 +9041,7 @@
       "annotations": {
         "readOnlyHint": false,
         "destructiveHint": false,
+        "sensitiveHint": false,
         "idempotentHint": false,
         "openWorldHint": false
       },
@@ -8939,6 +9123,7 @@
       "annotations": {
         "readOnlyHint": true,
         "destructiveHint": false,
+        "sensitiveHint": false,
         "idempotentHint": true,
         "openWorldHint": false
       },
@@ -8967,6 +9152,7 @@
       "annotations": {
         "readOnlyHint": true,
         "destructiveHint": false,
+        "sensitiveHint": false,
         "idempotentHint": false,
         "openWorldHint": false
       },
@@ -9017,6 +9203,7 @@
       "annotations": {
         "readOnlyHint": true,
         "destructiveHint": false,
+        "sensitiveHint": false,
         "idempotentHint": true,
         "openWorldHint": false
       },
@@ -9046,6 +9233,7 @@
       "annotations": {
         "readOnlyHint": false,
         "destructiveHint": true,
+        "sensitiveHint": false,
         "idempotentHint": true,
         "openWorldHint": false
       },
@@ -9142,6 +9330,7 @@
       "annotations": {
         "readOnlyHint": true,
         "destructiveHint": false,
+        "sensitiveHint": false,
         "idempotentHint": true,
         "openWorldHint": false
       },
@@ -9314,6 +9503,7 @@
       "annotations": {
         "readOnlyHint": true,
         "destructiveHint": false,
+        "sensitiveHint": false,
         "idempotentHint": true,
         "openWorldHint": false
       },
@@ -9463,6 +9653,7 @@
       "annotations": {
         "readOnlyHint": true,
         "destructiveHint": false,
+        "sensitiveHint": false,
         "idempotentHint": true,
         "openWorldHint": false
       },
@@ -9622,6 +9813,7 @@
       "annotations": {
         "readOnlyHint": true,
         "destructiveHint": false,
+        "sensitiveHint": false,
         "idempotentHint": true,
         "openWorldHint": false
       },
@@ -9694,6 +9886,7 @@
       "annotations": {
         "readOnlyHint": true,
         "destructiveHint": false,
+        "sensitiveHint": false,
         "idempotentHint": true,
         "openWorldHint": false
       },
@@ -9759,6 +9952,7 @@
       "annotations": {
         "readOnlyHint": true,
         "destructiveHint": false,
+        "sensitiveHint": false,
         "idempotentHint": true,
         "openWorldHint": false
       },
@@ -9853,6 +10047,7 @@
       "annotations": {
         "readOnlyHint": true,
         "destructiveHint": false,
+        "sensitiveHint": false,
         "idempotentHint": true,
         "openWorldHint": false
       },
@@ -9925,6 +10120,7 @@
       "annotations": {
         "readOnlyHint": true,
         "destructiveHint": false,
+        "sensitiveHint": false,
         "idempotentHint": true,
         "openWorldHint": false
       },
@@ -9960,6 +10156,7 @@
       "annotations": {
         "readOnlyHint": false,
         "destructiveHint": true,
+        "sensitiveHint": false,
         "idempotentHint": false,
         "openWorldHint": true
       },
@@ -9994,6 +10191,7 @@
       "annotations": {
         "readOnlyHint": false,
         "destructiveHint": true,
+        "sensitiveHint": false,
         "idempotentHint": false,
         "openWorldHint": false
       },
@@ -10034,6 +10232,7 @@
       "annotations": {
         "readOnlyHint": false,
         "destructiveHint": true,
+        "sensitiveHint": false,
         "idempotentHint": false,
         "openWorldHint": true
       },
@@ -10082,6 +10281,7 @@
       "annotations": {
         "readOnlyHint": false,
         "destructiveHint": false,
+        "sensitiveHint": false,
         "idempotentHint": true,
         "openWorldHint": false
       },
@@ -10118,6 +10318,7 @@
       "annotations": {
         "readOnlyHint": true,
         "destructiveHint": false,
+        "sensitiveHint": false,
         "idempotentHint": true,
         "openWorldHint": true
       },
@@ -10156,6 +10357,7 @@
       "annotations": {
         "readOnlyHint": true,
         "destructiveHint": false,
+        "sensitiveHint": false,
         "idempotentHint": false,
         "openWorldHint": false
       },
@@ -10198,6 +10400,7 @@
       "annotations": {
         "readOnlyHint": false,
         "destructiveHint": true,
+        "sensitiveHint": false,
         "idempotentHint": false,
         "openWorldHint": true
       },
@@ -10231,6 +10434,7 @@
       "annotations": {
         "readOnlyHint": false,
         "destructiveHint": true,
+        "sensitiveHint": false,
         "idempotentHint": false,
         "openWorldHint": true
       },
@@ -10258,6 +10462,7 @@
       "annotations": {
         "readOnlyHint": true,
         "destructiveHint": false,
+        "sensitiveHint": false,
         "idempotentHint": false,
         "openWorldHint": false
       },
@@ -10287,6 +10492,7 @@
       "annotations": {
         "readOnlyHint": true,
         "destructiveHint": false,
+        "sensitiveHint": false,
         "idempotentHint": true,
         "openWorldHint": false
       },
@@ -10397,6 +10603,7 @@
       "annotations": {
         "readOnlyHint": true,
         "destructiveHint": false,
+        "sensitiveHint": false,
         "idempotentHint": true,
         "openWorldHint": false
       },
@@ -10520,6 +10727,7 @@
       "annotations": {
         "readOnlyHint": true,
         "destructiveHint": false,
+        "sensitiveHint": false,
         "idempotentHint": true,
         "openWorldHint": false
       },
@@ -10628,6 +10836,7 @@
       "annotations": {
         "readOnlyHint": true,
         "destructiveHint": false,
+        "sensitiveHint": false,
         "idempotentHint": true,
         "openWorldHint": false
       },
@@ -10723,6 +10932,7 @@
       "annotations": {
         "readOnlyHint": true,
         "destructiveHint": false,
+        "sensitiveHint": false,
         "idempotentHint": true,
         "openWorldHint": false
       },
@@ -10809,6 +11019,7 @@
       "annotations": {
         "readOnlyHint": true,
         "destructiveHint": false,
+        "sensitiveHint": false,
         "idempotentHint": true,
         "openWorldHint": false
       },
@@ -10837,6 +11048,7 @@
       "annotations": {
         "readOnlyHint": false,
         "destructiveHint": false,
+        "sensitiveHint": false,
         "idempotentHint": true,
         "openWorldHint": true
       },
@@ -10929,6 +11141,7 @@
       "annotations": {
         "readOnlyHint": true,
         "destructiveHint": false,
+        "sensitiveHint": false,
         "idempotentHint": true,
         "openWorldHint": false
       },
@@ -10969,6 +11182,7 @@
       "annotations": {
         "readOnlyHint": false,
         "destructiveHint": false,
+        "sensitiveHint": false,
         "idempotentHint": true,
         "openWorldHint": true
       },
@@ -11068,6 +11282,7 @@
       "annotations": {
         "readOnlyHint": true,
         "destructiveHint": false,
+        "sensitiveHint": false,
         "idempotentHint": true,
         "openWorldHint": false
       },
@@ -11179,6 +11394,7 @@
       "annotations": {
         "readOnlyHint": true,
         "destructiveHint": false,
+        "sensitiveHint": false,
         "idempotentHint": true,
         "openWorldHint": false
       },
@@ -11214,6 +11430,7 @@
       "annotations": {
         "readOnlyHint": true,
         "destructiveHint": false,
+        "sensitiveHint": false,
         "idempotentHint": true,
         "openWorldHint": false
       },
@@ -11308,6 +11525,7 @@
       "annotations": {
         "readOnlyHint": true,
         "destructiveHint": false,
+        "sensitiveHint": false,
         "idempotentHint": true,
         "openWorldHint": false
       },
@@ -11355,6 +11573,7 @@
       "annotations": {
         "readOnlyHint": true,
         "destructiveHint": false,
+        "sensitiveHint": false,
         "idempotentHint": true,
         "openWorldHint": false
       },
@@ -11423,6 +11642,7 @@
       "annotations": {
         "readOnlyHint": true,
         "destructiveHint": false,
+        "sensitiveHint": false,
         "idempotentHint": true,
         "openWorldHint": false
       },
@@ -11512,6 +11732,7 @@
       "annotations": {
         "readOnlyHint": true,
         "destructiveHint": false,
+        "sensitiveHint": false,
         "idempotentHint": true,
         "openWorldHint": false
       },
@@ -11531,6 +11752,7 @@
       "annotations": {
         "readOnlyHint": false,
         "destructiveHint": true,
+        "sensitiveHint": false,
         "idempotentHint": true,
         "openWorldHint": false
       },
@@ -11566,6 +11788,7 @@
       "annotations": {
         "readOnlyHint": false,
         "destructiveHint": true,
+        "sensitiveHint": false,
         "idempotentHint": true,
         "openWorldHint": false
       },
@@ -11619,6 +11842,7 @@
       "annotations": {
         "readOnlyHint": true,
         "destructiveHint": false,
+        "sensitiveHint": false,
         "idempotentHint": true,
         "openWorldHint": false
       },
@@ -11638,6 +11862,7 @@
       "annotations": {
         "readOnlyHint": true,
         "destructiveHint": false,
+        "sensitiveHint": false,
         "idempotentHint": true,
         "openWorldHint": false
       },
@@ -11674,6 +11899,7 @@
       "annotations": {
         "readOnlyHint": false,
         "destructiveHint": true,
+        "sensitiveHint": false,
         "idempotentHint": false,
         "openWorldHint": true
       },
@@ -11745,6 +11971,7 @@
       "annotations": {
         "readOnlyHint": false,
         "destructiveHint": true,
+        "sensitiveHint": false,
         "idempotentHint": false,
         "openWorldHint": true
       },
@@ -11780,6 +12007,7 @@
       "annotations": {
         "readOnlyHint": false,
         "destructiveHint": true,
+        "sensitiveHint": false,
         "idempotentHint": false,
         "openWorldHint": true
       },
@@ -11809,6 +12037,7 @@
       "annotations": {
         "readOnlyHint": false,
         "destructiveHint": false,
+        "sensitiveHint": false,
         "idempotentHint": true,
         "openWorldHint": false
       },
@@ -11853,6 +12082,7 @@
       "annotations": {
         "readOnlyHint": false,
         "destructiveHint": false,
+        "sensitiveHint": false,
         "idempotentHint": true,
         "openWorldHint": false
       },
@@ -11886,6 +12116,7 @@
       "annotations": {
         "readOnlyHint": false,
         "destructiveHint": false,
+        "sensitiveHint": false,
         "idempotentHint": true,
         "openWorldHint": false
       },
@@ -11919,6 +12150,7 @@
       "annotations": {
         "readOnlyHint": false,
         "destructiveHint": false,
+        "sensitiveHint": false,
         "idempotentHint": true,
         "openWorldHint": false
       },
@@ -11956,6 +12188,7 @@
       "annotations": {
         "readOnlyHint": false,
         "destructiveHint": false,
+        "sensitiveHint": false,
         "idempotentHint": true,
         "openWorldHint": false
       },
@@ -11991,6 +12224,7 @@
       "annotations": {
         "readOnlyHint": false,
         "destructiveHint": false,
+        "sensitiveHint": false,
         "idempotentHint": true,
         "openWorldHint": false
       },
@@ -12024,6 +12258,7 @@
       "annotations": {
         "readOnlyHint": false,
         "destructiveHint": false,
+        "sensitiveHint": false,
         "idempotentHint": true,
         "openWorldHint": false
       },
@@ -12070,6 +12305,7 @@
       "annotations": {
         "readOnlyHint": false,
         "destructiveHint": false,
+        "sensitiveHint": false,
         "idempotentHint": true,
         "openWorldHint": false
       },
@@ -12089,6 +12325,7 @@
       "annotations": {
         "readOnlyHint": true,
         "destructiveHint": false,
+        "sensitiveHint": false,
         "idempotentHint": true,
         "openWorldHint": false
       },
@@ -12130,6 +12367,7 @@
       "annotations": {
         "readOnlyHint": true,
         "destructiveHint": false,
+        "sensitiveHint": false,
         "idempotentHint": true,
         "openWorldHint": false
       },
@@ -12173,6 +12411,7 @@
       "annotations": {
         "readOnlyHint": false,
         "destructiveHint": false,
+        "sensitiveHint": false,
         "idempotentHint": false,
         "openWorldHint": false
       },
@@ -12192,6 +12431,7 @@
       "annotations": {
         "readOnlyHint": true,
         "destructiveHint": false,
+        "sensitiveHint": false,
         "idempotentHint": true,
         "openWorldHint": false
       },
@@ -12211,6 +12451,7 @@
       "annotations": {
         "readOnlyHint": false,
         "destructiveHint": false,
+        "sensitiveHint": false,
         "idempotentHint": false,
         "openWorldHint": false
       },
@@ -12230,6 +12471,7 @@
       "annotations": {
         "readOnlyHint": true,
         "destructiveHint": false,
+        "sensitiveHint": false,
         "idempotentHint": true,
         "openWorldHint": false
       },
@@ -12255,6 +12497,7 @@
       "annotations": {
         "readOnlyHint": false,
         "destructiveHint": false,
+        "sensitiveHint": false,
         "idempotentHint": false,
         "openWorldHint": false
       },
@@ -12274,6 +12517,7 @@
       "annotations": {
         "readOnlyHint": false,
         "destructiveHint": false,
+        "sensitiveHint": false,
         "idempotentHint": false,
         "openWorldHint": false
       },
@@ -12293,6 +12537,7 @@
       "annotations": {
         "readOnlyHint": false,
         "destructiveHint": false,
+        "sensitiveHint": false,
         "idempotentHint": false,
         "openWorldHint": false
       },
@@ -12312,6 +12557,7 @@
       "annotations": {
         "readOnlyHint": true,
         "destructiveHint": false,
+        "sensitiveHint": false,
         "idempotentHint": true,
         "openWorldHint": false
       },
@@ -12331,6 +12577,7 @@
       "annotations": {
         "readOnlyHint": true,
         "destructiveHint": false,
+        "sensitiveHint": false,
         "idempotentHint": true,
         "openWorldHint": false
       },
@@ -12350,6 +12597,7 @@
       "annotations": {
         "readOnlyHint": true,
         "destructiveHint": false,
+        "sensitiveHint": false,
         "idempotentHint": true,
         "openWorldHint": false
       },
@@ -12385,6 +12633,7 @@
       "annotations": {
         "readOnlyHint": false,
         "destructiveHint": false,
+        "sensitiveHint": false,
         "idempotentHint": false,
         "openWorldHint": false
       },
@@ -12404,6 +12653,7 @@
       "annotations": {
         "readOnlyHint": true,
         "destructiveHint": false,
+        "sensitiveHint": false,
         "idempotentHint": true,
         "openWorldHint": false
       },
@@ -12423,6 +12673,7 @@
       "annotations": {
         "readOnlyHint": true,
         "destructiveHint": false,
+        "sensitiveHint": false,
         "idempotentHint": true,
         "openWorldHint": false
       },
@@ -12442,6 +12693,7 @@
       "annotations": {
         "readOnlyHint": false,
         "destructiveHint": true,
+        "sensitiveHint": false,
         "idempotentHint": true,
         "openWorldHint": false
       },
@@ -12461,6 +12713,7 @@
       "annotations": {
         "readOnlyHint": false,
         "destructiveHint": false,
+        "sensitiveHint": false,
         "idempotentHint": true,
         "openWorldHint": false
       },
@@ -12535,6 +12788,7 @@
       "annotations": {
         "readOnlyHint": true,
         "destructiveHint": false,
+        "sensitiveHint": false,
         "idempotentHint": true,
         "openWorldHint": false
       },
@@ -12560,6 +12814,7 @@
       "annotations": {
         "readOnlyHint": true,
         "destructiveHint": false,
+        "sensitiveHint": false,
         "idempotentHint": true,
         "openWorldHint": false
       },
@@ -12588,6 +12843,7 @@
       "annotations": {
         "readOnlyHint": true,
         "destructiveHint": false,
+        "sensitiveHint": false,
         "idempotentHint": true,
         "openWorldHint": false
       },
@@ -12619,6 +12875,7 @@
       "annotations": {
         "readOnlyHint": false,
         "destructiveHint": true,
+        "sensitiveHint": false,
         "idempotentHint": false,
         "openWorldHint": false
       },
@@ -12638,6 +12895,7 @@
       "annotations": {
         "readOnlyHint": false,
         "destructiveHint": true,
+        "sensitiveHint": false,
         "idempotentHint": false,
         "openWorldHint": false
       },
@@ -12677,6 +12935,7 @@
       "annotations": {
         "readOnlyHint": true,
         "destructiveHint": false,
+        "sensitiveHint": false,
         "idempotentHint": true,
         "openWorldHint": false
       },
@@ -12696,6 +12955,7 @@
       "annotations": {
         "readOnlyHint": true,
         "destructiveHint": false,
+        "sensitiveHint": false,
         "idempotentHint": true,
         "openWorldHint": false
       },
@@ -12767,6 +13027,7 @@
       "annotations": {
         "readOnlyHint": true,
         "destructiveHint": false,
+        "sensitiveHint": false,
         "idempotentHint": true,
         "openWorldHint": false
       },
@@ -12798,6 +13059,7 @@
       "annotations": {
         "readOnlyHint": false,
         "destructiveHint": false,
+        "sensitiveHint": false,
         "idempotentHint": true,
         "openWorldHint": false
       },
@@ -12825,6 +13087,7 @@
       "annotations": {
         "readOnlyHint": false,
         "destructiveHint": false,
+        "sensitiveHint": false,
         "idempotentHint": true,
         "openWorldHint": false
       },
@@ -12852,6 +13115,7 @@
       "annotations": {
         "readOnlyHint": false,
         "destructiveHint": true,
+        "sensitiveHint": false,
         "idempotentHint": true,
         "openWorldHint": false
       },
@@ -12884,6 +13148,7 @@
       "annotations": {
         "readOnlyHint": true,
         "destructiveHint": false,
+        "sensitiveHint": false,
         "idempotentHint": true,
         "openWorldHint": false
       },
@@ -12913,6 +13178,7 @@
       "annotations": {
         "readOnlyHint": false,
         "destructiveHint": true,
+        "sensitiveHint": false,
         "idempotentHint": true,
         "openWorldHint": false
       },
@@ -12932,6 +13198,7 @@
       "annotations": {
         "readOnlyHint": true,
         "destructiveHint": false,
+        "sensitiveHint": false,
         "idempotentHint": true,
         "openWorldHint": false
       },
@@ -12967,6 +13234,7 @@
       "annotations": {
         "readOnlyHint": true,
         "destructiveHint": false,
+        "sensitiveHint": false,
         "idempotentHint": true,
         "openWorldHint": false
       },
@@ -12986,6 +13254,7 @@
       "annotations": {
         "readOnlyHint": true,
         "destructiveHint": false,
+        "sensitiveHint": false,
         "idempotentHint": true,
         "openWorldHint": false
       },
@@ -13014,6 +13283,7 @@
       "annotations": {
         "readOnlyHint": false,
         "destructiveHint": false,
+        "sensitiveHint": false,
         "idempotentHint": false,
         "openWorldHint": false
       },
@@ -13047,6 +13317,7 @@
       "annotations": {
         "readOnlyHint": false,
         "destructiveHint": false,
+        "sensitiveHint": false,
         "idempotentHint": false,
         "openWorldHint": false
       },
@@ -13082,6 +13353,7 @@
       "annotations": {
         "readOnlyHint": true,
         "destructiveHint": false,
+        "sensitiveHint": false,
         "idempotentHint": true,
         "openWorldHint": false
       },
@@ -13149,6 +13421,7 @@
       "annotations": {
         "readOnlyHint": true,
         "destructiveHint": false,
+        "sensitiveHint": false,
         "idempotentHint": true,
         "openWorldHint": true
       },
@@ -13196,6 +13469,7 @@
       "annotations": {
         "readOnlyHint": false,
         "destructiveHint": true,
+        "sensitiveHint": false,
         "idempotentHint": false,
         "openWorldHint": true
       },
@@ -13230,6 +13504,7 @@
       "annotations": {
         "readOnlyHint": true,
         "destructiveHint": false,
+        "sensitiveHint": false,
         "idempotentHint": true,
         "openWorldHint": true
       },
@@ -13258,6 +13533,7 @@
       "annotations": {
         "readOnlyHint": false,
         "destructiveHint": false,
+        "sensitiveHint": false,
         "idempotentHint": true,
         "openWorldHint": true
       },
@@ -13350,6 +13626,7 @@
       "annotations": {
         "readOnlyHint": false,
         "destructiveHint": true,
+        "sensitiveHint": false,
         "idempotentHint": false,
         "openWorldHint": true
       },
@@ -13389,6 +13666,7 @@
       "annotations": {
         "readOnlyHint": false,
         "destructiveHint": true,
+        "sensitiveHint": false,
         "idempotentHint": false,
         "openWorldHint": true
       },
@@ -13428,6 +13706,7 @@
       "annotations": {
         "readOnlyHint": true,
         "destructiveHint": false,
+        "sensitiveHint": false,
         "idempotentHint": true,
         "openWorldHint": true
       },
@@ -13472,6 +13751,7 @@
       "annotations": {
         "readOnlyHint": false,
         "destructiveHint": false,
+        "sensitiveHint": false,
         "idempotentHint": false,
         "openWorldHint": true
       },
@@ -13522,6 +13802,7 @@
       "annotations": {
         "readOnlyHint": true,
         "destructiveHint": false,
+        "sensitiveHint": false,
         "idempotentHint": true,
         "openWorldHint": true
       },
@@ -13555,6 +13836,7 @@
       "annotations": {
         "readOnlyHint": false,
         "destructiveHint": true,
+        "sensitiveHint": false,
         "idempotentHint": false,
         "openWorldHint": true
       },
@@ -13608,6 +13890,7 @@
       "annotations": {
         "readOnlyHint": false,
         "destructiveHint": true,
+        "sensitiveHint": false,
         "idempotentHint": true,
         "openWorldHint": false
       },
@@ -13661,6 +13944,7 @@
       "annotations": {
         "readOnlyHint": false,
         "destructiveHint": true,
+        "sensitiveHint": false,
         "idempotentHint": true,
         "openWorldHint": false
       },
@@ -13695,6 +13979,7 @@
       "annotations": {
         "readOnlyHint": false,
         "destructiveHint": true,
+        "sensitiveHint": false,
         "idempotentHint": true,
         "openWorldHint": false
       },
@@ -13754,6 +14039,7 @@
       "annotations": {
         "readOnlyHint": false,
         "destructiveHint": true,
+        "sensitiveHint": false,
         "idempotentHint": true,
         "openWorldHint": false
       },

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -29,11 +29,11 @@ These are the workflows AirMCP should make obvious in product, docs, demos, and 
 | Workflow | Type | Required modules | Core tools and skills | Safety shape |
 | --- | --- | --- | --- | --- |
 | Daily Briefing | built-in-skill | `calendar`, `reminders`, `mail`, `notes` | `skill_daily-briefing`, `summarize_context`, `today_events`, `list_reminders`, `get_unread_count`, `list_notes` | Read-only by default; saving a note or reminder is a separate write action. |
-| Inbox Triage | built-in-skill | `mail`, `reminders` | `skill_inbox-triage`, `skill_sender-to-tasks`, `search_messages`, `create_reminder` | Reads mail first; reminder creation is auditable and can be approved per call. |
+| Inbox Triage | built-in-skill | `mail`, `reminders` | `skill_inbox-triage`, `skill_sender-to-tasks`, `search_messages`, `create_reminder` | Reads mail first; reminder creation is auditable and prompts per call at the default HITL level. |
 | Meeting Prep | prompt-recipe | `calendar`, `notes`, `contacts`, `finder`, `reminders` | `today_events`, `search_notes`, `search_contacts`, `recent_files`, `list_reminders` | Read-only prep flow; agenda or task creation is an explicit follow-up write. |
 | Project Digest | built-in-skill | `memory`, `notes`, `calendar`, `reminders`, `mail`, `finder` | `semantic_index`, `skill_project-digest`, `semantic_search`, `find_related` | Digest is read-only after indexing; indexing writes only to AirMCP's local semantic store. |
-| Focus Blocks | built-in-skill | `reminders`, `calendar` | `skill_focus-block-planner`, `list_reminders`, `create_event` | Calendar writes are non-destructive but non-idempotent, so each created event remains auditable. |
-| Research to Output | prompt-recipe | `safari`, `intelligence`, `notes`, `mail` | `list_tabs`, `read_page_content`, `summarize_text`, `create_note`, `send_mail` | Reading and summarizing are read-only. Sending or saving output is a separate write action. |
+| Focus Blocks | built-in-skill | `reminders`, `calendar` | `skill_focus-block-planner`, `list_reminders`, `create_event` | Calendar writes are non-destructive but sensitive, so each created event prompts at the default HITL level. |
+| Research to Output | prompt-recipe | `safari`, `intelligence`, `notes`, `mail` | `list_tabs`, `read_page_content`, `summarize_text`, `create_note`, `send_mail` | Reading and summarizing are read-only. Sending or saving output is a separate HITL-gated action. |
 
 ## Copyable Prompts
 

--- a/scripts/dump-tool-manifest.mjs
+++ b/scripts/dump-tool-manifest.mjs
@@ -155,6 +155,7 @@ try {
       annotations: {
         readOnlyHint: t.annotations?.readOnlyHint ?? false,
         destructiveHint: t.annotations?.destructiveHint ?? false,
+        sensitiveHint: t.annotations?.sensitiveHint ?? false,
         idempotentHint: t.annotations?.idempotentHint ?? false,
         openWorldHint: t.annotations?.openWorldHint ?? true,
       },

--- a/scripts/verify-tool-manifest.mjs
+++ b/scripts/verify-tool-manifest.mjs
@@ -113,12 +113,12 @@ if (Array.isArray(manifest.tools)) {
       fail(path, `outputSchema must be null or an object`);
     }
 
-    // annotations — all 4 boolean hints required
+    // annotations — all boolean hints required
     const a = tool.annotations;
     if (typeof a !== "object" || a === null) {
       fail(path, `annotations missing`);
     } else {
-      for (const key of ["readOnlyHint", "destructiveHint", "idempotentHint", "openWorldHint"]) {
+      for (const key of ["readOnlyHint", "destructiveHint", "sensitiveHint", "idempotentHint", "openWorldHint"]) {
         if (typeof a[key] !== "boolean") {
           fail(`${path}.annotations.${key}`, `expected boolean, got ${typeof a[key]}`);
         }

--- a/src/calendar/tools.ts
+++ b/src/calendar/tools.ts
@@ -250,6 +250,7 @@ export function registerCalendarTools(server: McpServer, _config: AirMcpConfig):
       annotations: {
         readOnlyHint: false,
         destructiveHint: false,
+        sensitiveHint: true,
         idempotentHint: false,
         openWorldHint: false,
       },
@@ -503,6 +504,7 @@ export function registerCalendarTools(server: McpServer, _config: AirMcpConfig):
       annotations: {
         readOnlyHint: false,
         destructiveHint: false,
+        sensitiveHint: true,
         idempotentHint: false,
         openWorldHint: false,
       },

--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -374,7 +374,12 @@ export async function runInit(): Promise<void> {
   // --- Step 2: Security & privacy settings ---
   console.log("");
   const securityOptions: SelectOption[] = [
-    { label: "Recommended (destructive actions need approval)", value: "destructive-only", hint: "default" },
+    {
+      label: "Recommended (sensitive and destructive actions need approval)",
+      value: "sensitive-only",
+      hint: "default",
+    },
+    { label: "Minimal (destructive actions only)", value: "destructive-only" },
     { label: "Strict (all write operations need approval)", value: "all-writes" },
     { label: "Maximum (every tool call needs approval)", value: "all" },
     { label: "Off (no confirmations)", value: "off" },

--- a/src/cli/workflows-catalog.json
+++ b/src/cli/workflows-catalog.json
@@ -5,7 +5,14 @@
     "bestFor": "Start the day with calendar, reminders, mail, and recent notes.",
     "prompt": "Brief me on today's calendar, overdue reminders, unread mail, and recent notes.",
     "siri": "Daily Briefing in AirMCP",
-    "tools": ["skill_daily-briefing", "summarize_context", "today_events", "list_reminders", "get_unread_count", "list_notes"],
+    "tools": [
+      "skill_daily-briefing",
+      "summarize_context",
+      "today_events",
+      "list_reminders",
+      "get_unread_count",
+      "list_notes"
+    ],
     "requiredModules": ["calendar", "reminders", "mail", "notes"],
     "implementation": "built-in-skill",
     "safety": "Read-only by default. Saving a note or reminder becomes a separate approved action."

--- a/src/contacts/tools.ts
+++ b/src/contacts/tools.ts
@@ -228,7 +228,13 @@ export function registerContactTools(server: McpServer, _config: AirMcpConfig): 
         jobTitle: z.string().max(500).optional().describe("Job title"),
         note: z.string().max(5000).optional().describe("Notes"),
       },
-      annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: false },
+      annotations: {
+        readOnlyHint: false,
+        destructiveHint: false,
+        sensitiveHint: true,
+        idempotentHint: false,
+        openWorldHint: false,
+      },
     },
     async ({ firstName, lastName, email, phone, organization, jobTitle, note }) => {
       try {
@@ -336,7 +342,13 @@ export function registerContactTools(server: McpServer, _config: AirMcpConfig): 
         email: z.string().email().describe("Email address to add"),
         label: z.string().max(500).optional().default("work").describe("Email label (default: work)"),
       },
-      annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: false },
+      annotations: {
+        readOnlyHint: false,
+        destructiveHint: false,
+        sensitiveHint: true,
+        idempotentHint: false,
+        openWorldHint: false,
+      },
     },
     async ({ id, email, label }) => {
       try {
@@ -361,7 +373,13 @@ export function registerContactTools(server: McpServer, _config: AirMcpConfig): 
         phone: z.string().min(1).max(1000).describe("Phone number to add"),
         label: z.string().max(500).optional().default("mobile").describe("Phone label (default: mobile)"),
       },
-      annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: false },
+      annotations: {
+        readOnlyHint: false,
+        destructiveHint: false,
+        sensitiveHint: true,
+        idempotentHint: false,
+        openWorldHint: false,
+      },
     },
     async ({ id, phone, label }) => {
       try {

--- a/src/finder/tools.ts
+++ b/src/finder/tools.ts
@@ -212,7 +212,13 @@ export function registerFinderTools(server: McpServer, _config: AirMcpConfig): v
       inputSchema: {
         path: zFilePath.describe("Absolute path of the folder to create"),
       },
-      annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: true, openWorldHint: false },
+      annotations: {
+        readOnlyHint: false,
+        destructiveHint: false,
+        sensitiveHint: true,
+        idempotentHint: true,
+        openWorldHint: false,
+      },
     },
     async ({ path }) => {
       try {

--- a/src/music/tools.ts
+++ b/src/music/tools.ts
@@ -283,7 +283,13 @@ export function registerMusicTools(server: McpServer, _config: AirMcpConfig): vo
       inputSchema: {
         name: z.string().max(500).describe("Name for the new playlist"),
       },
-      annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: false },
+      annotations: {
+        readOnlyHint: false,
+        destructiveHint: false,
+        sensitiveHint: true,
+        idempotentHint: false,
+        openWorldHint: false,
+      },
     },
     async ({ name }) => {
       try {
@@ -303,7 +309,13 @@ export function registerMusicTools(server: McpServer, _config: AirMcpConfig): vo
         playlistName: z.string().max(500).describe("Playlist name"),
         trackName: z.string().max(500).describe("Track name to add"),
       },
-      annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: false },
+      annotations: {
+        readOnlyHint: false,
+        destructiveHint: false,
+        sensitiveHint: true,
+        idempotentHint: false,
+        openWorldHint: false,
+      },
     },
     async ({ playlistName, trackName }) => {
       try {

--- a/src/notes/tools.ts
+++ b/src/notes/tools.ts
@@ -254,6 +254,7 @@ export function registerNoteTools(server: McpServer, config: AirMcpConfig): void
       annotations: {
         readOnlyHint: false,
         destructiveHint: false,
+        sensitiveHint: true,
         idempotentHint: false,
         openWorldHint: false,
       },
@@ -372,6 +373,7 @@ export function registerNoteTools(server: McpServer, config: AirMcpConfig): void
       annotations: {
         readOnlyHint: false,
         destructiveHint: false,
+        sensitiveHint: true,
         idempotentHint: true,
         openWorldHint: false,
       },

--- a/src/photos/tools.ts
+++ b/src/photos/tools.ts
@@ -295,7 +295,13 @@ export function registerPhotosTools(server: McpServer, _config: AirMcpConfig): v
       inputSchema: {
         name: z.string().max(500).describe("Album name"),
       },
-      annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: false },
+      annotations: {
+        readOnlyHint: false,
+        destructiveHint: false,
+        sensitiveHint: true,
+        idempotentHint: false,
+        openWorldHint: false,
+      },
     },
     async ({ name }) => {
       try {
@@ -322,7 +328,13 @@ export function registerPhotosTools(server: McpServer, _config: AirMcpConfig): v
         photoIds: z.array(z.string().max(500)).min(1).max(500).describe("Array of photo media item IDs (max 500)"),
         albumName: z.string().max(500).describe("Target album name"),
       },
-      annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: false },
+      annotations: {
+        readOnlyHint: false,
+        destructiveHint: false,
+        sensitiveHint: true,
+        idempotentHint: false,
+        openWorldHint: false,
+      },
     },
     async ({ photoIds, albumName }) => {
       try {

--- a/src/reminders/tools.ts
+++ b/src/reminders/tools.ts
@@ -218,6 +218,7 @@ export function registerReminderTools(server: McpServer, _config: AirMcpConfig):
       annotations: {
         readOnlyHint: false,
         destructiveHint: false,
+        sensitiveHint: true,
         idempotentHint: false,
         openWorldHint: false,
       },
@@ -303,6 +304,7 @@ export function registerReminderTools(server: McpServer, _config: AirMcpConfig):
       annotations: {
         readOnlyHint: false,
         destructiveHint: false,
+        sensitiveHint: true,
         idempotentHint: true,
         openWorldHint: false,
       },
@@ -408,6 +410,7 @@ export function registerReminderTools(server: McpServer, _config: AirMcpConfig):
       annotations: {
         readOnlyHint: false,
         destructiveHint: false,
+        sensitiveHint: true,
         idempotentHint: false,
         openWorldHint: false,
       },
@@ -491,6 +494,7 @@ export function registerReminderTools(server: McpServer, _config: AirMcpConfig):
       annotations: {
         readOnlyHint: false,
         destructiveHint: false,
+        sensitiveHint: true,
         idempotentHint: false,
         openWorldHint: false,
       },

--- a/src/shared/config.ts
+++ b/src/shared/config.ts
@@ -77,7 +77,7 @@ export function getCompatibilityEnv(): CompatibilityEnv {
 /** npm package name — single source of truth for npx/install references */
 export const NPM_PACKAGE_NAME = "airmcp";
 
-export type HitlLevel = "off" | "destructive-only" | "all-writes" | "all";
+export type HitlLevel = "off" | "destructive-only" | "sensitive-only" | "all-writes" | "all";
 
 export interface HitlConfig {
   level: HitlLevel;
@@ -86,7 +86,7 @@ export interface HitlConfig {
   socketPath: string;
 }
 
-const HITL_LEVELS: readonly string[] = ["off", "destructive-only", "all-writes", "all"];
+const HITL_LEVELS: readonly string[] = ["off", "destructive-only", "sensitive-only", "all-writes", "all"];
 
 export const MODULE_NAMES = [
   "notes",
@@ -310,7 +310,7 @@ export function parseConfig(): AirMcpConfig {
 
   // Validate hitl.level: warn if not a valid level
   if (file.hitl?.level !== undefined && !HITL_LEVELS.includes(file.hitl.level)) {
-    log.warn("invalid hitl.level — using default 'destructive-only'", {
+    log.warn("invalid hitl.level — using default 'sensitive-only'", {
       provided: file.hitl.level,
       expected: HITL_LEVELS,
     });
@@ -391,8 +391,8 @@ export function parseConfig(): AirMcpConfig {
   }
 
   // HITL config: env var > JSON > default
-  const hitlLevelRaw = process.env.AIRMCP_HITL_LEVEL ?? file.hitl?.level ?? "destructive-only";
-  const hitlLevel: HitlLevel = HITL_LEVELS.includes(hitlLevelRaw) ? (hitlLevelRaw as HitlLevel) : "destructive-only";
+  const hitlLevelRaw = process.env.AIRMCP_HITL_LEVEL ?? file.hitl?.level ?? "sensitive-only";
+  const hitlLevel: HitlLevel = HITL_LEVELS.includes(hitlLevelRaw) ? (hitlLevelRaw as HitlLevel) : "sensitive-only";
   const hitlWhitelist = new Set<string>(file.hitl?.whitelist ?? []);
   const hitlTimeout = file.hitl?.timeout ?? 30;
   const hitlSocketPath = PATHS.HITL_SOCKET;

--- a/src/shared/hitl-guard.ts
+++ b/src/shared/hitl-guard.ts
@@ -10,6 +10,7 @@ const NOT_HANDLED = Symbol("hitl-elicitation-not-handled");
 interface ToolAnnotations {
   readOnlyHint?: boolean;
   destructiveHint?: boolean;
+  sensitiveHint?: boolean;
   idempotentHint?: boolean;
   openWorldHint?: boolean;
 }
@@ -70,6 +71,8 @@ function shouldRequireApproval(
       return false;
     case "destructive-only":
       return annotations.destructiveHint === true;
+    case "sensitive-only":
+      return annotations.destructiveHint === true || annotations.sensitiveHint === true;
     case "all-writes":
       return annotations.readOnlyHint === false;
     case "all":
@@ -86,6 +89,7 @@ async function tryElicitApproval(
   toolName: string,
   toolArgs: Record<string, unknown>,
   destructive: boolean,
+  sensitive: boolean,
 ): Promise<boolean | undefined> {
   // RFC 0008 §3.3 — operator opt-out for end-to-end scripted pipelines
   // that don't want any user prompt. When set, every call falls through
@@ -104,7 +108,11 @@ async function tryElicitApproval(
     const caps = inner.getClientCapabilities?.();
     if (caps && !caps.elicitation) return undefined;
 
-    const label = destructive ? `⚠️ Destructive: ${toolName}` : `Approve: ${toolName}`;
+    const label = destructive
+      ? `⚠️ Destructive: ${toolName}`
+      : sensitive
+        ? `⚠️ Sensitive: ${toolName}`
+        : `Approve: ${toolName}`;
     const argsSummary = JSON.stringify(toolArgs, null, 2).slice(0, 500);
 
     const result = await inner.elicitInput({
@@ -170,12 +178,13 @@ export function installHitlGuard(server: McpServer, hitlClient: HitlClient, conf
     const wrapped = async (...args: unknown[]) => {
       const toolArgs = (args[0] ?? {}) as Record<string, unknown>;
       const destructive = annotations.destructiveHint ?? false;
+      const sensitive = annotations.sensitiveHint ?? false;
       const managed = isManagedClient(server);
 
       // Resolve the call through MCP elicitation. Returns NOT_HANDLED when the
       // client offers no elicitation channel, so the caller can fall back.
       const viaElicitation = async (): Promise<unknown> => {
-        const elicitResult = await tryElicitApproval(server, name, toolArgs, destructive);
+        const elicitResult = await tryElicitApproval(server, name, toolArgs, destructive, sensitive);
         if (elicitResult === undefined) return NOT_HANDLED;
         if (telemetryEnabled) {
           traceApproval(name, elicitResult ? "approved" : "denied", "elicitation", { destructive, managed });
@@ -215,6 +224,7 @@ export function installHitlGuard(server: McpServer, hitlClient: HitlClient, conf
         toolArgs,
         destructive,
         annotations.openWorldHint ?? false,
+        sensitive,
       );
       if (telemetryEnabled) {
         traceApproval(name, approved ? "approved" : "denied", "socket", { destructive, managed });

--- a/src/shared/hitl.ts
+++ b/src/shared/hitl.ts
@@ -10,6 +10,7 @@ interface HitlRequest {
   args: Record<string, unknown>;
   module?: string;
   destructive: boolean;
+  sensitive: boolean;
   openWorld: boolean;
 }
 
@@ -49,6 +50,7 @@ export class HitlClient {
     args: Record<string, unknown>,
     destructive: boolean,
     openWorld: boolean,
+    sensitive = false,
   ): Promise<boolean> {
     try {
       await this.ensureConnected();
@@ -64,6 +66,7 @@ export class HitlClient {
       tool,
       args,
       destructive,
+      sensitive,
       openWorld,
     };
 

--- a/src/shortcuts/tools.ts
+++ b/src/shortcuts/tools.ts
@@ -138,7 +138,13 @@ export function registerShortcutsTools(server: McpServer, _config: AirMcpConfig)
       inputSchema: {
         name: z.string().max(500).describe("Name for the new shortcut"),
       },
-      annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: true },
+      annotations: {
+        readOnlyHint: false,
+        destructiveHint: false,
+        sensitiveHint: true,
+        idempotentHint: false,
+        openWorldHint: true,
+      },
     },
     async ({ name }) => {
       try {

--- a/src/skills/register.ts
+++ b/src/skills/register.ts
@@ -10,6 +10,7 @@ import { log } from "../shared/logger.js";
 type SkillToolAnnotations = {
   readOnlyHint: boolean;
   destructiveHint: boolean;
+  sensitiveHint: boolean;
   idempotentHint: boolean;
   openWorldHint: boolean;
 };
@@ -120,6 +121,7 @@ function skillToolAnnotations(skill: SkillDefinition): SkillToolAnnotations {
   return {
     readOnlyHint: skill.annotations?.readOnlyHint ?? true,
     destructiveHint: skill.annotations?.destructiveHint ?? false,
+    sensitiveHint: skill.annotations?.sensitiveHint ?? false,
     idempotentHint: skill.annotations?.idempotentHint ?? true,
     openWorldHint: skill.annotations?.openWorldHint ?? false,
   };

--- a/src/skills/types.ts
+++ b/src/skills/types.ts
@@ -62,6 +62,7 @@ export const SkillAnnotationsSchema = z
   .object({
     readOnlyHint: z.boolean().optional(),
     destructiveHint: z.boolean().optional(),
+    sensitiveHint: z.boolean().optional(),
     idempotentHint: z.boolean().optional(),
     openWorldHint: z.boolean().optional(),
   })

--- a/tests/calendar-tools.test.js
+++ b/tests/calendar-tools.test.js
@@ -99,9 +99,10 @@ describe('Calendar tools registration', () => {
     }
   });
 
-  test('create_event is not destructive', () => {
+  test('create_event is not destructive but requires sensitive approval', () => {
     const { config } = server.tools.get('create_event');
     expect(config.annotations.destructiveHint).toBe(false);
+    expect(config.annotations.sensitiveHint).toBe(true);
   });
 });
 

--- a/tests/config.test.js
+++ b/tests/config.test.js
@@ -305,9 +305,9 @@ describe('parseConfig() — HITL config parsing', () => {
     restoreEnv();
   });
 
-  test('HITL level defaults to "destructive-only"', () => {
+  test('HITL level defaults to "sensitive-only"', () => {
     const cfg = parseConfig();
-    expect(cfg.hitl.level).toBe('destructive-only');
+    expect(cfg.hitl.level).toBe('sensitive-only');
   });
 
   test('HITL timeout defaults to 30', () => {
@@ -343,10 +343,16 @@ describe('parseConfig() — HITL config parsing', () => {
     expect(cfg.hitl.level).toBe('all-writes');
   });
 
-  test('invalid HITL level falls back to "destructive-only"', () => {
+  test('AIRMCP_HITL_LEVEL=sensitive-only is accepted', () => {
+    process.env.AIRMCP_HITL_LEVEL = 'sensitive-only';
+    const cfg = parseConfig();
+    expect(cfg.hitl.level).toBe('sensitive-only');
+  });
+
+  test('invalid HITL level falls back to "sensitive-only"', () => {
     process.env.AIRMCP_HITL_LEVEL = 'invalid-value';
     const cfg = parseConfig();
-    expect(cfg.hitl.level).toBe('destructive-only');
+    expect(cfg.hitl.level).toBe('sensitive-only');
   });
 
   test('HITL config has expected shape', () => {

--- a/tests/contacts-tools.test.js
+++ b/tests/contacts-tools.test.js
@@ -91,9 +91,15 @@ describe('Contacts tools registration', () => {
     }
   });
 
-  test('create_contact is not destructive', () => {
+  test('contact creation and enrichment are not destructive but require sensitive approval', () => {
     const { config } = server.tools.get('create_contact');
     expect(config.annotations.destructiveHint).toBe(false);
+    expect(config.annotations.sensitiveHint).toBe(true);
+    for (const name of ['add_contact_email', 'add_contact_phone']) {
+      const { config: addConfig } = server.tools.get(name);
+      expect(addConfig.annotations.destructiveHint).toBe(false);
+      expect(addConfig.annotations.sensitiveHint).toBe(true);
+    }
   });
 });
 

--- a/tests/finder-tools.test.js
+++ b/tests/finder-tools.test.js
@@ -81,8 +81,9 @@ describe('Finder tools registration', () => {
     }
   });
 
-  test('create_directory is not destructive', () => {
+  test('create_directory is not destructive but requires sensitive approval', () => {
     const { config } = server.tools.get('create_directory');
     expect(config.annotations.destructiveHint).toBe(false);
+    expect(config.annotations.sensitiveHint).toBe(true);
   });
 });

--- a/tests/hitl-client.test.js
+++ b/tests/hitl-client.test.js
@@ -396,16 +396,15 @@ describe('HitlClient', () => {
     const bigChunk = 'x'.repeat(1_048_577 + 100);
     serverConn.write(bigChunk);
 
-    // Wait for the data to be processed
-    await new Promise((r) => setTimeout(r, 200));
-
-    console.error = origError;
-
-    const result = await resultPromise;
-    expect(result).toBe(false);
-    expect(consoleSpy.calls.some(c =>
-      typeof c[0] === 'string' && c[0].includes('buffer exceeded 1MB')
-    )).toBe(true);
+    try {
+      const result = await resultPromise;
+      expect(result).toBe(false);
+      expect(consoleSpy.calls.some(c =>
+        typeof c[0] === 'string' && c[0].includes('buffer exceeded 1MB')
+      )).toBe(true);
+    } finally {
+      console.error = origError;
+    }
   }, 10000);
 
   test('handles empty lines in response data', async () => {

--- a/tests/hitl-guard.test.js
+++ b/tests/hitl-guard.test.js
@@ -60,8 +60,8 @@ function makeMockHitlClient(autoApprove = true, reachable = true) {
     isReachable() {
       return Promise.resolve(reachable);
     },
-    requestApproval(tool, args, destructive, openWorld) {
-      calls.push({ tool, args, destructive, openWorld });
+    requestApproval(tool, args, destructive, openWorld, sensitive = false) {
+      calls.push({ tool, args, destructive, openWorld, sensitive });
       return Promise.resolve(autoApprove);
     },
     dispose() {},
@@ -130,6 +130,69 @@ describe('level "destructive-only"', () => {
     for (const reg of registrations) {
       expect(reg.callback).toBe(original);
     }
+  });
+});
+
+// ---------- level: "sensitive-only" ----------
+
+describe('level "sensitive-only"', () => {
+  test('wraps destructive and sensitive tools', () => {
+    const { server, registrations } = makeMockServer();
+    const hitl = makeMockHitlClient();
+    const config = makeConfig('sensitive-only');
+
+    installHitlGuard(server, hitl, config);
+
+    const original = () => 'original';
+    server.registerTool('dangerous', { annotations: { destructiveHint: true } }, original);
+    server.registerTool('persisting_create', { annotations: { sensitiveHint: true, readOnlyHint: false } }, original);
+
+    expect(registrations).toHaveLength(2);
+    expect(registrations[0].callback).not.toBe(original);
+    expect(registrations[1].callback).not.toBe(original);
+  });
+
+  test('does NOT wrap generic non-sensitive writes or read-only tools', () => {
+    const { server, registrations } = makeMockServer();
+    const hitl = makeMockHitlClient();
+    const config = makeConfig('sensitive-only');
+
+    installHitlGuard(server, hitl, config);
+
+    const original = () => 'original';
+    server.registerTool('safe_write', { annotations: { readOnlyHint: false } }, original);
+    server.registerTool('reader', { annotations: { readOnlyHint: true } }, original);
+
+    for (const reg of registrations) {
+      expect(reg.callback).toBe(original);
+    }
+  });
+
+  test('sensitive approval is requested without marking the call destructive', async () => {
+    const { server, registrations } = makeMockServer();
+    const hitl = makeMockHitlClient(true);
+    const config = makeConfig('sensitive-only');
+
+    installHitlGuard(server, hitl, config);
+
+    server.registerTool(
+      'create_reminder',
+      { annotations: { readOnlyHint: false, destructiveHint: false, sensitiveHint: true, openWorldHint: false } },
+      () => 'created',
+    );
+
+    const result = await registrations[0].callback({ title: 'Follow up' });
+
+    expect(result).toBe('created');
+    expect(hitl.calls).toEqual([
+      {
+        tool: 'create_reminder',
+        args: { title: 'Follow up' },
+        destructive: false,
+        openWorld: false,
+        sensitive: true,
+      },
+    ]);
   });
 });
 
@@ -731,6 +794,38 @@ describe('elicitation paths', () => {
     await registrations[0].callback({});
 
     expect(elicitMessages[0]).toContain('Approve');
+    expect(elicitMessages[0]).not.toContain('Destructive');
+  });
+
+  test('elicitation with sensitiveHint uses sensitive label', async () => {
+    const elicitMessages = [];
+    const registrations = [];
+    const server = {
+      registerTool(name, toolConfig, callback) {
+        registrations.push({ name, toolConfig, callback });
+      },
+      server: {
+        getClientVersion: () => ({ name: 'cursor', version: '1.0' }),
+        elicitInput: jest.fn(async (req) => {
+          elicitMessages.push(req.message);
+          return { action: 'accept', content: { approve: true } };
+        }),
+      },
+    };
+    const hitl = makeMockHitlClient(true);
+    const config = makeConfig('sensitive-only');
+
+    installHitlGuard(server, hitl, config);
+
+    server.registerTool(
+      'create_reminder',
+      { annotations: { readOnlyHint: false, destructiveHint: false, sensitiveHint: true } },
+      () => 'ok',
+    );
+    await registrations[0].callback({ title: 'Follow up' });
+
+    expect(elicitMessages[0]).toContain('Sensitive');
+    expect(elicitMessages[0]).toContain('create_reminder');
     expect(elicitMessages[0]).not.toContain('Destructive');
   });
 });

--- a/tests/intelligence-tools.test.js
+++ b/tests/intelligence-tools.test.js
@@ -79,7 +79,7 @@ describe('Intelligence tools registration', () => {
   test('only file-writing tools are destructive', () => {
     // generate_image writes a PNG/JPEG to a user-supplied path and may
     // overwrite an existing file, so it must be marked destructive so HITL
-    // can prompt the user under the destructive-only policy.
+    // can prompt the user under the default sensitive-only policy.
     const expectedDestructive = new Set(['generate_image']);
     for (const [name, { config }] of server.tools) {
       expect(config.annotations.destructiveHint).toBe(expectedDestructive.has(name));

--- a/tests/music-tools.test.js
+++ b/tests/music-tools.test.js
@@ -138,4 +138,12 @@ describe('Music tools registration', () => {
       expect(config.annotations.destructiveHint).toBe(false);
     }
   });
+
+  test('playlist creation and additions require sensitive approval', () => {
+    for (const name of ['create_playlist', 'add_to_playlist']) {
+      const { config } = server.tools.get(name);
+      expect(config.annotations.destructiveHint).toBe(false);
+      expect(config.annotations.sensitiveHint).toBe(true);
+    }
+  });
 });

--- a/tests/notes-tools.test.js
+++ b/tests/notes-tools.test.js
@@ -80,6 +80,15 @@ describe('registerNoteTools', () => {
       expect(tool.opts.annotations.readOnlyHint).toBe(false);
     }
   });
+
+  test('create tools are not destructive but require sensitive approval', () => {
+    const { server } = setup();
+    for (const name of ['create_note', 'create_folder']) {
+      const tool = server._tools.get(name);
+      expect(tool.opts.annotations.destructiveHint).toBe(false);
+      expect(tool.opts.annotations.sensitiveHint).toBe(true);
+    }
+  });
 });
 
 // ── list_notes ───────────────────────────────────────────────────────

--- a/tests/photos-tools.test.js
+++ b/tests/photos-tools.test.js
@@ -108,8 +108,11 @@ describe('Photos tools registration', () => {
     expect(config.annotations.destructiveHint).toBe(true);
   });
 
-  test('create_album is not marked destructive', () => {
-    const { config } = server.tools.get('create_album');
-    expect(config.annotations.destructiveHint).toBe(false);
+  test('album creation and additions are not destructive but require sensitive approval', () => {
+    for (const name of ['create_album', 'add_to_album']) {
+      const { config } = server.tools.get(name);
+      expect(config.annotations.destructiveHint).toBe(false);
+      expect(config.annotations.sensitiveHint).toBe(true);
+    }
   });
 });

--- a/tests/reminders-tools.test.js
+++ b/tests/reminders-tools.test.js
@@ -101,13 +101,15 @@ describe('Reminders tools registration', () => {
   test('complete_reminder is not destructive', () => {
     const { config } = server.tools.get('complete_reminder');
     expect(config.annotations.destructiveHint).toBe(false);
+    expect(config.annotations.sensitiveHint).toBe(true);
   });
 
-  test('create tools are not destructive', () => {
+  test('create tools are not destructive but require sensitive approval', () => {
     const creates = ['create_reminder', 'create_reminder_list', 'create_recurring_reminder'];
     for (const name of creates) {
       const { config } = server.tools.get(name);
       expect(config.annotations.destructiveHint).toBe(false);
+      expect(config.annotations.sensitiveHint).toBe(true);
     }
   });
 });

--- a/tests/safety-annotations.test.js
+++ b/tests/safety-annotations.test.js
@@ -2,7 +2,7 @@
  * Safety Annotations consistency test.
  *
  * Boots every module and verifies that tool annotations follow naming
- * conventions and that every tool has all four annotation fields defined.
+ * conventions and that every tool has the core annotation fields defined.
  */
 import { describe, test, expect, jest } from '@jest/globals';
 import { createMockServer } from './helpers/mock-server.js';
@@ -148,9 +148,9 @@ describe('Safety Annotations consistency', () => {
     return result;
   }
 
-  // ── 1. All tools must have all 4 annotation fields defined ────────
+  // ── 1. All tools must have core annotation fields defined ─────────
 
-  test('every tool has all 4 annotation fields defined', () => {
+  test('every tool has core annotation fields defined', () => {
     const tools = getAllTools();
     expect(tools.length).toBeGreaterThan(0);
 
@@ -166,6 +166,9 @@ describe('Safety Annotations consistency', () => {
         if (annotations[field] === undefined) {
           failures.push(`${name}: annotations.${field} is undefined`);
         }
+      }
+      if (annotations.sensitiveHint !== undefined && typeof annotations.sensitiveHint !== 'boolean') {
+        failures.push(`${name}: annotations.sensitiveHint is ${typeof annotations.sensitiveHint}`);
       }
     }
 
@@ -266,7 +269,53 @@ describe('Safety Annotations consistency', () => {
     }
   });
 
-  // ── 5. Read-only-prefix tools must have readOnlyHint: true ────────
+  // ── 5. Durable side-effect tools must be sensitive-gated ──────────
+
+  test('known durable create/enrich tools have sensitiveHint: true without destructiveHint', () => {
+    const SENSITIVE_SIDE_EFFECT_TOOLS = [
+      'add_contact_email',
+      'add_contact_phone',
+      'add_to_album',
+      'add_to_playlist',
+      'complete_reminder',
+      'create_album',
+      'create_contact',
+      'create_directory',
+      'create_event',
+      'create_folder',
+      'create_note',
+      'create_playlist',
+      'create_recurring_event',
+      'create_recurring_reminder',
+      'create_reminder',
+      'create_reminder_list',
+      'create_shortcut',
+    ];
+    const tools = getAllTools();
+    const failures = [];
+
+    for (const name of SENSITIVE_SIDE_EFFECT_TOOLS) {
+      const tool = tools.find((t) => t.name === name);
+      if (!tool) {
+        failures.push(`${name}: not registered`);
+        continue;
+      }
+      if (tool.annotations?.destructiveHint !== false) {
+        failures.push(`${name}: destructiveHint=${tool.annotations?.destructiveHint}`);
+      }
+      if (tool.annotations?.sensitiveHint !== true) {
+        failures.push(`${name}: sensitiveHint=${tool.annotations?.sensitiveHint}`);
+      }
+    }
+
+    if (failures.length > 0) {
+      throw new Error(
+        `sensitive side-effect tool(s) lack the expected annotations:\n  ${failures.join('\n  ')}`,
+      );
+    }
+  });
+
+  // ── 6. Read-only-prefix tools must have readOnlyHint: true ────────
 
   test('tools with list_/get_/search_/read_/today_/upcoming_ prefix have readOnlyHint: true', () => {
     const READ_ONLY_PREFIXES = ['list_', 'get_', 'search_', 'read_', 'today_', 'upcoming_'];
@@ -297,7 +346,7 @@ describe('Safety Annotations consistency', () => {
     }
   });
 
-  // ── 6. Read-only exceptions must have openWorldHint: true ──────────
+  // ── 7. Read-only exceptions must have openWorldHint: true ──────────
 
   test('read-only prefix exceptions have openWorldHint: true (justifying the override)', () => {
     const EXCEPTIONS = ['search_location', 'get_directions', 'search_nearby'];
@@ -324,7 +373,7 @@ describe('Safety Annotations consistency', () => {
     }
   });
 
-  // ── 7. run_javascript must have destructiveHint and openWorldHint ─
+  // ── 8. run_javascript must have destructiveHint and openWorldHint ─
 
   test('run_javascript has destructiveHint: true and openWorldHint: true', () => {
     const tools = getAllTools();
@@ -334,7 +383,7 @@ describe('Safety Annotations consistency', () => {
     expect(rj.annotations.openWorldHint).toBe(true);
   });
 
-  // ── 8. Summary: report total tools checked ────────────────────────
+  // ── 9. Summary: report total tools checked ────────────────────────
 
   test('registered tool count is at least 200', () => {
     const count = server._tools.size;

--- a/tests/skills-register.test.js
+++ b/tests/skills-register.test.js
@@ -95,6 +95,7 @@ describe('registerSkills', () => {
         annotations: {
           readOnlyHint: true,
           destructiveHint: false,
+          sensitiveHint: false,
           idempotentHint: true,
           openWorldHint: false,
         },
@@ -109,6 +110,7 @@ describe('registerSkills', () => {
       annotations: {
         readOnlyHint: false,
         destructiveHint: false,
+        sensitiveHint: true,
         idempotentHint: false,
         openWorldHint: false,
       },
@@ -122,6 +124,7 @@ describe('registerSkills', () => {
         annotations: {
           readOnlyHint: false,
           destructiveHint: false,
+          sensitiveHint: true,
           idempotentHint: false,
           openWorldHint: false,
         },

--- a/tests/swift-hitl-contract.test.js
+++ b/tests/swift-hitl-contract.test.js
@@ -37,6 +37,7 @@ let requestJson = """
     "count": 2
   },
   "destructive": true,
+  "sensitive": true,
   "openWorld": false
 }
 """
@@ -54,6 +55,7 @@ require(request.args["id"] == "note-123", "arg id")
 require(request.args["force"] == "true", "arg bool")
 require(request.args["count"] == "2", "arg number")
 require(request.destructive, "destructive")
+require(request.sensitive, "sensitive")
 require(!request.openWorld, "openWorld")
 require(request.timestamp == timestamp, "timestamp")
 

--- a/tests/tool-registry-scope-gate.test.js
+++ b/tests/tool-registry-scope-gate.test.js
@@ -74,7 +74,7 @@ describe('tool-registry OAuth scope gate', () => {
       {
         title: 'Create reminder',
         description: 'd',
-        annotations: { readOnlyHint: false, destructiveHint: false },
+        annotations: { readOnlyHint: false, destructiveHint: false, sensitiveHint: true },
       },
       async () => ({ content: [{ type: 'text', text: 'ok' }] }),
     );
@@ -120,6 +120,14 @@ describe('tool-registry OAuth scope gate', () => {
         callToolThroughGate(server, 'create_reminder'),
       ),
     ).rejects.toThrow(/\[forbidden\] scope mcp:write required/);
+  });
+
+  test('mcp:write token allows sensitive non-destructive create_reminder', async () => {
+    const result = await runWithRequestContext(
+      { oauth: { subject: 'u', scopes: ['mcp:write'], raw: {} } },
+      () => callToolThroughGate(server, 'create_reminder'),
+    );
+    expect(result.content[0].text).toBe('ok');
   });
 
   test('mcp:write token denies delete_note', async () => {


### PR DESCRIPTION
## Summary

Adds a new `sensitive-only` HITL level and makes it the default approval policy.
This closes the gap where non-destructive but durable create/enrich actions like
`create_reminder` and `create_event` could run without approval under the old
`destructive-only` default.

## What changed

- Adds `sensitiveHint` to tool annotations and generated tool manifests.
- Adds `sensitive-only` to config, CLI init, and the macOS menu bar app.
- Gates destructive or sensitive tools at the default HITL level.
- Marks durable workspace writes such as reminders, calendar events, notes,
  contacts, albums/playlists, directories, and shortcuts as sensitive.
- Propagates the sensitive flag through MCP elicitation and the native HITL
  socket protocol so the app can label sensitive approvals clearly.
- Updates docs and workflow copy to avoid over-claiming approval for all calls.

## Validation

- `npm test -- --runInBand` — 137 suites / 2079 tests passed
- `npm run typecheck`
- `npm run format:check`
- `npm run gen:manifest:check`
- `npm run gen:intents:check`
- `npm run stats:check`
- `npm run mcp:validate`
- `node scripts/verify-tool-manifest.mjs docs/tool-manifest.json`
- `npm run llms:check`
- `npm run app-build`
- `npm run swift-build`
- `npm run build:mcpb:check`
- `npm audit --audit-level=high` exits 0; npm still reports low/moderate advisories.
