### PR TITLE
Verify app runtime MCP roundtrip

### DIFF
--- a/scripts/bundle-app.sh
+++ b/scripts/bundle-app.sh
@@ -267,7 +267,6 @@ verify_app_owned_runtime() {
   local token_mode
   local unauth_status
   local token
-  local authed_status
 
   health="$(wait_for_http_runtime)" || {
     echo "✗ app-owned HTTP runtime did not become healthy at $APP_HEALTH_URL" >&2
@@ -308,17 +307,19 @@ verify_app_owned_runtime() {
   echo "✓ Unauthenticated /mcp request is rejected (401)"
 
   token="$(tr -d "\r\n" < "$TOKEN_FILE")"
-  authed_status="$(
-    curl -sS --max-time 2 -o /dev/null -w "%{http_code}" \
-      -X GET "$APP_MCP_URL" \
-      -H "Authorization: Bearer $token" \
-      2>/dev/null || true
-  )"
-  if [ "$authed_status" = "401" ] || [ -z "$authed_status" ] || [ "$authed_status" = "000" ]; then
-    echo "✗ token-authenticated /mcp request did not pass the auth gate (status ${authed_status:-no response})" >&2
+  local probe_output
+  if ! probe_output="$(
+    node "$SCRIPT_DIR/probe-app-runtime.mjs" \
+      --url "$APP_MCP_URL" \
+      --token "$token" \
+      --min-tools 1 \
+      --timeout-ms 5000 2>&1
+  )"; then
+    echo "✗ token-authenticated MCP initialize/tools-list failed" >&2
+    echo "$probe_output" >&2
     exit 1
   fi
-  echo "✓ Token-authenticated /mcp request passes auth gate (HTTP $authed_status)"
+  echo "✓ Token-authenticated MCP initialize + tools/list passes ($probe_output)"
 }
 
 verify_running() {

--- a/scripts/probe-app-runtime.mjs
+++ b/scripts/probe-app-runtime.mjs
@@ -1,0 +1,92 @@
+#!/usr/bin/env node
+
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+
+function usage() {
+  return [
+    "Usage: node scripts/probe-app-runtime.mjs --url http://127.0.0.1:3847/mcp --token <token>",
+    "",
+    "Performs a real MCP initialize + tools/list round trip against the app-owned HTTP runtime.",
+  ].join("\n");
+}
+
+function parseArgs(argv) {
+  const options = {
+    url: "",
+    token: "",
+    timeoutMs: 5_000,
+    minTools: 1,
+    clientName: "airmcp-bundle-verify",
+  };
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === "--help" || arg === "-h") {
+      console.log(usage());
+      process.exit(0);
+    }
+    if (arg === "--url") {
+      options.url = argv[++i] ?? "";
+      continue;
+    }
+    if (arg === "--token") {
+      options.token = argv[++i] ?? "";
+      continue;
+    }
+    if (arg === "--timeout-ms") {
+      options.timeoutMs = Number(argv[++i] ?? "");
+      continue;
+    }
+    if (arg === "--min-tools") {
+      options.minTools = Number(argv[++i] ?? "");
+      continue;
+    }
+    if (arg === "--client-name") {
+      options.clientName = argv[++i] ?? "";
+      continue;
+    }
+    throw new Error(`unknown option: ${arg}`);
+  }
+
+  if (!options.url) throw new Error("--url is required");
+  if (!options.token) throw new Error("--token is required");
+  if (!Number.isFinite(options.timeoutMs) || options.timeoutMs <= 0) {
+    throw new Error("--timeout-ms must be a positive number");
+  }
+  if (!Number.isInteger(options.minTools) || options.minTools < 1) {
+    throw new Error("--min-tools must be a positive integer");
+  }
+  return options;
+}
+
+async function main() {
+  const options = parseArgs(process.argv.slice(2));
+  const client = new Client({ name: options.clientName, version: "0" }, { capabilities: {} });
+  const transport = new StreamableHTTPClientTransport(new URL(options.url), {
+    requestInit: {
+      headers: {
+        Authorization: `Bearer ${options.token}`,
+      },
+    },
+  });
+
+  try {
+    await client.connect(transport, { timeout: options.timeoutMs });
+    const result = await client.listTools(undefined, { timeout: options.timeoutMs });
+    if (result.tools.length < options.minTools) {
+      throw new Error(`tools/list returned ${result.tools.length} tools; expected at least ${options.minTools}`);
+    }
+    const server = client.getServerVersion();
+    const name = server?.name ?? "unknown";
+    const version = server?.version ?? "unknown";
+    console.log(`${result.tools.length} tools from ${name} v${version}`);
+  } finally {
+    await client.close().catch(() => undefined);
+  }
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exit(1);
+});

--- a/src/cli/app-runtime-probe.ts
+++ b/src/cli/app-runtime-probe.ts
@@ -1,0 +1,55 @@
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+
+export interface AppRuntimeProbeOptions {
+  url: string;
+  token: string;
+  clientName?: string;
+  clientVersion?: string;
+  timeoutMs?: number;
+  minTools?: number;
+}
+
+export interface AppRuntimeProbeResult {
+  serverName?: string;
+  serverVersion?: string;
+  toolCount: number;
+  sampleTools: string[];
+}
+
+export async function probeAppRuntimeMcp(options: AppRuntimeProbeOptions): Promise<AppRuntimeProbeResult> {
+  const timeout = options.timeoutMs ?? 3_000;
+  const minTools = options.minTools ?? 1;
+  const client = new Client(
+    {
+      name: options.clientName ?? "airmcp-runtime-probe",
+      version: options.clientVersion ?? "0",
+    },
+    { capabilities: {} },
+  );
+  const transport = new StreamableHTTPClientTransport(new URL(options.url), {
+    requestInit: {
+      headers: {
+        Authorization: `Bearer ${options.token}`,
+      },
+    },
+  });
+
+  try {
+    await client.connect(transport, { timeout });
+    const tools = await client.listTools(undefined, { timeout });
+    const toolCount = tools.tools.length;
+    if (toolCount < minTools) {
+      throw new Error(`tools/list returned ${toolCount} tools; expected at least ${minTools}`);
+    }
+    const serverVersion = client.getServerVersion();
+    return {
+      serverName: serverVersion?.name,
+      serverVersion: serverVersion?.version,
+      toolCount,
+      sampleTools: tools.tools.slice(0, 5).map((tool) => tool.name),
+    };
+  } finally {
+    await client.close().catch(() => undefined);
+  }
+}

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -19,6 +19,7 @@ import { MODULE_MANIFEST } from "../shared/modules.js";
 import { summarizeCompatibility } from "../shared/compatibility.js";
 import { RESET, BOLD, DIM, WHITE, GREEN, SYM, heading, line, divider, spinner, sleep } from "./style.js";
 import { APP_RUNTIME_TOKEN_PATH } from "../shared/app-runtime-token.js";
+import { probeAppRuntimeMcp } from "./app-runtime-probe.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 /** Package root — works in repo checkout, npm cache, and git worktrees. */
@@ -255,23 +256,18 @@ export async function runDoctor(): Promise<void> {
 
       if (appRuntimeToken) {
         try {
-          const authed = await fetchWithTimeout(
-            CODEX_APP_OWNED_URL,
-            {
-              method: "GET",
-              headers: {
-                Authorization: `Bearer ${appRuntimeToken}`,
-              },
-            },
-            1500,
-          );
-          if (authed.status === 401) {
-            bad("Runtime auth", "token-authenticated /mcp was rejected (401)");
-          } else {
-            ok("Runtime auth", `token-authenticated /mcp passed auth gate (HTTP ${authed.status})`);
-          }
+          const probe = await probeAppRuntimeMcp({
+            url: CODEX_APP_OWNED_URL,
+            token: appRuntimeToken,
+            clientName: "airmcp-doctor",
+            timeoutMs: 3_000,
+          });
+          ok("Runtime MCP", `initialize + tools/list ok (${probe.toolCount} tools)`);
         } catch (e) {
-          meh("Runtime auth", `token-authenticated probe failed: ${e instanceof Error ? e.message : String(e)}`);
+          bad(
+            "Runtime MCP",
+            `token-authenticated initialize/tools-list failed: ${e instanceof Error ? e.message : String(e)}`,
+          );
         }
       }
     }

--- a/tests/app-owned-runtime-version-pin.test.js
+++ b/tests/app-owned-runtime-version-pin.test.js
@@ -47,6 +47,7 @@ describe("app-owned runtime npm package pin", () => {
     expect(bundleScript).toContain("verify_app_owned_runtime");
     expect(bundleScript).toContain("app-owned runtime version mismatch");
     expect(bundleScript).toContain("unauthenticated /mcp request should return 401");
-    expect(bundleScript).toContain("token-authenticated /mcp request did not pass the auth gate");
+    expect(bundleScript).toContain("probe-app-runtime.mjs");
+    expect(bundleScript).toContain("token-authenticated MCP initialize/tools-list failed");
   });
 });

--- a/tests/cli-connect.test.js
+++ b/tests/cli-connect.test.js
@@ -4,6 +4,7 @@ import { createServer } from "node:net";
 import { createInterface } from "node:readline";
 import { fileURLToPath } from "node:url";
 import { cleanBootEnv } from "../scripts/lib/clean-boot-env.mjs";
+import { probeAppRuntimeMcp } from "../dist/cli/app-runtime-probe.js";
 
 const DIST = fileURLToPath(new URL("../dist/index.js", import.meta.url));
 const ROOT = fileURLToPath(new URL("..", import.meta.url));
@@ -123,6 +124,28 @@ afterEach(async () => {
 });
 
 describe("airmcp connect", () => {
+  test("app runtime probe performs initialize and tools/list over token-gated HTTP", async () => {
+    const port = await getFreePort();
+    const token = "test-runtime-token";
+    const server = spawnAirMcp(["--http", "--port", String(port)], {
+      AIRMCP_ALLOW_NETWORK: "with-token",
+      AIRMCP_HTTP_TOKEN: token,
+    });
+    await waitForHealth(port, server);
+
+    const probe = await probeAppRuntimeMcp({
+      url: `http://127.0.0.1:${port}/mcp`,
+      token,
+      clientName: "airmcp-runtime-probe-test",
+      timeoutMs: 10_000,
+      minTools: 100,
+    });
+
+    expect(probe.serverName).toBe("airmcp");
+    expect(probe.toolCount).toBeGreaterThan(100);
+    expect(probe.sampleTools.length).toBeGreaterThan(0);
+  }, 30_000);
+
   test("bridges a stdio client to the token-gated app-owned HTTP runtime", async () => {
     const port = await getFreePort();
     const token = "test-runtime-token";


### PR DESCRIPTION
## Summary
- add an SDK-based app runtime probe that performs real MCP initialize + tools/list
- make `doctor` report authenticated runtime MCP contract failures instead of only checking GET auth
- make `app:verify` assert token-authenticated initialize + tools/list against the app-owned runtime

## Verification
- npm run app:verify
- npm run gen:manifest:check
- npm run gen:intents:check
- npm run stats:check
- node scripts/verify-golden-intents.mjs
- npm run typecheck
- npm test
- npm run mcp:validate
- npm run build:mcpb:check
- npm run version:check
- npm run app-build