### PR TITLE
fix(app): pin app-owned npm runtime version

### DIFF
--- a/app/Sources/AirMCPApp/AppIntents.swift
+++ b/app/Sources/AirMCPApp/AppIntents.swift
@@ -189,7 +189,7 @@ func installMCPIntentRouterForMacOS() {
 private func runAirMCPTool(_ toolName: String, args: [String: Any]) async throws -> String {
     let process = Process()
     process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
-    process.arguments = ["npx", "-y", AirMcpConstants.npmPackageName]
+    process.arguments = ["npx", "-y", AirMcpConstants.npmPackageSpecifier]
 
     let stdinPipe = Pipe()
     let stdoutPipe = Pipe()

--- a/app/Sources/AirMCPApp/ServerManager.swift
+++ b/app/Sources/AirMCPApp/ServerManager.swift
@@ -201,7 +201,7 @@ final class ServerManager {
                 process.executableURL = URL(fileURLWithPath: npxPath)
                 process.arguments = [
                     "-y",
-                    AirMcpConstants.npmPackageName,
+                    AirMcpConstants.npmPackageSpecifier,
                     "--http",
                     "--port",
                     "\(AirMcpConstants.appOwnedHttpPort)",

--- a/app/Sources/AirMCPApp/Views/MenuContent.swift
+++ b/app/Sources/AirMCPApp/Views/MenuContent.swift
@@ -158,6 +158,11 @@ private let featuredWorkflows: [WorkflowInfo] = [
 
 enum AirMcpConstants {
     static let npmPackageName = "airmcp"
+    static let npmPackageVersion = "2.12.1"
+    static var npmPackageSpecifier: String {
+        ProcessInfo.processInfo.environment["AIRMCP_NPM_PACKAGE_SPECIFIER"]
+            ?? "\(npmPackageName)@\(npmPackageVersion)"
+    }
     static let mcpProtocolVersion = "2025-03-26"
     static let appOwnedHttpPort = 3847
     static let appOwnedHttpURL = "http://127.0.0.1:\(appOwnedHttpPort)/mcp"
@@ -166,7 +171,7 @@ enum AirMcpConstants {
     static let keyOnboardingCompleted = "onboardingCompleted"
 
     static var appOwnedProxyArgs: [String] {
-        ["-y", npmPackageName, "connect", "--url", appOwnedHttpURL]
+        ["-y", npmPackageSpecifier, "connect", "--url", appOwnedHttpURL]
     }
 
     static func appOwnedProxyEntry(token: String) -> [String: Any] {
@@ -190,7 +195,7 @@ enum AirMcpConstants {
           "mcpServers": {
             "airmcp": {
               "command": "npx",
-              "args": ["-y", "\(npmPackageName)", "connect", "--url", "\(appOwnedHttpURL)"],
+              "args": ["-y", "\(npmPackageSpecifier)", "connect", "--url", "\(appOwnedHttpURL)"],
               "env": {
                 "AIRMCP_HTTP_TOKEN": "\(token)"
               }
@@ -201,11 +206,11 @@ enum AirMcpConstants {
     }
 
     static func claudeCodeConfig() -> String {
-        "claude mcp add --env AIRMCP_HTTP_TOKEN=\(tokenForConfig()) airmcp -- npx -y \(npmPackageName) connect --url \(appOwnedHttpURL)"
+        "claude mcp add --env AIRMCP_HTTP_TOKEN=\(tokenForConfig()) airmcp -- npx -y \(npmPackageSpecifier) connect --url \(appOwnedHttpURL)"
     }
 
     static func codexConfig() -> String {
-        "codex mcp add --env AIRMCP_HTTP_TOKEN=\(tokenForConfig()) airmcp -- npx -y \(npmPackageName) connect --url \(appOwnedHttpURL)"
+        "codex mcp add --env AIRMCP_HTTP_TOKEN=\(tokenForConfig()) airmcp -- npx -y \(npmPackageSpecifier) connect --url \(appOwnedHttpURL)"
     }
 
     static func copyToClipboard(_ text: String) {

--- a/app/Sources/AirMCPApp/Views/OnboardingView.swift
+++ b/app/Sources/AirMCPApp/Views/OnboardingView.swift
@@ -784,7 +784,7 @@ struct OnboardingView: View {
                 "--",
                 "npx",
                 "-y",
-                AirMcpConstants.npmPackageName,
+                AirMcpConstants.npmPackageSpecifier,
                 "connect",
                 "--url",
                 AirMcpConstants.appOwnedHttpURL,

--- a/scripts/bundle-app.sh
+++ b/scripts/bundle-app.sh
@@ -217,6 +217,7 @@ launch_app() {
     pkill -x "$APP_EXECUTABLE" || true
     sleep 0.5
   fi
+  export AIRMCP_NPM_PACKAGE_SPECIFIER="${AIRMCP_NPM_PACKAGE_SPECIFIER:-$PROJECT_DIR}"
   /usr/bin/open -n "$BUNDLE_DIR"
 }
 

--- a/scripts/sync-version.mjs
+++ b/scripts/sync-version.mjs
@@ -7,11 +7,13 @@
  *   2. app/.../UpdateManager.swift          (menubar app update checker)
  *   3. src/shared/constants.ts              (User-Agent header)
  *   4. scripts/bundle-app.sh               (CFBundleShortVersionString)
- *   5. docs/PRIVACY_POLICY.md              (version header)
- *   6. .github/ISSUE_TEMPLATE/bug_report.yml (placeholder version)
- *   7. mcp.json                            (MCP Registry submission manifest)
- *   8. .claude-plugin/plugin.json          (Claude Code plugin manifest)
- *   9. .mcp.json                           (Claude Code project/plugin MCP config — pinned npm version)
+ *   5. app/.../MenuContent.swift            (pinned app-owned npm runtime)
+ *   6. src/shared/config.ts                 (pinned app-owned npm proxy)
+ *   7. docs/PRIVACY_POLICY.md              (version header)
+ *   8. .github/ISSUE_TEMPLATE/bug_report.yml (placeholder version)
+ *   9. mcp.json                            (MCP Registry submission manifest)
+ *   10. .claude-plugin/plugin.json         (Claude Code plugin manifest)
+ *   11. .mcp.json                          (Claude Code project/plugin MCP config — pinned npm version)
  *
  * Usage:
  *   node scripts/sync-version.mjs           # sync all files
@@ -124,7 +126,25 @@ syncFile("scripts/bundle-app.sh", [
   },
 ]);
 
-// 5. PRIVACY_POLICY.md — AirMCP vX.Y.Z
+// 5. MenuContent.swift — app-owned npx runtime pin.
+syncFile("app/Sources/AirMCPApp/Views/MenuContent.swift", [
+  {
+    pattern: /static let npmPackageVersion = "[^"]+"/,
+    replacement: `static let npmPackageVersion = "${VERSION}"`,
+    label: "app npmPackageVersion",
+  },
+]);
+
+// 6. config.ts — app-owned proxy/runtime package pin.
+syncFile("src/shared/config.ts", [
+  {
+    pattern: /export const NPM_PACKAGE_SPECIFIER = "airmcp@[^"]+"/,
+    replacement: `export const NPM_PACKAGE_SPECIFIER = "airmcp@${VERSION}"`,
+    label: "NPM_PACKAGE_SPECIFIER",
+  },
+]);
+
+// 7. PRIVACY_POLICY.md — AirMCP vX.Y.Z
 syncFile("docs/PRIVACY_POLICY.md", [
   {
     pattern: /AirMCP v[\d.]+/,
@@ -133,7 +153,7 @@ syncFile("docs/PRIVACY_POLICY.md", [
   },
 ]);
 
-// 6. bug_report.yml — placeholder version
+// 8. bug_report.yml — placeholder version
 syncFile(".github/ISSUE_TEMPLATE/bug_report.yml", [
   {
     pattern: /placeholder: "[\d.]+"/,
@@ -142,7 +162,7 @@ syncFile(".github/ISSUE_TEMPLATE/bug_report.yml", [
   },
 ]);
 
-// 7. mcp.json — MCP Registry submission manifest (top-level "version" field).
+// 9. mcp.json — MCP Registry submission manifest (top-level "version" field).
 const mcpJsonPath = resolve(root, "mcp.json");
 if (existsSync(mcpJsonPath)) {
   const mj = JSON.parse(readFileSync(mcpJsonPath, "utf8"));
@@ -160,7 +180,7 @@ if (existsSync(mcpJsonPath)) {
   }
 }
 
-// 8. .claude-plugin/plugin.json — Claude Code plugin manifest.
+// 10. .claude-plugin/plugin.json — Claude Code plugin manifest.
 const pluginJsonPath = resolve(root, ".claude-plugin/plugin.json");
 if (existsSync(pluginJsonPath)) {
   const pj = JSON.parse(readFileSync(pluginJsonPath, "utf8"));
@@ -178,7 +198,7 @@ if (existsSync(pluginJsonPath)) {
   }
 }
 
-// 9. .mcp.json — Claude Code plugin MCP config. The npx invocation is
+// 11. .mcp.json — Claude Code plugin MCP config. The npx invocation is
 //    pinned to the current package version so a marketplace install at
 //    plugin version X runs the npm tarball at version X (not whatever
 //    `dist-tags.latest` happens to point at).

--- a/src/cli/codex-mcp.ts
+++ b/src/cli/codex-mcp.ts
@@ -1,5 +1,5 @@
 import { execFileSync } from "node:child_process";
-import { NPM_PACKAGE_NAME } from "../shared/config.js";
+import { NPM_PACKAGE_SPECIFIER } from "../shared/config.js";
 import { IDENTITY } from "../shared/constants.js";
 import { ensureAppRuntimeToken } from "../shared/app-runtime-token.js";
 
@@ -65,7 +65,7 @@ export function configureCodexAirmcp(): "already-configured" | "configured" {
     "--",
     "npx",
     "-y",
-    NPM_PACKAGE_NAME,
+    NPM_PACKAGE_SPECIFIER,
     "connect",
     "--url",
     CODEX_APP_OWNED_URL,
@@ -74,7 +74,12 @@ export function configureCodexAirmcp(): "already-configured" | "configured" {
 }
 
 export function codexManualSetupCommand(): string {
-  return "codex mcp add --env AIRMCP_HTTP_TOKEN=<token> airmcp -- npx -y airmcp connect --url " + CODEX_APP_OWNED_URL;
+  return (
+    "codex mcp add --env AIRMCP_HTTP_TOKEN=<token> airmcp -- npx -y " +
+    NPM_PACKAGE_SPECIFIER +
+    " connect --url " +
+    CODEX_APP_OWNED_URL
+  );
 }
 
 export function stdioProxyEntry(token = ensureAppRuntimeToken()): {
@@ -84,7 +89,7 @@ export function stdioProxyEntry(token = ensureAppRuntimeToken()): {
 } {
   return {
     command: "npx",
-    args: ["-y", NPM_PACKAGE_NAME, "connect", "--url", CODEX_APP_OWNED_URL],
+    args: ["-y", NPM_PACKAGE_SPECIFIER, "connect", "--url", CODEX_APP_OWNED_URL],
     env: {
       AIRMCP_HTTP_TOKEN: token,
     },

--- a/src/shared/config.ts
+++ b/src/shared/config.ts
@@ -76,6 +76,8 @@ export function getCompatibilityEnv(): CompatibilityEnv {
 
 /** npm package name — single source of truth for npx/install references */
 export const NPM_PACKAGE_NAME = "airmcp";
+/** Version-pinned npm package specifier for app-owned proxy/runtime commands. */
+export const NPM_PACKAGE_SPECIFIER = "airmcp@2.12.1";
 
 export type HitlLevel = "off" | "destructive-only" | "sensitive-only" | "all-writes" | "all";
 

--- a/tests/app-owned-runtime-version-pin.test.js
+++ b/tests/app-owned-runtime-version-pin.test.js
@@ -1,0 +1,39 @@
+import { describe, expect, test } from "@jest/globals";
+import { readFileSync } from "node:fs";
+
+const pkg = JSON.parse(readFileSync(new URL("../package.json", import.meta.url), "utf8"));
+const expectedSpecifier = `airmcp@${pkg.version}`;
+
+const menuContent = readFileSync(
+  new URL("../app/Sources/AirMCPApp/Views/MenuContent.swift", import.meta.url),
+  "utf8",
+);
+const serverManager = readFileSync(new URL("../app/Sources/AirMCPApp/ServerManager.swift", import.meta.url), "utf8");
+const appIntents = readFileSync(new URL("../app/Sources/AirMCPApp/AppIntents.swift", import.meta.url), "utf8");
+const onboarding = readFileSync(new URL("../app/Sources/AirMCPApp/Views/OnboardingView.swift", import.meta.url), "utf8");
+const config = readFileSync(new URL("../src/shared/config.ts", import.meta.url), "utf8");
+
+describe("app-owned runtime npm package pin", () => {
+  test("Swift constants pin app-owned npx commands to the bundle/package version", () => {
+    expect(menuContent).toContain(`static let npmPackageVersion = "${pkg.version}"`);
+    expect(menuContent).toContain('ProcessInfo.processInfo.environment["AIRMCP_NPM_PACKAGE_SPECIFIER"]');
+    expect(menuContent).toContain('"\\(npmPackageName)@\\(npmPackageVersion)"');
+    expect(menuContent).toContain("npmPackageSpecifier");
+    expect(menuContent).not.toContain('["-y", npmPackageName, "connect"');
+  });
+
+  test("app runtime, AppIntents, and onboarding use the pinned specifier", () => {
+    expect(serverManager).toContain("AirMcpConstants.npmPackageSpecifier");
+    expect(appIntents).toContain("AirMcpConstants.npmPackageSpecifier");
+    expect(onboarding).toContain("AirMcpConstants.npmPackageSpecifier");
+  });
+
+  test("TypeScript app-owned proxy helper uses the same pinned package specifier", () => {
+    expect(config).toContain(`export const NPM_PACKAGE_SPECIFIER = "${expectedSpecifier}"`);
+  });
+
+  test("local app verification can override npx to the checkout instead of unpublished npm versions", () => {
+    const bundleScript = readFileSync(new URL("../scripts/bundle-app.sh", import.meta.url), "utf8");
+    expect(bundleScript).toContain('AIRMCP_NPM_PACKAGE_SPECIFIER="${AIRMCP_NPM_PACKAGE_SPECIFIER:-$PROJECT_DIR}"');
+  });
+});

--- a/tests/codex-mcp.test.js
+++ b/tests/codex-mcp.test.js
@@ -89,7 +89,7 @@ describe("codex MCP setup", () => {
         "--",
         "npx",
         "-y",
-        "airmcp",
+        "airmcp@2.12.1",
         "connect",
         "--url",
         CODEX_APP_OWNED_URL,
@@ -101,7 +101,7 @@ describe("codex MCP setup", () => {
   test("stdio clients use a token-gated proxy command rather than launching another server", () => {
     expect(stdioProxyEntry("test-token")).toEqual({
       command: "npx",
-      args: ["-y", "airmcp", "connect", "--url", CODEX_APP_OWNED_URL],
+      args: ["-y", "airmcp@2.12.1", "connect", "--url", CODEX_APP_OWNED_URL],
       env: { AIRMCP_HTTP_TOKEN: "test-token" },
     });
   });


### PR DESCRIPTION
## Summary
- Pin app-owned npx runtime/proxy commands to the bundle package version instead of bare `airmcp`
- Allow local app verification to override the package specifier to the checkout path, so unpublished versions can still be runtime-tested
- Extend version sync and tests so app/CLI proxy pins drift with package.json

## Verification
- npm test -- --runTestsByPath tests/app-owned-runtime-version-pin.test.js tests/codex-mcp.test.js
- npm run typecheck
- npm run app-build
- npm run app:verify
- npm test
- npm run gen:manifest:check && npm run gen:intents:check && npm run mcp:validate
- npm run stats:check && npm run build:mcpb:check && npm run version:check

## Runtime evidence
- Before: app-owned runtime launched cached `airmcp 2.12.0` while bundle/package was `2.12.1`
- After: app-owned health endpoint returns `{"status":"ok","version":"2.12.1"}`
- Unauthenticated `POST /mcp` returns 401

## Limitations
- Local bundle is ad-hoc signed on this machine; `security find-identity -p codesigning -v` reports 0 valid identities, so trusted AppIntents registration verification is not available here.