### PR TITLE
feat(cli): repair clients for app-owned runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -877,6 +877,7 @@ Or edit `~/.config/airmcp/config.json` directly:
 | `npx airmcp --full`    | Start with all 29 modules enabled |
 | `npx airmcp --http`    | Start as HTTP server (port 3847)  |
 | `npx airmcp connect`   | Proxy stdio clients to AirMCP.app |
+| `npx airmcp connect-clients` | Repair installed client configs for AirMCP.app |
 
 ## Configuration
 
@@ -894,6 +895,7 @@ Or edit `~/.config/airmcp/config.json` directly:
 | `AIRMCP_EMBEDDING_DIM`       | `3072`                       | Embedding dimension (256/512/1024/2048/3072)                 |
 | `AIRMCP_EMBEDDING_PROVIDER`  | auto                         | Force provider: `gemini`, `swift`, `hybrid`, `none`          |
 | `AIRMCP_HTTP_TOKEN`          | —                            | Bearer token for HTTP mode authentication                    |
+| `AIRMCP_NPM_PACKAGE_SPECIFIER` | `airmcp@<current>`          | Override app-owned proxy/runtime package for local testing   |
 
 ### Config File
 

--- a/scripts/sync-version.mjs
+++ b/scripts/sync-version.mjs
@@ -138,8 +138,8 @@ syncFile("app/Sources/AirMCPApp/Views/MenuContent.swift", [
 // 6. config.ts — app-owned proxy/runtime package pin.
 syncFile("src/shared/config.ts", [
   {
-    pattern: /export const NPM_PACKAGE_SPECIFIER = "airmcp@[^"]+"/,
-    replacement: `export const NPM_PACKAGE_SPECIFIER = "airmcp@${VERSION}"`,
+    pattern: /export const NPM_PACKAGE_SPECIFIER = process\.env\.AIRMCP_NPM_PACKAGE_SPECIFIER \|\| "airmcp@[^"]+"/,
+    replacement: `export const NPM_PACKAGE_SPECIFIER = process.env.AIRMCP_NPM_PACKAGE_SPECIFIER || "airmcp@${VERSION}"`,
     label: "NPM_PACKAGE_SPECIFIER",
   },
 ]);

--- a/src/cli/client-config.ts
+++ b/src/cli/client-config.ts
@@ -1,0 +1,179 @@
+import { copyFileSync, existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname } from "node:path";
+import type { McpClient } from "../shared/config.js";
+import { MCP_CLIENTS } from "../shared/config.js";
+import { isPlainObject } from "../shared/validate.js";
+import {
+  CODEX_APP_OWNED_URL,
+  type CodexAirmcpRuntimeShape,
+  configureCodexAirmcp,
+  codexAirmcpRuntimeShape,
+  isCodexCliAvailable,
+  stdioProxyEntry,
+} from "./codex-mcp.js";
+
+export type ClientRuntimeShape = "app-owned" | "direct" | "unknown";
+export type ClientConfigStatus = "configured" | "already-configured" | "would-configure" | "skipped" | "failed";
+
+export interface ClientConfigResult {
+  name: string;
+  status: ClientConfigStatus;
+  detail: string;
+  configPath?: string;
+}
+
+export interface ClientConfigOptions {
+  clients?: readonly McpClient[];
+  dryRun?: boolean;
+  includeSkipped?: boolean;
+  token?: string;
+  now?: () => number;
+  configureCodex?: boolean;
+  codex?: {
+    isAvailable: () => boolean;
+    shape: () => CodexAirmcpRuntimeShape;
+    configure: () => "already-configured" | "configured";
+  };
+}
+
+export function clientRuntimeShape(entry: unknown): ClientRuntimeShape {
+  if (!entry || typeof entry !== "object") return "unknown";
+  const record = entry as Record<string, unknown>;
+  const command = typeof record.command === "string" ? record.command : "";
+  const args = Array.isArray(record.args) ? record.args.filter((arg): arg is string => typeof arg === "string") : [];
+  const env = record.env && typeof record.env === "object" ? (record.env as Record<string, unknown>) : {};
+  const hasToken = typeof env.AIRMCP_HTTP_TOKEN === "string" && env.AIRMCP_HTTP_TOKEN.length > 0;
+  if (args.includes("connect") && args.includes(CODEX_APP_OWNED_URL) && hasToken) return "app-owned";
+  if (args.includes("connect") && args.includes(CODEX_APP_OWNED_URL)) return "unknown";
+  if (command === "npx" && args.some((arg) => arg === "airmcp" || arg.startsWith("airmcp@"))) return "direct";
+  return "unknown";
+}
+
+function deepEqual(a: unknown, b: unknown): boolean {
+  return JSON.stringify(a) === JSON.stringify(b);
+}
+
+function configureFileClient(
+  client: McpClient,
+  options: Required<Pick<ClientConfigOptions, "dryRun" | "now">> & {
+    token?: string;
+  },
+): ClientConfigResult {
+  const configExists = existsSync(client.configPath);
+  const parentExists = existsSync(dirname(client.configPath));
+  if (!configExists && !parentExists) {
+    return {
+      name: client.name,
+      status: "skipped",
+      detail: "client config directory not found",
+      configPath: client.configPath,
+    };
+  }
+
+  const targetEntry = stdioProxyEntry(options.dryRun ? "<app-runtime-token>" : options.token);
+
+  try {
+    let existing: Record<string, unknown> = {};
+    if (configExists) {
+      const parsed: unknown = JSON.parse(readFileSync(client.configPath, "utf-8"));
+      if (!isPlainObject(parsed)) throw new Error("existing config is not a JSON object");
+      existing = parsed;
+    }
+
+    const rawServers = existing[client.serversKey];
+    const servers: Record<string, unknown> = isPlainObject(rawServers) ? rawServers : {};
+    const currentEntry = servers.airmcp;
+    if (!options.dryRun && deepEqual(currentEntry, targetEntry)) {
+      return {
+        name: client.name,
+        status: "already-configured",
+        detail: "token-gated AirMCP.app runtime",
+        configPath: client.configPath,
+      };
+    }
+    if (options.dryRun && clientRuntimeShape(currentEntry) === "app-owned") {
+      return {
+        name: client.name,
+        status: "already-configured",
+        detail: "token-gated AirMCP.app runtime",
+        configPath: client.configPath,
+      };
+    }
+
+    if (options.dryRun) {
+      return {
+        name: client.name,
+        status: "would-configure",
+        detail: configExists ? "would replace airmcp with the app-owned runtime proxy" : "would create config file",
+        configPath: client.configPath,
+      };
+    }
+
+    servers.airmcp = targetEntry;
+    existing[client.serversKey] = servers;
+
+    if (configExists) copyFileSync(client.configPath, `${client.configPath}.bak.${options.now()}`);
+    mkdirSync(dirname(client.configPath), { recursive: true });
+    writeFileSync(client.configPath, JSON.stringify(existing, null, 2) + "\n");
+
+    return {
+      name: client.name,
+      status: "configured",
+      detail: "token-gated AirMCP.app runtime",
+      configPath: client.configPath,
+    };
+  } catch (error) {
+    return {
+      name: client.name,
+      status: "failed",
+      detail: error instanceof Error ? error.message : String(error),
+      configPath: client.configPath,
+    };
+  }
+}
+
+function configureCodexClient(
+  options: Required<Pick<ClientConfigOptions, "dryRun">> & {
+    codex: NonNullable<ClientConfigOptions["codex"]>;
+  },
+): ClientConfigResult {
+  if (!options.codex.isAvailable()) {
+    return { name: "Codex", status: "skipped", detail: "codex CLI not found" };
+  }
+
+  try {
+    const shape = options.codex.shape();
+    if (shape === "app-owned" || shape === "app-owned-pending-restart") {
+      return { name: "Codex", status: "already-configured", detail: "AirMCP.app runtime" };
+    }
+    if (options.dryRun) {
+      return {
+        name: "Codex",
+        status: "would-configure",
+        detail: shape === "missing" ? "would add airmcp MCP server" : "would replace existing airmcp MCP server",
+      };
+    }
+    options.codex.configure();
+    return { name: "Codex", status: "configured", detail: "token-gated AirMCP.app runtime" };
+  } catch (error) {
+    return { name: "Codex", status: "failed", detail: error instanceof Error ? error.message : String(error) };
+  }
+}
+
+export function configureMcpClients(options: ClientConfigOptions = {}): ClientConfigResult[] {
+  const dryRun = options.dryRun ?? false;
+  const includeSkipped = options.includeSkipped ?? true;
+  const clients = options.clients ?? MCP_CLIENTS;
+  const now = options.now ?? Date.now;
+  const codex = options.codex ?? {
+    isAvailable: isCodexCliAvailable,
+    shape: codexAirmcpRuntimeShape,
+    configure: configureCodexAirmcp,
+  };
+
+  const results = clients.map((client) => configureFileClient(client, { dryRun, now, token: options.token }));
+  if (options.configureCodex ?? true) {
+    results.push(configureCodexClient({ dryRun, codex }));
+  }
+  return includeSkipped ? results : results.filter((result) => result.status !== "skipped");
+}

--- a/src/cli/codex-mcp.ts
+++ b/src/cli/codex-mcp.ts
@@ -1,10 +1,14 @@
 import { execFileSync } from "node:child_process";
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
 import { NPM_PACKAGE_SPECIFIER } from "../shared/config.js";
-import { IDENTITY } from "../shared/constants.js";
+import { HOME, IDENTITY } from "../shared/constants.js";
 import { ensureAppRuntimeToken } from "../shared/app-runtime-token.js";
 
 export const CODEX_APP_OWNED_URL = `http://127.0.0.1:${IDENTITY.HTTP_PORT}/mcp`;
-export type CodexAirmcpRuntimeShape = "app-owned" | "direct" | "unknown" | "missing";
+export type CodexAirmcpRuntimeShape = "app-owned" | "app-owned-pending-restart" | "direct" | "unknown" | "missing";
+type CodexConfigFileRuntimeShape = "app-owned" | "direct" | "unknown";
+const CODEX_CONFIG_PATH = process.env.AIRMCP_CODEX_CONFIG_PATH || join(HOME, ".codex", "config.toml");
 
 function runCodex(args: string[]): string {
   return execFileSync("codex", args, {
@@ -35,8 +39,7 @@ export function isCodexAirmcpConfigured(): boolean {
   return getCodexAirmcpConfig() !== null;
 }
 
-export function codexAirmcpRuntimeShape(): CodexAirmcpRuntimeShape {
-  const config = getCodexAirmcpConfig();
+function codexCliRuntimeShape(config: string | null): Exclude<CodexAirmcpRuntimeShape, "app-owned-pending-restart"> {
   if (!config) return "missing";
   if (
     config.includes(CODEX_APP_OWNED_URL) &&
@@ -51,8 +54,53 @@ export function codexAirmcpRuntimeShape(): CodexAirmcpRuntimeShape {
   return "unknown";
 }
 
+function sectionBody(toml: string, header: string): string {
+  const lines = toml.split(/\r?\n/);
+  const start = lines.findIndex((line) => line.trim() === header);
+  if (start === -1) return "";
+  const body: string[] = [];
+  for (let i = start + 1; i < lines.length; i += 1) {
+    const line = lines[i]!;
+    if (/^\s*\[/.test(line)) break;
+    body.push(line);
+  }
+  return body.join("\n");
+}
+
+export function codexConfigTomlRuntimeShape(toml: string): CodexConfigFileRuntimeShape {
+  const server = sectionBody(toml, "[mcp_servers.airmcp]");
+  if (!server) return "unknown";
+  const env = sectionBody(toml, "[mcp_servers.airmcp.env]");
+  const hasToken = /AIRMCP_HTTP_TOKEN\s*=/.test(env);
+  if (server.includes(CODEX_APP_OWNED_URL) && server.includes('"connect"') && hasToken) return "app-owned";
+  if (/command\s*=\s*"npx"/.test(server) && /airmcp(@|")/.test(server)) return "direct";
+  return "unknown";
+}
+
+function codexConfigFileRuntimeShape(): CodexConfigFileRuntimeShape {
+  try {
+    if (!existsSync(CODEX_CONFIG_PATH)) return "unknown";
+    return codexConfigTomlRuntimeShape(readFileSync(CODEX_CONFIG_PATH, "utf8"));
+  } catch {
+    return "unknown";
+  }
+}
+
+export function codexAirmcpRuntimeShape(): CodexAirmcpRuntimeShape {
+  const cliShape = codexCliRuntimeShape(getCodexAirmcpConfig());
+  if (cliShape === "app-owned") return "app-owned";
+
+  const fileShape = codexConfigFileRuntimeShape();
+  if (fileShape === "app-owned") return "app-owned-pending-restart";
+  return cliShape;
+}
+
 export function configureCodexAirmcp(): "already-configured" | "configured" {
   const token = ensureAppRuntimeToken();
+  const shape = codexAirmcpRuntimeShape();
+  if (shape === "app-owned" || shape === "app-owned-pending-restart") {
+    return "already-configured";
+  }
   if (isCodexAirmcpConfigured()) {
     runCodex(["mcp", "remove", "airmcp"]);
   }

--- a/src/cli/connect-clients.ts
+++ b/src/cli/connect-clients.ts
@@ -1,0 +1,100 @@
+import { codexManualSetupCommand, stdioProxyEntry } from "./codex-mcp.js";
+import { configureMcpClients, type ClientConfigResult } from "./client-config.js";
+import { BOLD, DIM, GREEN, RED, RESET, SYM, WHITE, YELLOW } from "./style.js";
+
+interface ConnectClientsOptions {
+  dryRun: boolean;
+  json: boolean;
+}
+
+function usage(): string {
+  return [
+    "Usage: npx airmcp connect-clients [--dry-run] [--json]",
+    "",
+    "Configure installed MCP clients to use the token-gated AirMCP.app runtime.",
+    "This repairs stale direct stdio configs without rerunning the interactive setup wizard.",
+  ].join("\n");
+}
+
+function parseArgs(args: string[]): ConnectClientsOptions {
+  const options: ConnectClientsOptions = { dryRun: false, json: false };
+  for (const arg of args) {
+    if (arg === "--help" || arg === "-h") {
+      console.log(usage());
+      process.exit(0);
+    }
+    if (arg === "--dry-run") {
+      options.dryRun = true;
+      continue;
+    }
+    if (arg === "--json") {
+      options.json = true;
+      continue;
+    }
+    throw new Error(`Unknown connect-clients option: ${arg}`);
+  }
+  return options;
+}
+
+function iconFor(status: ClientConfigResult["status"]): string {
+  if (status === "failed") return `${RED}✗${RESET}`;
+  if (status === "skipped") return `${DIM}·${RESET}`;
+  if (status === "would-configure") return `${YELLOW}◆${RESET}`;
+  return SYM.ok;
+}
+
+function labelFor(status: ClientConfigResult["status"]): string {
+  if (status === "would-configure") return "would configure";
+  if (status === "already-configured") return "already configured";
+  return status;
+}
+
+export function runConnectClients(args = process.argv.slice(3)): void {
+  try {
+    const options = parseArgs(args);
+    const results = configureMcpClients({ dryRun: options.dryRun, includeSkipped: false });
+
+    if (options.json) {
+      console.log(JSON.stringify({ dryRun: options.dryRun, results }, null, 2));
+    } else {
+      console.log("");
+      console.log(`  ${BOLD}${WHITE}AirMCP Client Connection Repair${RESET}`);
+      console.log(
+        `  ${DIM}${options.dryRun ? "Previewing" : "Configuring"} clients for the token-gated AirMCP.app runtime.${RESET}`,
+      );
+      console.log("");
+
+      for (const result of results) {
+        console.log(
+          `  ${iconFor(result.status)} ${result.name.padEnd(16)} ${labelFor(result.status)} ${DIM}${result.detail}${RESET}`,
+        );
+      }
+
+      if (results.length === 0) {
+        console.log(`  ${YELLOW}⚠${RESET} No installed MCP client configs found.`);
+        console.log("");
+        console.log(`  ${DIM}Manual JSON entry:${RESET}`);
+        console.log(
+          `  ${DIM}${JSON.stringify({ mcpServers: { airmcp: stdioProxyEntry("<token>") } }, null, 2)}${RESET}`,
+        );
+        console.log("");
+        console.log(`  ${DIM}Codex CLI:${RESET}`);
+        console.log(`  ${DIM}${codexManualSetupCommand()}${RESET}`);
+      } else if (options.dryRun) {
+        console.log("");
+        console.log(`  ${DIM}Run ${BOLD}npx airmcp connect-clients${RESET}${DIM} to apply these changes.${RESET}`);
+      } else {
+        console.log("");
+        console.log(`  ${GREEN}✓${RESET} Start AirMCP.app, then restart configured MCP clients.`);
+      }
+      console.log("");
+    }
+
+    if (results.some((result) => result.status === "failed")) {
+      process.exitCode = 1;
+    }
+  } catch (error) {
+    console.error(`[AirMCP] ${error instanceof Error ? error.message : String(error)}`);
+    process.exitCode = 1;
+  }
+}

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -12,6 +12,7 @@ import { execFileSync } from "node:child_process";
 import { MODULE_NAMES, STARTER_MODULES, NPM_PACKAGE_NAME, MCP_CLIENTS, getCompatibilityEnv } from "../shared/config.js";
 import { HOME, PATHS } from "../shared/constants.js";
 import { CODEX_APP_OWNED_URL, codexAirmcpRuntimeShape, isCodexCliAvailable } from "./codex-mcp.js";
+import { clientRuntimeShape } from "./client-config.js";
 import { LOGO_LINES, typeLine } from "../shared/banner.js";
 import { esc } from "../shared/esc.js";
 import { MODULE_MANIFEST } from "../shared/modules.js";
@@ -30,19 +31,6 @@ interface FileConfig {
   includeShared?: boolean;
   allowSendMessages?: boolean;
   allowSendMail?: boolean;
-}
-
-function clientRuntimeShape(entry: unknown): "app-owned" | "direct" | "unknown" {
-  if (!entry || typeof entry !== "object") return "unknown";
-  const record = entry as Record<string, unknown>;
-  const command = typeof record.command === "string" ? record.command : "";
-  const args = Array.isArray(record.args) ? record.args.filter((arg): arg is string => typeof arg === "string") : [];
-  const env = record.env && typeof record.env === "object" ? (record.env as Record<string, unknown>) : {};
-  const hasToken = typeof env.AIRMCP_HTTP_TOKEN === "string" && env.AIRMCP_HTTP_TOKEN.length > 0;
-  if (args.includes("connect") && args.includes(CODEX_APP_OWNED_URL) && hasToken) return "app-owned";
-  if (args.includes("connect") && args.includes(CODEX_APP_OWNED_URL)) return "unknown";
-  if (command === "npx" && args.some((arg) => arg === "airmcp" || arg.startsWith("airmcp@"))) return "direct";
-  return "unknown";
 }
 
 async function fetchWithTimeout(url: string, init: RequestInit = {}, timeoutMs = 1500) {
@@ -164,7 +152,7 @@ export async function runDoctor(): Promise<void> {
           if (shape === "app-owned") {
             ok(client.name, `${GREEN}connected${RESET} ${DIM}(AirMCP.app runtime)${RESET}`);
           } else if (shape === "direct") {
-            meh(client.name, `connected via direct stdio — rerun init for AirMCP.app runtime`);
+            meh(client.name, `connected via direct stdio — run: npx airmcp connect-clients`);
           } else {
             meh(client.name, `airmcp entry found, runtime shape unknown`);
           }
@@ -181,8 +169,10 @@ export async function runDoctor(): Promise<void> {
     const shape = codexAirmcpRuntimeShape();
     if (shape === "app-owned") {
       ok("Codex", `${GREEN}connected${RESET} ${DIM}(AirMCP.app runtime)${RESET}`);
+    } else if (shape === "app-owned-pending-restart") {
+      meh("Codex", `config uses AirMCP.app runtime — restart Codex to reload MCP servers`);
     } else if (shape === "direct") {
-      meh("Codex", "connected via direct stdio — rerun init for token-gated AirMCP.app runtime");
+      meh("Codex", "connected via direct stdio — run: npx airmcp connect-clients");
     } else if (shape === "missing") {
       meh("Codex", `found but no airmcp entry`);
     } else {

--- a/src/cli/help.ts
+++ b/src/cli/help.ts
@@ -26,6 +26,9 @@ export function runHelp(): void {
   console.log(
     `    ${GREEN}$${RESET} npx airmcp ${BOLD}connect${RESET}         ${DIM}Proxy stdio clients to AirMCP.app local HTTP${RESET}`,
   );
+  console.log(
+    `    ${GREEN}$${RESET} npx airmcp ${BOLD}connect-clients${RESET} ${DIM}Repair client configs for AirMCP.app runtime${RESET}`,
+  );
   console.log(`    ${GREEN}$${RESET} npx airmcp                  ${DIM}Start MCP server (stdio)${RESET}`);
   console.log(`    ${GREEN}$${RESET} npx airmcp ${BOLD}--http${RESET}          ${DIM}Start as HTTP server${RESET}`);
   console.log(`    ${GREEN}$${RESET} npx airmcp ${BOLD}--full${RESET}          ${DIM}Enable all modules${RESET}`);
@@ -42,6 +45,9 @@ export function runHelp(): void {
   console.log(`    ${CYAN}init${RESET}       ${DIM}Choose language, select modules, configure MCP clients${RESET}`);
   console.log(`    ${CYAN}doctor${RESET}     ${DIM}Check Node.js, macOS, permissions, clients, modules${RESET}`);
   console.log(`    ${CYAN}connect${RESET}    ${DIM}Bridge stdio clients into the app-owned local runtime${RESET}`);
+  console.log(
+    `    ${CYAN}connect-clients${RESET} ${DIM}Configure installed clients to use that app-owned runtime${RESET}`,
+  );
   console.log(
     `    ${CYAN}workflows${RESET}  ${DIM}Show target workflows, prompts, modules, Siri phrases, safety notes${RESET}`,
   );
@@ -61,6 +67,9 @@ export function runHelp(): void {
   );
   console.log(
     `    ${WHITE}AIRMCP_HTTP_TOKEN${RESET}=${DIM}<secret>${RESET}       ${DIM}Bearer token for HTTP mode auth${RESET}`,
+  );
+  console.log(
+    `    ${WHITE}AIRMCP_NPM_PACKAGE_SPECIFIER${RESET}=${DIM}<specifier>${RESET} ${DIM}Override app-owned proxy package${RESET}`,
   );
   console.log("");
   console.log(`  ${BOLD}Config${RESET}  ${DIM}~/.config/airmcp/config.json${RESET}`);

--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -6,11 +6,11 @@
  * 3. Auto-detect and patch MCP client configs (Claude Desktop, Cursor, Windsurf, etc.)
  */
 
-import { readFileSync, writeFileSync, mkdirSync, existsSync, copyFileSync } from "node:fs";
-import { join } from "node:path";
-import { MODULE_NAMES, STARTER_MODULES, MCP_CLIENTS } from "../shared/config.js";
+import { readFileSync, writeFileSync, mkdirSync, existsSync } from "node:fs";
+import { MODULE_NAMES, STARTER_MODULES } from "../shared/config.js";
 import { PATHS } from "../shared/constants.js";
-import { codexManualSetupCommand, configureCodexAirmcp, isCodexCliAvailable, stdioProxyEntry } from "./codex-mcp.js";
+import { codexManualSetupCommand, stdioProxyEntry } from "./codex-mcp.js";
+import { configureMcpClients } from "./client-config.js";
 import { LOGO_LINES, typeLine, sleep, writeOut } from "../shared/banner.js";
 import { isPlainObject } from "../shared/validate.js";
 import { formatError } from "../shared/errors.js";
@@ -456,63 +456,20 @@ export async function runInit(): Promise<void> {
 
   // --- Step 3: Auto-detect and patch MCP client configs ---
   const airmcpEntry = stdioProxyEntry();
-
+  const clientResults = configureMcpClients({ includeSkipped: false });
+  const detectedClients = clientResults.map((result) => result.name);
   let patchedClients = 0;
-  const detectedClients: string[] = [];
 
-  for (const client of MCP_CLIENTS) {
-    const configExists = existsSync(client.configPath);
-    const parentExists = existsSync(join(client.configPath, ".."));
-
-    // Only patch if the config file or its parent directory already exists (client is installed)
-    if (!configExists && !parentExists) continue;
-
-    detectedClients.push(client.name);
-    process.stdout.write(`  Configuring ${client.name}...`);
-
-    try {
-      let existing: Record<string, unknown> = {};
-      if (configExists) {
-        const parsed: unknown = JSON.parse(readFileSync(client.configPath, "utf-8"));
-        if (!isPlainObject(parsed)) {
-          throw new Error(`existing config is not a JSON object`);
-        }
-        existing = parsed;
-      }
-
-      const rawServers = existing[client.serversKey];
-      const servers: Record<string, unknown> = isPlainObject(rawServers) ? rawServers : {};
-      servers.airmcp = airmcpEntry;
-      existing[client.serversKey] = servers;
-
-      // Snapshot the original file before overwriting so users can recover
-      // if the wizard ever produces unexpected output. .bak.<timestamp> keeps
-      // older snapshots from being clobbered on repeated runs.
-      if (configExists) {
-        copyFileSync(client.configPath, `${client.configPath}.bak.${Date.now()}`);
-      }
-      mkdirSync(join(client.configPath, ".."), { recursive: true });
-      writeFileSync(client.configPath, JSON.stringify(existing, null, 2) + "\n");
-      console.log(` ${GREEN}\u2713${RESET}`);
-      patchedClients++;
-    } catch (e) {
-      console.log(` ${YELLOW}\u26A0${RESET} ${e instanceof Error ? e.message : String(e)}`);
+  for (const result of clientResults) {
+    process.stdout.write(`  Configuring ${result.name}...`);
+    if (result.status === "failed") {
+      console.log(` ${YELLOW}\u26A0${RESET} ${result.detail}`);
+      continue;
     }
-  }
-
-  if (isCodexCliAvailable()) {
-    detectedClients.push("Codex");
-    process.stdout.write("  Configuring Codex...");
-
-    try {
-      const result = configureCodexAirmcp();
-      console.log(
-        ` ${GREEN}\u2713${RESET}${result === "already-configured" ? ` ${DIM}(already connected)${RESET}` : ""}`,
-      );
-      patchedClients++;
-    } catch (e) {
-      console.log(` ${YELLOW}\u26A0${RESET} ${e instanceof Error ? e.message : String(e)}`);
-    }
+    console.log(
+      ` ${GREEN}\u2713${RESET}${result.status === "already-configured" ? ` ${DIM}(already connected)${RESET}` : ""}`,
+    );
+    patchedClients++;
   }
 
   if (detectedClients.length === 0) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,6 +21,7 @@ if (
   _sub === "doctor" ||
   _sub === "workflows" ||
   _sub === "connect" ||
+  _sub === "connect-clients" ||
   _sub === "--help" ||
   _sub === "-h" ||
   _sub === "help"
@@ -37,6 +38,9 @@ if (
   } else if (_sub === "connect") {
     const mod = await import("./cli/connect.js");
     await mod.runConnect();
+  } else if (_sub === "connect-clients") {
+    const mod = await import("./cli/connect-clients.js");
+    mod.runConnectClients();
   } else {
     const mod = await import("./cli/help.js");
     mod.runHelp();

--- a/src/shared/config.ts
+++ b/src/shared/config.ts
@@ -77,7 +77,7 @@ export function getCompatibilityEnv(): CompatibilityEnv {
 /** npm package name — single source of truth for npx/install references */
 export const NPM_PACKAGE_NAME = "airmcp";
 /** Version-pinned npm package specifier for app-owned proxy/runtime commands. */
-export const NPM_PACKAGE_SPECIFIER = "airmcp@2.12.1";
+export const NPM_PACKAGE_SPECIFIER = process.env.AIRMCP_NPM_PACKAGE_SPECIFIER || "airmcp@2.12.1";
 
 export type HitlLevel = "off" | "destructive-only" | "sensitive-only" | "all-writes" | "all";
 

--- a/tests/app-owned-runtime-version-pin.test.js
+++ b/tests/app-owned-runtime-version-pin.test.js
@@ -30,7 +30,7 @@ describe("app-owned runtime npm package pin", () => {
   });
 
   test("TypeScript app-owned proxy helper uses the same pinned package specifier", () => {
-    expect(config).toContain(`export const NPM_PACKAGE_SPECIFIER = "${expectedSpecifier}"`);
+    expect(config).toContain(`process.env.AIRMCP_NPM_PACKAGE_SPECIFIER || "${expectedSpecifier}"`);
   });
 
   test("local app verification can override npx to the checkout instead of unpublished npm versions", () => {

--- a/tests/client-config.test.js
+++ b/tests/client-config.test.js
@@ -1,0 +1,180 @@
+import { afterEach, beforeEach, describe, expect, jest, test } from "@jest/globals";
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+
+const originalHome = process.env.HOME;
+const tempHomes = [];
+
+async function loadClientConfig(home) {
+  process.env.HOME = home;
+  delete process.env.AIRMCP_NPM_PACKAGE_SPECIFIER;
+  jest.resetModules();
+  return import("../dist/cli/client-config.js");
+}
+
+function readJson(path) {
+  return JSON.parse(readFileSync(path, "utf8"));
+}
+
+beforeEach(() => {
+  jest.resetModules();
+});
+
+afterEach(() => {
+  process.env.HOME = originalHome;
+  delete process.env.AIRMCP_NPM_PACKAGE_SPECIFIER;
+  jest.resetModules();
+  for (const home of tempHomes.splice(0)) {
+    rmSync(home, { recursive: true, force: true });
+  }
+});
+
+describe("client config repair", () => {
+  test("migrates an installed stdio client to the token-gated AirMCP.app proxy and backs up the old config", async () => {
+    const home = mkdtempSync(join(tmpdir(), "airmcp-client-config-"));
+    tempHomes.push(home);
+    const { CODEX_APP_OWNED_URL } = await import("../dist/cli/codex-mcp.js");
+    const { configureMcpClients } = await loadClientConfig(home);
+    const configPath = join(home, "Client", "mcp.json");
+    mkdirSync(dirname(configPath), { recursive: true });
+    writeFileSync(
+      configPath,
+      JSON.stringify(
+        {
+          mcpServers: {
+            keep: { command: "node", args: ["server.js"] },
+            airmcp: { command: "npx", args: ["-y", "airmcp@2.12.0"] },
+          },
+        },
+        null,
+        2,
+      ) + "\n",
+    );
+
+    const results = configureMcpClients({
+      clients: [{ name: "Test Client", configPath, serversKey: "mcpServers" }],
+      configureCodex: false,
+      now: () => 123,
+      token: "test-token",
+    });
+
+    expect(results).toEqual([
+      {
+        name: "Test Client",
+        status: "configured",
+        detail: "token-gated AirMCP.app runtime",
+        configPath,
+      },
+    ]);
+    expect(readFileSync(`${configPath}.bak.123`, "utf8")).toContain("airmcp@2.12.0");
+    const updated = readJson(configPath);
+    expect(updated.mcpServers.keep).toEqual({ command: "node", args: ["server.js"] });
+    expect(updated.mcpServers.airmcp).toEqual({
+      command: "npx",
+      args: ["-y", "airmcp@2.12.1", "connect", "--url", CODEX_APP_OWNED_URL],
+      env: { AIRMCP_HTTP_TOKEN: "test-token" },
+    });
+  });
+
+  test("dry-run reports changes without writing a token, backup, or config mutation", async () => {
+    const home = mkdtempSync(join(tmpdir(), "airmcp-client-config-"));
+    tempHomes.push(home);
+    const { configureMcpClients } = await loadClientConfig(home);
+    const configPath = join(home, "Client", "mcp.json");
+    mkdirSync(dirname(configPath), { recursive: true });
+    const original = JSON.stringify({ mcpServers: { airmcp: { command: "npx", args: ["-y", "airmcp"] } } }, null, 2);
+    writeFileSync(configPath, `${original}\n`);
+
+    const results = configureMcpClients({
+      clients: [{ name: "Test Client", configPath, serversKey: "mcpServers" }],
+      configureCodex: false,
+      dryRun: true,
+    });
+
+    expect(results[0].status).toBe("would-configure");
+    expect(readFileSync(configPath, "utf8")).toBe(`${original}\n`);
+    expect(() => statSync(`${configPath}.bak.123`)).toThrow();
+    expect(() => statSync(join(home, "Library", "Application Support", "AirMCP", "http-token"))).toThrow();
+  });
+
+  test("does not rewrite a client that already has the exact app-owned proxy entry", async () => {
+    const home = mkdtempSync(join(tmpdir(), "airmcp-client-config-"));
+    tempHomes.push(home);
+    const { stdioProxyEntry } = await import("../dist/cli/codex-mcp.js");
+    const { configureMcpClients } = await loadClientConfig(home);
+    const configPath = join(home, "Client", "mcp.json");
+    mkdirSync(dirname(configPath), { recursive: true });
+    const existing = { mcpServers: { airmcp: stdioProxyEntry("existing-token") } };
+    writeFileSync(configPath, JSON.stringify(existing, null, 2) + "\n");
+
+    const results = configureMcpClients({
+      clients: [{ name: "Test Client", configPath, serversKey: "mcpServers" }],
+      configureCodex: false,
+      token: "existing-token",
+    });
+
+    expect(results[0].status).toBe("already-configured");
+    expect(readJson(configPath)).toEqual(existing);
+  });
+
+  test("surfaces parse errors without clobbering the existing client config", async () => {
+    const home = mkdtempSync(join(tmpdir(), "airmcp-client-config-"));
+    tempHomes.push(home);
+    const { configureMcpClients } = await loadClientConfig(home);
+    const configPath = join(home, "Client", "mcp.json");
+    mkdirSync(dirname(configPath), { recursive: true });
+    writeFileSync(configPath, "{ nope\n");
+
+    const results = configureMcpClients({
+      clients: [{ name: "Test Client", configPath, serversKey: "mcpServers" }],
+      configureCodex: false,
+    });
+
+    expect(results[0].status).toBe("failed");
+    expect(results[0].detail).toMatch(/JSON/);
+    expect(readFileSync(configPath, "utf8")).toBe("{ nope\n");
+  });
+
+  test("supports dry-run Codex repair without shelling out to the real codex CLI", async () => {
+    const home = mkdtempSync(join(tmpdir(), "airmcp-client-config-"));
+    tempHomes.push(home);
+    const { configureMcpClients } = await loadClientConfig(home);
+    const configure = jest.fn();
+
+    const results = configureMcpClients({
+      clients: [],
+      dryRun: true,
+      codex: {
+        isAvailable: () => true,
+        shape: () => "direct",
+        configure,
+      },
+    });
+
+    expect(results).toEqual([
+      { name: "Codex", status: "would-configure", detail: "would replace existing airmcp MCP server" },
+    ]);
+    expect(configure).not.toHaveBeenCalled();
+  });
+
+  test("honors AIRMCP_NPM_PACKAGE_SPECIFIER for local development client wiring", async () => {
+    const home = mkdtempSync(join(tmpdir(), "airmcp-client-config-"));
+    tempHomes.push(home);
+    process.env.HOME = home;
+    process.env.AIRMCP_NPM_PACKAGE_SPECIFIER = "/Users/ren/IdeaProjects/MCP/AirMCP";
+    jest.resetModules();
+    const { configureMcpClients } = await import("../dist/cli/client-config.js");
+    const configPath = join(home, "Client", "mcp.json");
+    mkdirSync(dirname(configPath), { recursive: true });
+    writeFileSync(configPath, JSON.stringify({ mcpServers: {} }, null, 2) + "\n");
+
+    configureMcpClients({
+      clients: [{ name: "Test Client", configPath, serversKey: "mcpServers" }],
+      configureCodex: false,
+      token: "test-token",
+    });
+
+    expect(readJson(configPath).mcpServers.airmcp.args[1]).toBe("/Users/ren/IdeaProjects/MCP/AirMCP");
+  });
+});

--- a/tests/codex-mcp.test.js
+++ b/tests/codex-mcp.test.js
@@ -1,4 +1,13 @@
-import { beforeEach, describe, expect, jest, test } from "@jest/globals";
+import { afterAll, beforeEach, describe, expect, jest, test } from "@jest/globals";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const originalHome = process.env.HOME;
+const originalCodexConfigPath = process.env.AIRMCP_CODEX_CONFIG_PATH;
+const testHome = mkdtempSync(join(tmpdir(), "airmcp-codex-mcp-"));
+process.env.HOME = testHome;
+process.env.AIRMCP_CODEX_CONFIG_PATH = join(testHome, "config.toml");
 
 const execFileSync = jest.fn();
 const ensureAppRuntimeToken = jest.fn(() => "test-runtime-token");
@@ -14,6 +23,7 @@ jest.unstable_mockModule("../dist/shared/app-runtime-token.js", () => ({
 const {
   CODEX_APP_OWNED_URL,
   codexAirmcpRuntimeShape,
+  codexConfigTomlRuntimeShape,
   configureCodexAirmcp,
   isCodexAirmcpConfigured,
   stdioProxyEntry,
@@ -23,6 +33,7 @@ let codexGetOutput;
 
 beforeEach(() => {
   codexGetOutput = null;
+  writeFileSync(process.env.AIRMCP_CODEX_CONFIG_PATH, "");
   execFileSync.mockReset();
   execFileSync.mockImplementation((_command, args) => {
     if (args[0] === "--version") return "codex 0.0.0";
@@ -32,6 +43,14 @@ beforeEach(() => {
     }
     return "";
   });
+});
+
+afterAll(() => {
+  if (originalHome === undefined) delete process.env.HOME;
+  else process.env.HOME = originalHome;
+  if (originalCodexConfigPath === undefined) delete process.env.AIRMCP_CODEX_CONFIG_PATH;
+  else process.env.AIRMCP_CODEX_CONFIG_PATH = originalCodexConfigPath;
+  rmSync(testHome, { recursive: true, force: true });
 });
 
 describe("codex MCP setup", () => {
@@ -67,6 +86,45 @@ describe("codex MCP setup", () => {
     ].join("\n");
 
     expect(codexAirmcpRuntimeShape()).toBe("app-owned");
+  });
+
+  test("classifies config.toml app-owned entries as pending restart when CLI output is stale", () => {
+    codexGetOutput = [
+      "airmcp",
+      "  enabled: true",
+      "  transport: stdio",
+      "  command: npx",
+      "  args: -y airmcp@2.12.0",
+    ].join("\n");
+    writeFileSync(
+      process.env.AIRMCP_CODEX_CONFIG_PATH,
+      [
+        "[mcp_servers.airmcp]",
+        'command = "npx"',
+        `args = ["-y", "/Users/ren/IdeaProjects/MCP/AirMCP", "connect", "--url", "${CODEX_APP_OWNED_URL}"]`,
+        "",
+        "[mcp_servers.airmcp.env]",
+        'AIRMCP_HTTP_TOKEN = "token"',
+        "",
+      ].join("\n"),
+    );
+
+    expect(codexAirmcpRuntimeShape()).toBe("app-owned-pending-restart");
+  });
+
+  test("parses Codex config.toml app-owned proxy shape", () => {
+    expect(
+      codexConfigTomlRuntimeShape(
+        [
+          "[mcp_servers.airmcp]",
+          'command = "npx"',
+          `args = ["-y", "airmcp@2.12.1", "connect", "--url", "${CODEX_APP_OWNED_URL}"]`,
+          "",
+          "[mcp_servers.airmcp.env]",
+          'AIRMCP_HTTP_TOKEN = "token"',
+        ].join("\n"),
+      ),
+    ).toBe("app-owned");
   });
 
   test("replaces an existing Codex entry with the token-gated app-owned proxy", () => {

--- a/tests/connect-clients-cli.test.js
+++ b/tests/connect-clients-cli.test.js
@@ -1,0 +1,59 @@
+import { afterEach, describe, expect, test } from "@jest/globals";
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { cleanBootEnv } from "../scripts/lib/clean-boot-env.mjs";
+
+const DIST = fileURLToPath(new URL("../dist/index.js", import.meta.url));
+const ROOT = fileURLToPath(new URL("..", import.meta.url));
+const homes = [];
+
+function runCli(home, args) {
+  return spawnSync(process.execPath, [DIST, ...args], {
+    cwd: ROOT,
+    env: { ...cleanBootEnv(), HOME: home, NO_COLOR: "1", PATH: "/usr/bin:/bin:/usr/sbin:/sbin" },
+    encoding: "utf8",
+  });
+}
+
+afterEach(() => {
+  for (const home of homes.splice(0)) {
+    rmSync(home, { recursive: true, force: true });
+  }
+});
+
+describe("airmcp connect-clients", () => {
+  test("dry-run JSON reports an installed direct Claude Desktop config without mutating it", () => {
+    const home = mkdtempSync(join(tmpdir(), "airmcp-connect-clients-"));
+    homes.push(home);
+    const configPath = join(home, "Library", "Application Support", "Claude", "claude_desktop_config.json");
+    mkdirSync(dirname(configPath), { recursive: true });
+    writeFileSync(configPath, JSON.stringify({ mcpServers: { airmcp: { command: "npx", args: ["-y", "airmcp"] } } }));
+
+    const result = runCli(home, ["connect-clients", "--dry-run", "--json"]);
+
+    expect(result.status).toBe(0);
+    const payload = JSON.parse(result.stdout);
+    expect(payload.dryRun).toBe(true);
+    expect(payload.results).toEqual([
+      expect.objectContaining({
+        name: "Claude Desktop",
+        status: "would-configure",
+        configPath,
+      }),
+    ]);
+    expect(readFileSync(configPath, "utf8")).toContain('"airmcp"');
+  });
+
+  test("rejects unknown flags with a non-zero exit code", () => {
+    const home = mkdtempSync(join(tmpdir(), "airmcp-connect-clients-"));
+    homes.push(home);
+
+    const result = runCli(home, ["connect-clients", "--wat"]);
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain("Unknown connect-clients option: --wat");
+  });
+});


### PR DESCRIPTION
## Summary
- add `airmcp connect-clients` to repair installed MCP client configs without rerunning interactive init
- share client runtime-shape detection between init/doctor and surface Codex pending-restart state
- support `AIRMCP_NPM_PACKAGE_SPECIFIER` for local app-owned proxy/runtime testing

## Verification
- `npm test` (2094 tests)
- `npm run app-build`
- `npm run app:verify`
- `npm run gen:manifest:check`
- `npm run gen:intents:check`
- `npm run mcp:validate`
- `npm run stats:check`
- `npm run build:mcpb:check`
- `npm run version:check`
