### PR TITLE
fix(app): verify app-owned runtime contract

### DIFF
--- a/app/Sources/AirMCPApp/AirMCPApp.swift
+++ b/app/Sources/AirMCPApp/AirMCPApp.swift
@@ -97,7 +97,9 @@ struct AirMCPApp: App {
         if !appInitialized {
             appInitialized = true
             updateManager.startPeriodicChecks()
-            if !UserDefaults.standard.bool(forKey: AirMcpConstants.keyOnboardingCompleted) {
+            if ProcessInfo.processInfo.environment[AirMcpConstants.envForceAppRuntime] == "1" {
+                serverManager.startServer()
+            } else if !UserDefaults.standard.bool(forKey: AirMcpConstants.keyOnboardingCompleted) {
                 showOnboardingWindow()
             } else {
                 serverManager.autoStartIfNeeded()

--- a/app/Sources/AirMCPApp/Views/MenuContent.swift
+++ b/app/Sources/AirMCPApp/Views/MenuContent.swift
@@ -169,6 +169,7 @@ enum AirMcpConstants {
     static let appOwnedHealthURL = "http://127.0.0.1:\(appOwnedHttpPort)/health"
     static let keyAutoStart = "autoStartServer"
     static let keyOnboardingCompleted = "onboardingCompleted"
+    static let envForceAppRuntime = "AIRMCP_FORCE_APP_RUNTIME"
 
     static var appOwnedProxyArgs: [String] {
         ["-y", npmPackageSpecifier, "connect", "--url", appOwnedHttpURL]

--- a/scripts/bundle-app.sh
+++ b/scripts/bundle-app.sh
@@ -14,7 +14,7 @@ Usage: scripts/bundle-app.sh [bundle|run|verify|verify-appintents|logs|telemetry
 Modes:
   bundle     Build AirMCP.app only (default)
   run        Build AirMCP.app and launch it
-  verify     Build, launch, and assert that the bundled app process is alive
+  verify     Build, launch, and assert the app-owned HTTP runtime contract
   verify-appintents
              Require a trusted signing identity, then verify AppIntents registration
   logs       Build, launch, and stream logs for the AirMCP process
@@ -69,6 +69,13 @@ APP_EXECUTABLE="AirMCP"
 APP_BINARY="$BUNDLE_DIR/Contents/MacOS/$APP_EXECUTABLE"
 LSREGISTER="/System/Library/Frameworks/CoreServices.framework/Frameworks/LaunchServices.framework/Support/lsregister"
 SIGN_IDENTITY="${AIRMCP_SIGN_IDENTITY:--}"
+APP_HEALTH_URL="http://127.0.0.1:3847/health"
+APP_MCP_URL="http://127.0.0.1:3847/mcp"
+TOKEN_FILE="$HOME/Library/Application Support/AirMCP/http-token"
+EXPECTED_VERSION="$(
+  node -e 'const fs = require("fs"); console.log(JSON.parse(fs.readFileSync(process.argv[1], "utf8")).version)' \
+    "$PROJECT_DIR/package.json"
+)"
 
 if [ "$MODE" = "verify-appintents" ]; then
   if [ "$SIGN_IDENTITY" = "-" ]; then
@@ -218,6 +225,9 @@ launch_app() {
     sleep 0.5
   fi
   export AIRMCP_NPM_PACKAGE_SPECIFIER="${AIRMCP_NPM_PACKAGE_SPECIFIER:-$PROJECT_DIR}"
+  case "$MODE" in
+    verify|verify-appintents) export AIRMCP_FORCE_APP_RUNTIME=1 ;;
+  esac
   /usr/bin/open -n "$BUNDLE_DIR"
 }
 
@@ -236,6 +246,79 @@ wait_for_pid() {
 
 check_gatekeeper() {
   /usr/sbin/spctl --assess --type execute -vv "$BUNDLE_DIR" >/dev/null 2>&1
+}
+
+wait_for_http_runtime() {
+  local health=""
+  for _ in $(seq 1 60); do
+    health="$(curl -fsS --max-time 1 "$APP_HEALTH_URL" 2>/dev/null || true)"
+    if [ -n "$health" ]; then
+      echo "$health"
+      return 0
+    fi
+    sleep 0.25
+  done
+  return 1
+}
+
+verify_app_owned_runtime() {
+  local health
+  local actual_version
+  local token_mode
+  local unauth_status
+  local token
+  local authed_status
+
+  health="$(wait_for_http_runtime)" || {
+    echo "✗ app-owned HTTP runtime did not become healthy at $APP_HEALTH_URL" >&2
+    exit 1
+  }
+
+  actual_version="$(
+    node -e 'const health = JSON.parse(process.argv[1]); process.stdout.write(String(health.version ?? ""));' "$health"
+  )"
+  if [ "$actual_version" != "$EXPECTED_VERSION" ]; then
+    echo "✗ app-owned runtime version mismatch: expected $EXPECTED_VERSION, got $actual_version" >&2
+    exit 1
+  fi
+  echo "✓ App-owned runtime is healthy (v$actual_version)"
+
+  if [ ! -f "$TOKEN_FILE" ]; then
+    echo "✗ app-owned runtime token missing: $TOKEN_FILE" >&2
+    exit 1
+  fi
+  token_mode="$(stat -f "%Lp" "$TOKEN_FILE")"
+  if [ "$token_mode" != "600" ]; then
+    echo "✗ app-owned runtime token permissions must be 600, got $token_mode" >&2
+    exit 1
+  fi
+  echo "✓ App-owned runtime token is private (0600)"
+
+  unauth_status="$(
+    curl -sS --max-time 2 -o /dev/null -w "%{http_code}" \
+      -X POST "$APP_MCP_URL" \
+      -H "Content-Type: application/json" \
+      --data '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"bundle-verify","version":"0"}}}' \
+      2>/dev/null || true
+  )"
+  if [ "$unauth_status" != "401" ]; then
+    echo "✗ unauthenticated /mcp request should return 401, got ${unauth_status:-no response}" >&2
+    exit 1
+  fi
+  echo "✓ Unauthenticated /mcp request is rejected (401)"
+
+  token="$(tr -d "\r\n" < "$TOKEN_FILE")"
+  authed_status="$(
+    curl -sS --max-time 2 -o /dev/null -w "%{http_code}" \
+      -X GET "$APP_MCP_URL" \
+      -H "Authorization: Bearer $token" \
+      2>/dev/null || true
+  )"
+  if [ "$authed_status" = "401" ] || [ -z "$authed_status" ] || [ "$authed_status" = "000" ]; then
+    echo "✗ token-authenticated /mcp request did not pass the auth gate (status ${authed_status:-no response})" >&2
+    exit 1
+  fi
+  echo "✓ Token-authenticated /mcp request passes auth gate (HTTP $authed_status)"
 }
 
 verify_running() {
@@ -265,6 +348,8 @@ verify_running() {
     echo "⚠ AppIntents registration failed in runtime logs." >&2
     echo "  This commonly happens for unsigned/ad-hoc local bundles." >&2
   fi
+
+  verify_app_owned_runtime
 }
 
 verify_appintents() {
@@ -278,6 +363,7 @@ verify_appintents() {
     echo "✗ $APP_EXECUTABLE did not start from $BUNDLE_DIR" >&2
     exit 1
   }
+  verify_app_owned_runtime
   sleep 2
 
   local intent_predicate

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -5,7 +5,7 @@
  * module status, and optionally probes macOS permissions.
  */
 
-import { readFileSync, existsSync } from "node:fs";
+import { readFileSync, existsSync, statSync } from "node:fs";
 import { join, dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { execFileSync } from "node:child_process";
@@ -17,10 +17,12 @@ import { esc } from "../shared/esc.js";
 import { MODULE_MANIFEST } from "../shared/modules.js";
 import { summarizeCompatibility } from "../shared/compatibility.js";
 import { RESET, BOLD, DIM, WHITE, GREEN, SYM, heading, line, divider, spinner, sleep } from "./style.js";
+import { APP_RUNTIME_TOKEN_PATH } from "../shared/app-runtime-token.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 /** Package root — works in repo checkout, npm cache, and git worktrees. */
 const PKG_ROOT = resolve(__dirname, "..", "..");
+const APP_OWNED_HEALTH_URL = CODEX_APP_OWNED_URL.replace(/\/mcp$/, "/health");
 
 interface FileConfig {
   locale?: string;
@@ -41,6 +43,16 @@ function clientRuntimeShape(entry: unknown): "app-owned" | "direct" | "unknown" 
   if (args.includes("connect") && args.includes(CODEX_APP_OWNED_URL)) return "unknown";
   if (command === "npx" && args.some((arg) => arg === "airmcp" || arg.startsWith("airmcp@"))) return "direct";
   return "unknown";
+}
+
+async function fetchWithTimeout(url: string, init: RequestInit = {}, timeoutMs = 1500) {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    return await fetch(url, { ...init, signal: controller.signal });
+  } finally {
+    clearTimeout(timeout);
+  }
 }
 
 export async function runDoctor(): Promise<void> {
@@ -179,6 +191,102 @@ export async function runDoctor(): Promise<void> {
   }
   if (!anyClientFound) {
     meh("MCP Clients", `No clients found — run: npx ${NPM_PACKAGE_NAME} init`);
+  }
+
+  // ── AirMCP.app runtime ─────────────────────────────────────────────
+  //
+  // This is the recommended production shape: AirMCP.app owns macOS/TCC
+  // permissions and exposes a local token-gated HTTP runtime for clients.
+  // Doctor checks the live runtime contract instead of trusting client config.
+  console.log(heading("AirMCP.app Runtime"));
+  const tokenExists = existsSync(APP_RUNTIME_TOKEN_PATH);
+  let appRuntimeToken: string | null = null;
+  if (tokenExists) {
+    try {
+      const mode = statSync(APP_RUNTIME_TOKEN_PATH).mode & 0o777;
+      appRuntimeToken = readFileSync(APP_RUNTIME_TOKEN_PATH, "utf8").trim();
+      if (mode === 0o600 && appRuntimeToken) {
+        ok("Runtime token", `${APP_RUNTIME_TOKEN_PATH.replace(HOME, "~")} (0600)`);
+      } else if (!appRuntimeToken) {
+        bad("Runtime token", `${APP_RUNTIME_TOKEN_PATH.replace(HOME, "~")} is empty`);
+      } else {
+        bad(
+          "Runtime token",
+          `${APP_RUNTIME_TOKEN_PATH.replace(HOME, "~")} permissions ${mode.toString(8)}; expected 600`,
+        );
+      }
+    } catch (e) {
+      meh("Runtime token", `could not inspect token: ${e instanceof Error ? e.message : String(e)}`);
+    }
+  } else {
+    meh("Runtime token", `not created yet — launch AirMCP.app or copy a client config from the app`);
+  }
+
+  try {
+    const healthResponse = await fetchWithTimeout(APP_OWNED_HEALTH_URL);
+    if (!healthResponse.ok) {
+      bad("Runtime health", `${APP_OWNED_HEALTH_URL} returned HTTP ${healthResponse.status}`);
+    } else {
+      const health = (await healthResponse.json()) as { status?: string; version?: string };
+      const pkgPath = join(PKG_ROOT, "package.json");
+      const current = JSON.parse(readFileSync(pkgPath, "utf-8")).version as string;
+      if (health.status === "ok" && health.version === current) {
+        ok("Runtime health", `healthy v${health.version}`);
+      } else if (health.status === "ok") {
+        bad("Runtime health", `version mismatch: app/package v${current}, runtime v${health.version ?? "unknown"}`);
+      } else {
+        bad("Runtime health", `unexpected payload: ${JSON.stringify(health)}`);
+      }
+
+      const probeBody = JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "initialize",
+        params: {
+          protocolVersion: "2025-03-26",
+          capabilities: {},
+          clientInfo: { name: "airmcp-doctor", version: "0" },
+        },
+      });
+      try {
+        const unauth = await fetchWithTimeout(
+          CODEX_APP_OWNED_URL,
+          { method: "POST", headers: { "Content-Type": "application/json" }, body: probeBody },
+          1500,
+        );
+        if (unauth.status === 401) {
+          ok("Runtime auth", "unauthenticated /mcp rejected (401)");
+        } else {
+          bad("Runtime auth", `unauthenticated /mcp returned HTTP ${unauth.status}; expected 401`);
+        }
+      } catch (e) {
+        meh("Runtime auth", `unauthenticated probe failed: ${e instanceof Error ? e.message : String(e)}`);
+      }
+
+      if (appRuntimeToken) {
+        try {
+          const authed = await fetchWithTimeout(
+            CODEX_APP_OWNED_URL,
+            {
+              method: "GET",
+              headers: {
+                Authorization: `Bearer ${appRuntimeToken}`,
+              },
+            },
+            1500,
+          );
+          if (authed.status === 401) {
+            bad("Runtime auth", "token-authenticated /mcp was rejected (401)");
+          } else {
+            ok("Runtime auth", `token-authenticated /mcp passed auth gate (HTTP ${authed.status})`);
+          }
+        } catch (e) {
+          meh("Runtime auth", `token-authenticated probe failed: ${e instanceof Error ? e.message : String(e)}`);
+        }
+      }
+    }
+  } catch {
+    meh("Runtime health", `not running at ${APP_OWNED_HEALTH_URL} — launch AirMCP.app or run npm run app:verify`);
   }
 
   // ── Modules ────────────────────────────────────────────────────────

--- a/tests/app-owned-runtime-version-pin.test.js
+++ b/tests/app-owned-runtime-version-pin.test.js
@@ -9,6 +9,7 @@ const menuContent = readFileSync(
   "utf8",
 );
 const serverManager = readFileSync(new URL("../app/Sources/AirMCPApp/ServerManager.swift", import.meta.url), "utf8");
+const app = readFileSync(new URL("../app/Sources/AirMCPApp/AirMCPApp.swift", import.meta.url), "utf8");
 const appIntents = readFileSync(new URL("../app/Sources/AirMCPApp/AppIntents.swift", import.meta.url), "utf8");
 const onboarding = readFileSync(new URL("../app/Sources/AirMCPApp/Views/OnboardingView.swift", import.meta.url), "utf8");
 const config = readFileSync(new URL("../src/shared/config.ts", import.meta.url), "utf8");
@@ -35,5 +36,17 @@ describe("app-owned runtime npm package pin", () => {
   test("local app verification can override npx to the checkout instead of unpublished npm versions", () => {
     const bundleScript = readFileSync(new URL("../scripts/bundle-app.sh", import.meta.url), "utf8");
     expect(bundleScript).toContain('AIRMCP_NPM_PACKAGE_SPECIFIER="${AIRMCP_NPM_PACKAGE_SPECIFIER:-$PROJECT_DIR}"');
+  });
+
+  test("bundle verification forces and validates the app-owned runtime contract", () => {
+    const bundleScript = readFileSync(new URL("../scripts/bundle-app.sh", import.meta.url), "utf8");
+    expect(menuContent).toContain('static let envForceAppRuntime = "AIRMCP_FORCE_APP_RUNTIME"');
+    expect(app).toContain("ProcessInfo.processInfo.environment[AirMcpConstants.envForceAppRuntime] == \"1\"");
+    expect(app).toContain("serverManager.startServer()");
+    expect(bundleScript).toContain("export AIRMCP_FORCE_APP_RUNTIME=1");
+    expect(bundleScript).toContain("verify_app_owned_runtime");
+    expect(bundleScript).toContain("app-owned runtime version mismatch");
+    expect(bundleScript).toContain("unauthenticated /mcp request should return 401");
+    expect(bundleScript).toContain("token-authenticated /mcp request did not pass the auth gate");
   });
 });


### PR DESCRIPTION
## Summary
- Force the app-owned runtime during local bundle verification without mutating onboarding defaults
- Make `app:verify` fail unless the HTTP runtime is healthy, matches package.json version, has a private token file, rejects unauthenticated /mcp, and accepts token-authenticated requests through the auth gate
- Add the same live app-owned runtime checks to `airmcp doctor`

## Verification
- bash -n scripts/bundle-app.sh
- npm test -- --runTestsByPath tests/app-owned-runtime-version-pin.test.js
- npm run app-build
- npm run app:verify
- npm run typecheck
- npm run build && node dist/index.js doctor
- npm test
- npm run gen:manifest:check && npm run gen:intents:check && npm run mcp:validate
- npm run stats:check && npm run build:mcpb:check && npm run version:check

## Notes
- Local bundle remains ad-hoc signed on this machine, so trusted AppIntents registration still requires a valid codesigning identity.