### PR TITLE
fix: harden AppIntent runtime and output decoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@
 ## Features
 
 - **286 tools** (29 modules) — Apple app CRUD + system control + Apple Intelligence + UI Automation + Screen Capture + Maps + Podcasts + Weather + iWork (Pages/Numbers/Keynote) + Google Workspace + dynamic shortcuts + context memory + audit introspection
-- **228 Shortcuts / Siri AppIntents** — auto-generated from the tool manifest (82 Interactive Snippet views + 13 AppEnum pickers); workflow-first AppShortcuts ship by default, while `AskAirMCPIntent` is a FoundationModels preview gated behind `AIRMCP_ENABLE_FOUNDATION_MODELS`
+- **228 Shortcuts / Siri AppIntents** — auto-generated from the tool manifest (79 Interactive Snippet views + 13 AppEnum pickers); workflow-first AppShortcuts ship by default, while `AskAirMCPIntent` is a FoundationModels preview gated behind `AIRMCP_ENABLE_FOUNDATION_MODELS`
 - **32 prompts + 14 YAML skill built-ins** — per-app workflows + cross-module + developer workflows + Skills DSL (`inputs` / `parallel` / `loop` / `on_error` / `retry` / 9 event triggers)
 - **9 MCP resources** — Notes, Calendar, Reminders, Music, Mail, System, Context Memory + unified `context://snapshot/{depth}`
 - **3 interactive MCP Apps** — `calendar_week_view`, `music_player`, `timeline_today` (fuses events + reminders on one day-axis)

--- a/app/Sources/AirMCPApp/AppIntents.swift
+++ b/app/Sources/AirMCPApp/AppIntents.swift
@@ -196,9 +196,82 @@ func installMCPIntentRouterForMacOS() {
 
 // MARK: - AirMCP Tool Runner
 
-/// Execute an AirMCP MCP tool by calling the Node.js server via stdio.
-/// This is a lightweight bridge: sends a JSON-RPC request to the airmcp process.
+private enum AppIntentMCPTransportError: Error {
+    case invalidRuntimeURL
+    case missingSessionID
+    case httpStatus(Int, String)
+    case invalidJSONResponse(String)
+    case rpcError(String)
+    case missingToolText
+    case toolCallUncertain(Error)
+}
+
+/// Execute an AirMCP MCP tool through the app-owned HTTP runtime when it is
+/// already available, then fall back to the legacy stdio bridge. The fallback
+/// keeps cold Shortcuts/Siri invocations working while the preferred path
+/// shares the same token-gated, app-owned runtime as Claude/Codex/Cursor.
 private func runAirMCPTool(_ toolName: String, args: [String: Any]) async throws -> String {
+    do {
+        return try await runAirMCPToolViaAppRuntime(toolName, args: args)
+    } catch {
+        if let transportError = error as? AppIntentMCPTransportError,
+           case .toolCallUncertain = transportError {
+            throw error
+        }
+        return try await runAirMCPToolViaStdio(toolName, args: args)
+    }
+}
+
+private func runAirMCPToolViaAppRuntime(_ toolName: String, args: [String: Any]) async throws -> String {
+    let token = try AppRuntimeToken.ensure()
+    let initResponse = try await postAppRuntimeMCPRequest(
+        [
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": [
+                "protocolVersion": AirMcpConstants.mcpProtocolVersion,
+                "capabilities": [:] as [String: Any],
+                "clientInfo": ["name": "AirMCPAppIntents", "version": "1.0"],
+            ],
+        ],
+        token: token
+    )
+    guard let sessionID = initResponse.sessionID else {
+        throw AppIntentMCPTransportError.missingSessionID
+    }
+    defer {
+        Task {
+            try? await closeAppRuntimeMCPSession(sessionID: sessionID, token: token)
+        }
+    }
+
+    _ = try await postAppRuntimeMCPRequest(
+        ["jsonrpc": "2.0", "method": "notifications/initialized", "params": [:] as [String: Any]],
+        token: token,
+        sessionID: sessionID,
+        allowsEmptyResponse: true
+    )
+
+    do {
+        let toolResponse = try await postAppRuntimeMCPRequest(
+            [
+                "jsonrpc": "2.0",
+                "id": 2,
+                "method": "tools/call",
+                "params": ["name": toolName, "arguments": args],
+            ],
+            token: token,
+            sessionID: sessionID,
+            timeoutInterval: 30
+        )
+        return try extractToolText(from: toolResponse.json)
+    } catch {
+        throw AppIntentMCPTransportError.toolCallUncertain(error)
+    }
+}
+
+private func runAirMCPToolViaStdio(_ toolName: String, args: [String: Any]) async throws -> String {
     let process = Process()
     process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
     process.arguments = ["npx", "-y", AirMcpConstants.npmPackageSpecifier]
@@ -257,4 +330,90 @@ private func runAirMCPTool(_ toolName: String, args: [String: Any]) async throws
     }
 
     return output.prefix(500).description
+}
+
+private func appRuntimeURL() throws -> URL {
+    guard let url = URL(string: AirMcpConstants.appOwnedHttpURL) else {
+        throw AppIntentMCPTransportError.invalidRuntimeURL
+    }
+    return url
+}
+
+private func postAppRuntimeMCPRequest(
+    _ payload: [String: Any],
+    token: String,
+    sessionID: String? = nil,
+    allowsEmptyResponse: Bool = false,
+    timeoutInterval: TimeInterval = 2
+) async throws -> (json: [String: Any], sessionID: String?) {
+    var request = URLRequest(url: try appRuntimeURL())
+    request.httpMethod = "POST"
+    request.timeoutInterval = timeoutInterval
+    request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+    request.setValue("application/json, text/event-stream", forHTTPHeaderField: "Accept")
+    request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+    if let sessionID {
+        request.setValue(sessionID, forHTTPHeaderField: "Mcp-Session-Id")
+    }
+    request.httpBody = try JSONSerialization.data(withJSONObject: payload)
+
+    let (data, response) = try await URLSession.shared.data(for: request)
+    guard let http = response as? HTTPURLResponse else {
+        throw AppIntentMCPTransportError.invalidJSONResponse("missing HTTP response")
+    }
+    guard (200..<300).contains(http.statusCode) else {
+        let body = String(data: data, encoding: .utf8) ?? ""
+        throw AppIntentMCPTransportError.httpStatus(http.statusCode, body)
+    }
+    if data.isEmpty && allowsEmptyResponse {
+        return ([:], http.value(forHTTPHeaderField: "Mcp-Session-Id"))
+    }
+    let json = try decodeMCPHTTPBody(data, allowsEmptyResponse: allowsEmptyResponse)
+    return (json, http.value(forHTTPHeaderField: "Mcp-Session-Id"))
+}
+
+private func closeAppRuntimeMCPSession(sessionID: String, token: String) async throws {
+    var request = URLRequest(url: try appRuntimeURL())
+    request.httpMethod = "DELETE"
+    request.timeoutInterval = 1
+    request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+    request.setValue(sessionID, forHTTPHeaderField: "Mcp-Session-Id")
+    _ = try await URLSession.shared.data(for: request)
+}
+
+private func decodeMCPHTTPBody(_ data: Data, allowsEmptyResponse: Bool = false) throws -> [String: Any] {
+    if data.isEmpty {
+        if allowsEmptyResponse { return [:] }
+        throw AppIntentMCPTransportError.invalidJSONResponse("empty response")
+    }
+    if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] {
+        return json
+    }
+    let text = String(data: data, encoding: .utf8) ?? ""
+    for line in text.split(separator: "\n") {
+        let trimmed = line.trimmingCharacters(in: .whitespaces)
+        guard trimmed.hasPrefix("data:") else { continue }
+        let payload = String(trimmed.dropFirst("data:".count)).trimmingCharacters(in: .whitespaces)
+        guard !payload.isEmpty, payload != "[DONE]" else { continue }
+        if let json = try? JSONSerialization.jsonObject(with: Data(payload.utf8)) as? [String: Any] {
+            return json
+        }
+    }
+    if allowsEmptyResponse { return [:] }
+    throw AppIntentMCPTransportError.invalidJSONResponse(String(text.prefix(500)))
+}
+
+private func extractToolText(from json: [String: Any]) throws -> String {
+    if let error = json["error"] as? [String: Any] {
+        let message = error["message"] as? String ?? String(describing: error)
+        throw AppIntentMCPTransportError.rpcError(message)
+    }
+    guard
+        let result = json["result"] as? [String: Any],
+        let content = result["content"] as? [[String: Any]],
+        let text = content.first?["text"] as? String
+    else {
+        throw AppIntentMCPTransportError.missingToolText
+    }
+    return text
 }

--- a/scripts/gen-swift-intents.mjs
+++ b/scripts/gen-swift-intents.mjs
@@ -260,17 +260,17 @@ for (const name of APP_SHORTCUTS_TOP) {
 //
 // Limits (A.2b.2 scope):
 //   • Supports type: string / number / integer / boolean
-//   • Nullable union {type: [X, "null"]} → Optional<SwiftX>
-//   • array → [Element] (with Element recursively mapped)
+//   • Nullable union {type: [X, "null"]} or {anyOf: [X, null]} → Optional<SwiftX>
+//   • array → [Element] (with Element recursively mapped; homogeneous tuple
+//     arrays like items: [{number}, {number}] become [Double])
 //   • nested object → nested Swift struct (e.g. ListCalendarsOutput.CalendarsItem)
-//   • additionalProperties: true OR {} → the tool is flagged not-codable-safe
-//     and falls back to ReturnsValue<String>. Exactly one tool today
-//     (audit_log, because of the free-form 'args' field).
+//   • additionalProperties: true OR {} and unconstrained schema nodes ({}) →
+//     the tool is flagged not-codable-safe and falls back to ReturnsValue<String>.
 //
 // Everything else (oneOf, allOf, recursive refs) would require AnyCodable
 // or more elaborate machinery — out of A.2b.2 scope.
 
-// isNullableUnion, nonNullType, isCodableSafe, swiftOutputType,
+// isNullableUnion, nonNullType, nonNullSchema, isCodableSafe, swiftOutputType,
 // renderStruct, hasTypedOutput, outputTypeNameFor, buildConfirmDialogBody
 // all imported from scripts/lib/codegen-helpers.mjs. The dialog-body
 // helper lives in lib so the test suite can import it without
@@ -732,15 +732,15 @@ const header = `// GENERATED — do not edit.
 // Run \`npm run gen:intents\` to refresh after tool metadata changes.
 // CI guards against drift via \`npm run gen:intents:check\`.
 //
-// Router runtime is live as of PR #103 (A.2a): macOS execFile stdio and
-// iOS in-process MCPServer.callToolText. Every generated intent's
-// \`perform()\` hits that router. Typed intents additionally decode the
-// router's String result through JSONDecoder.
+// Router runtime is live as of PR #103 (A.2a): macOS app-owned HTTP with
+// stdio fallback and iOS in-process MCPServer.callToolText. Every generated
+// intent's \`perform()\` hits that router. Typed intents additionally decode
+// the router's String result through JSONDecoder.
 //
 // Snippet views (§3.7) are SwiftUI View structs matching each typed
-// output shape. A.4.1 ships the views; A.4.2 will plug them into the
-// intents' \`.result(value:, view:)\` overloads. Kept in a separate
-// #if so iOS 17 builds stay green.
+// output shape and typed intents already return them through
+// \`.result(value:, view:)\` overloads. Kept in a separate #if so iOS 17
+// builds stay green.
 
 #if canImport(AppIntents)
 import AppIntents

--- a/scripts/lib/codegen-helpers.mjs
+++ b/scripts/lib/codegen-helpers.mjs
@@ -204,18 +204,44 @@ export function wireExpr(type, varName, isEnum, isEntity = false, opts = {}) {
   return type === "Date" ? `ISO8601DateFormatter().string(from: ${varName})` : varName;
 }
 
-// JSON Schema supports nullable via `type: ["string", "null"]` — we
-// treat anything matching that shape as optional. Alternate null
-// encodings (anyOf, oneOf) need explicit support if they ever appear
-// in the manifest.
+// JSON Schema supports nullable via either `type: ["string", "null"]`
+// or the draft-07 `anyOf: [{ type: "string" }, { type: "null" }]`
+// shape emitted by zod-to-json-schema. Both appear in the tool
+// manifest, so the AppIntent output bridge must unwrap both forms
+// before choosing a Swift Codable type.
 export function isNullableUnion(schema) {
-  if (!schema || !Array.isArray(schema.type)) return false;
-  return schema.type.length === 2 && schema.type.includes("null");
+  return nonNullSchema(schema) !== null;
 }
 
 export function nonNullType(schema) {
   if (!schema || !Array.isArray(schema.type)) return null;
   return schema.type.find((t) => t !== "null");
+}
+
+export function nonNullSchema(schema) {
+  if (!schema || typeof schema !== "object") return null;
+  if (Array.isArray(schema.type) && schema.type.length === 2 && schema.type.includes("null")) {
+    const inner = nonNullType(schema);
+    return inner ? { ...schema, type: inner } : null;
+  }
+  if (Array.isArray(schema.anyOf) && schema.anyOf.length === 2) {
+    const nonNullMembers = schema.anyOf.filter((member) => member?.type !== "null");
+    if (nonNullMembers.length === 1) return nonNullMembers[0];
+  }
+  return null;
+}
+
+function arrayItemSchema(schema) {
+  const items = schema?.items;
+  if (!Array.isArray(items)) return items ?? {};
+  if (items.length === 0) return {};
+  const types = items.map((item) => item?.type);
+  if (types.every((type) => type === "number" || type === "integer")) {
+    return types.includes("number") ? { type: "number" } : { type: "integer" };
+  }
+  if (types.every((type) => type === "string")) return { type: "string" };
+  if (types.every((type) => type === "boolean")) return { type: "boolean" };
+  return {};
 }
 
 // ── Naming helpers for generated Swift types ───────────────────────────
@@ -315,6 +341,9 @@ export function systemImageFor(toolName) {
 // anywhere in the tree.
 export function isCodableSafe(schema) {
   if (!schema || typeof schema !== "object") return true;
+  if (isNullableUnion(schema)) return isCodableSafe(nonNullSchema(schema));
+  if (Array.isArray(schema.anyOf)) return false;
+  if (!("type" in schema)) return false;
   if (schema.type === "object") {
     if (schema.additionalProperties === true) return false;
     if (
@@ -329,7 +358,7 @@ export function isCodableSafe(schema) {
     }
     return true;
   }
-  if (schema.type === "array") return isCodableSafe(schema.items);
+  if (schema.type === "array") return isCodableSafe(arrayItemSchema(schema));
   return true;
 }
 
@@ -340,15 +369,14 @@ export function isCodableSafe(schema) {
 // node — used to name nested structs deterministically.
 export function swiftOutputType(schema, path, nested) {
   if (isNullableUnion(schema)) {
-    const inner = nonNullType(schema);
-    return swiftOutputType({ ...schema, type: inner }, path, nested) + "?";
+    return swiftOutputType(nonNullSchema(schema), path, nested) + "?";
   }
   if (schema.type === "string") return "String";
   if (schema.type === "number") return "Double";
   if (schema.type === "integer") return "Int";
   if (schema.type === "boolean") return "Bool";
   if (schema.type === "array") {
-    const itemSchema = schema.items ?? {};
+    const itemSchema = arrayItemSchema(schema);
     const itemName = `${path}Item`;
     const itemType = swiftOutputType(itemSchema, itemName, nested);
     return `[${itemType}]`;

--- a/swift/Sources/AirMCPKit/Generated/MCPIntents.swift
+++ b/swift/Sources/AirMCPKit/Generated/MCPIntents.swift
@@ -3,20 +3,20 @@
 // Source: docs/tool-manifest.json
 // Generator: scripts/gen-swift-intents.mjs
 // RFC 0007 Phase A.2b.2 + A.4.1 — 228 auto-selected read-only
-// tools (82 with typed drift-guards + Interactive Snippet
+// tools (79 with typed drift-guards + Interactive Snippet
 // SwiftUI views) + 9 AppShortcutsProvider entries.
 // Run `npm run gen:intents` to refresh after tool metadata changes.
 // CI guards against drift via `npm run gen:intents:check`.
 //
-// Router runtime is live as of PR #103 (A.2a): macOS execFile stdio and
-// iOS in-process MCPServer.callToolText. Every generated intent's
-// `perform()` hits that router. Typed intents additionally decode the
-// router's String result through JSONDecoder.
+// Router runtime is live as of PR #103 (A.2a): macOS app-owned HTTP with
+// stdio fallback and iOS in-process MCPServer.callToolText. Every generated
+// intent's `perform()` hits that router. Typed intents additionally decode
+// the router's String result through JSONDecoder.
 //
 // Snippet views (§3.7) are SwiftUI View structs matching each typed
-// output shape. A.4.1 ships the views; A.4.2 will plug them into the
-// intents' `.result(value:, view:)` overloads. Kept in a separate
-// #if so iOS 17 builds stay green.
+// output shape and typed intents already return them through
+// `.result(value:, view:)` overloads. Kept in a separate #if so iOS 17
+// builds stay green.
 
 #if canImport(AppIntents)
 import AppIntents
@@ -84,16 +84,16 @@ public struct MCPDiscoverToolsOutput: Codable, Sendable {
 
 // Output type for: get_battery_status
 public struct MCPGetBatteryStatusOutput: Codable, Sendable {
-    public let percentage: String
+    public let percentage: Int?
     public let charging: Bool
-    public let source: String
-    public let timeRemaining: String
+    public let source: String?
+    public let timeRemaining: String?
     public let raw: String
 }
 
 // Output type for: get_brightness
 public struct MCPGetBrightnessOutput: Codable, Sendable {
-    public let brightness: String
+    public let brightness: Double?
     public let raw: String
 }
 
@@ -151,16 +151,16 @@ public struct MCPGetFrontmostAppOutput: Codable, Sendable {
 // Output type for: get_photo_info
 public struct MCPGetPhotoInfoOutput: Codable, Sendable {
     public let id: String
-    public let filename: String
-    public let name: String
-    public let description: String
-    public let date: String
+    public let filename: String?
+    public let name: String?
+    public let description: String?
+    public let date: String?
     public let width: Double
     public let height: Double
-    public let altitude: String
-    public let location: String
+    public let altitude: Double?
+    public let location: [Double]?
     public let favorite: Bool
-    public let keywords: String
+    public let keywords: [String]?
 }
 
 // Output type for: get_rating
@@ -176,9 +176,9 @@ public struct MCPGetRatingOutput: Codable, Sendable {
 public struct MCPGetScreenInfoOutput: Codable, Sendable {
     public struct DisplaysItem: Codable, Sendable {
         public let name: String
-        public let resolution: String
-        public let pixelWidth: String
-        public let pixelHeight: String
+        public let resolution: String?
+        public let pixelWidth: Int?
+        public let pixelHeight: Int?
         public let retina: Bool
     }
 
@@ -207,7 +207,7 @@ public struct MCPGetTrackInfoOutput: Codable, Sendable {
     public let rating: Int
     public let favorited: Bool
     public let disliked: Bool
-    public let dateAdded: String
+    public let dateAdded: String?
     public let sampleRate: Int
     public let bitRate: Int
     public let size: Double
@@ -251,11 +251,11 @@ public struct MCPGetVolumeOutput: Codable, Sendable {
 
 // Output type for: get_wifi_status
 public struct MCPGetWifiStatusOutput: Codable, Sendable {
-    public let ssid: String
-    public let bssid: String
-    public let signalStrength: String
-    public let noiseLevel: String
-    public let channel: String
+    public let ssid: String?
+    public let bssid: String?
+    public let signalStrength: Int?
+    public let noiseLevel: Int?
+    public let channel: String?
     public let connected: Bool
     public let raw: String
 }
@@ -264,16 +264,16 @@ public struct MCPGetWifiStatusOutput: Codable, Sendable {
 public struct MCPIsAppRunningOutput: Codable, Sendable {
     public let running: Bool
     public let name: String
-    public let bundleIdentifier: String
-    public let pid: String
-    public let visible: String
+    public let bundleIdentifier: String?
+    public let pid: Int?
+    public let visible: Bool?
 }
 
 // Output type for: list_accounts
 public struct MCPListAccountsOutput: Codable, Sendable {
     public struct AccountsItem: Codable, Sendable {
         public let name: String
-        public let fullName: String
+        public let fullName: String?
         public let emailAddresses: [String]
     }
 
@@ -286,8 +286,8 @@ public struct MCPListAllWindowsOutput: Codable, Sendable {
         public let app: String
         public let pid: Int
         public let title: String
-        public let position: String
-        public let size: String
+        public let position: [Double]?
+        public let size: [Double]?
         public let minimized: Bool
     }
 
@@ -300,8 +300,8 @@ public struct MCPListBluetoothDevicesOutput: Codable, Sendable {
     public struct DevicesItem: Codable, Sendable {
         public let name: String
         public let connected: Bool
-        public let address: String
-        public let type: String
+        public let address: String?
+        public let type: String?
     }
 
     public let total: Int
@@ -325,7 +325,7 @@ public struct MCPListCalendarsOutput: Codable, Sendable {
     public struct CalendarsItem: Codable, Sendable {
         public let id: String
         public let name: String
-        public let color: String
+        public let color: String?
         public let writable: Bool
     }
 
@@ -336,14 +336,14 @@ public struct MCPListCalendarsOutput: Codable, Sendable {
 public struct MCPListChatsOutput: Codable, Sendable {
     public struct ChatsItem: Codable, Sendable {
         public struct ParticipantsItem: Codable, Sendable {
-            public let name: String
-            public let handle: String
+            public let name: String?
+            public let handle: String?
         }
 
         public let id: String
-        public let name: String
+        public let name: String?
         public let participants: [ParticipantsItem]
-        public let updated: String
+        public let updated: String?
     }
 
     public let total: Double
@@ -356,8 +356,8 @@ public struct MCPListContactsOutput: Codable, Sendable {
     public struct ContactsItem: Codable, Sendable {
         public let id: String
         public let name: String
-        public let email: String
-        public let phone: String
+        public let email: String?
+        public let phone: String?
     }
 
     public let total: Double
@@ -401,9 +401,9 @@ public struct MCPListEventsOutput: Codable, Sendable {
 public struct MCPListFavoritesOutput: Codable, Sendable {
     public struct PhotosItem: Codable, Sendable {
         public let id: String
-        public let filename: String
-        public let name: String
-        public let date: String
+        public let filename: String?
+        public let name: String?
+        public let date: String?
         public let width: Double
         public let height: Double
         public let favorite: Bool
@@ -432,8 +432,8 @@ public struct MCPListGroupMembersOutput: Codable, Sendable {
     public struct ContactsItem: Codable, Sendable {
         public let id: String
         public let name: String
-        public let email: String
-        public let phone: String
+        public let email: String?
+        public let phone: String?
     }
 
     public let group: String
@@ -469,7 +469,7 @@ public struct MCPListMessagesOutput: Codable, Sendable {
         public let id: String
         public let subject: String
         public let sender: String
-        public let dateReceived: String
+        public let dateReceived: String?
         public let read: Bool
         public let flagged: Bool
     }
@@ -500,12 +500,12 @@ public struct MCPListNotesOutput: Codable, Sendable {
 // Output type for: list_participants
 public struct MCPListParticipantsOutput: Codable, Sendable {
     public struct ParticipantsItem: Codable, Sendable {
-        public let name: String
-        public let handle: String
+        public let name: String?
+        public let handle: String?
     }
 
     public let chatId: String
-    public let chatName: String
+    public let chatName: String?
     public let participants: [ParticipantsItem]
 }
 
@@ -513,9 +513,9 @@ public struct MCPListParticipantsOutput: Codable, Sendable {
 public struct MCPListPhotosOutput: Codable, Sendable {
     public struct PhotosItem: Codable, Sendable {
         public let id: String
-        public let filename: String
-        public let name: String
-        public let date: String
+        public let filename: String?
+        public let name: String?
+        public let date: String?
         public let width: Double
         public let height: Double
         public let favorite: Bool
@@ -567,7 +567,7 @@ public struct MCPListRemindersOutput: Codable, Sendable {
         public let id: String
         public let name: String
         public let completed: Bool
-        public let dueDate: String
+        public let dueDate: String?
         public let priority: Double
         public let flagged: Bool
         public let list: String
@@ -615,12 +615,12 @@ public struct MCPListTracksOutput: Codable, Sendable {
     public struct TracksItem: Codable, Sendable {
         public let id: String
         public let name: String
-        public let artist: String
-        public let album: String
-        public let duration: String
-        public let trackNumber: String
-        public let genre: String
-        public let year: String
+        public let artist: String?
+        public let album: String?
+        public let duration: Double?
+        public let trackNumber: Double?
+        public let genre: String?
+        public let year: Double?
     }
 
     public let total: Double
@@ -681,30 +681,23 @@ public struct MCPMemoryStatsOutput: Codable, Sendable {
 
 // Output type for: now_playing
 public struct MCPNowPlayingOutput: Codable, Sendable {
+    public struct Track: Codable, Sendable {
+        public let name: String
+        public let artist: String
+        public let album: String
+        public let duration: Double
+        public let playerPosition: Double
+    }
+
     public let playerState: String
-    public let track: String
-}
-
-// Output type for: numbers_get_cell
-public struct MCPNumbersGetCellOutput: Codable, Sendable {
-    public let address: String
-    public let value: String
-    public let formattedValue: String
-}
-
-// Output type for: numbers_get_formula
-public struct MCPNumbersGetFormulaOutput: Codable, Sendable {
-    public let address: String
-    public let formula: String
-    public let value: String
-    public let formattedValue: String
+    public let track: Track?
 }
 
 // Output type for: numbers_list_documents
 public struct MCPNumbersListDocumentsOutput: Codable, Sendable {
     public struct DocumentsItem: Codable, Sendable {
         public let name: String
-        public let path: String
+        public let path: String?
         public let modified: Bool
     }
 
@@ -732,15 +725,6 @@ public struct MCPNumbersListTablesOutput: Codable, Sendable {
     public let tables: [TablesItem]
 }
 
-// Output type for: numbers_read_cells
-public struct MCPNumbersReadCellsOutput: Codable, Sendable {
-    public let rows: [[String]]
-    public let startRow: Int
-    public let startCol: Int
-    public let endRow: Int
-    public let endCol: Int
-}
-
 // Output type for: proactive_context
 public struct MCPProactiveContextOutput: Codable, Sendable {
     public struct Timecontext: Codable, Sendable {
@@ -761,14 +745,14 @@ public struct MCPProactiveContextOutput: Codable, Sendable {
 // Output type for: read_chat
 public struct MCPReadChatOutput: Codable, Sendable {
     public struct ParticipantsItem: Codable, Sendable {
-        public let name: String
-        public let handle: String
+        public let name: String?
+        public let handle: String?
     }
 
     public let id: String
-    public let name: String
+    public let name: String?
     public let participants: [ParticipantsItem]
-    public let updated: String
+    public let updated: String?
 }
 
 // Output type for: read_contact
@@ -794,10 +778,10 @@ public struct MCPReadContactOutput: Codable, Sendable {
     public let name: String
     public let firstName: String
     public let lastName: String
-    public let organization: String
-    public let jobTitle: String
-    public let department: String
-    public let note: String
+    public let organization: String?
+    public let jobTitle: String?
+    public let department: String?
+    public let note: String?
     public let emails: [EmailsItem]
     public let phones: [PhonesItem]
     public let addresses: [AddressesItem]
@@ -806,20 +790,20 @@ public struct MCPReadContactOutput: Codable, Sendable {
 // Output type for: read_event
 public struct MCPReadEventOutput: Codable, Sendable {
     public struct AttendeesItem: Codable, Sendable {
-        public let name: String
-        public let email: String
-        public let status: String
+        public let name: String?
+        public let email: String?
+        public let status: String?
     }
 
     public let id: String
     public let summary: String
-    public let description: String
-    public let location: String
+    public let description: String?
+    public let location: String?
     public let startDate: String
     public let endDate: String
     public let allDay: Bool
-    public let recurrence: String
-    public let url: String
+    public let recurrence: String?
+    public let url: String?
     public let calendar: String
     public let attendees: [AttendeesItem]
 }
@@ -827,12 +811,12 @@ public struct MCPReadEventOutput: Codable, Sendable {
 // Output type for: read_message
 public struct MCPReadMessageOutput: Codable, Sendable {
     public struct ToItem: Codable, Sendable {
-        public let name: String
-        public let address: String
+        public let name: String?
+        public let address: String?
     }
     public struct CcItem: Codable, Sendable {
-        public let name: String
-        public let address: String
+        public let name: String?
+        public let address: String?
     }
 
     public let id: String
@@ -841,7 +825,7 @@ public struct MCPReadMessageOutput: Codable, Sendable {
     public let to: [ToItem]
     public let cc: [CcItem]
     public let dateReceived: String
-    public let dateSent: String
+    public let dateSent: String?
     public let read: Bool
     public let flagged: Bool
     public let content: String
@@ -876,10 +860,10 @@ public struct MCPReadReminderOutput: Codable, Sendable {
     public let name: String
     public let body: String
     public let completed: Bool
-    public let completionDate: String
+    public let completionDate: String?
     public let creationDate: String
     public let modificationDate: String
-    public let dueDate: String
+    public let dueDate: String?
     public let priority: Double
     public let flagged: Bool
     public let list: String
@@ -919,14 +903,14 @@ public struct MCPScanNotesOutput: Codable, Sendable {
 public struct MCPSearchChatsOutput: Codable, Sendable {
     public struct ChatsItem: Codable, Sendable {
         public struct ParticipantsItem: Codable, Sendable {
-            public let name: String
-            public let handle: String
+            public let name: String?
+            public let handle: String?
         }
 
         public let id: String
-        public let name: String
+        public let name: String?
         public let participants: [ParticipantsItem]
-        public let updated: String
+        public let updated: String?
     }
 
     public let total: Double
@@ -939,9 +923,9 @@ public struct MCPSearchContactsOutput: Codable, Sendable {
     public struct ContactsItem: Codable, Sendable {
         public let id: String
         public let name: String
-        public let organization: String
-        public let email: String
-        public let phone: String
+        public let organization: String?
+        public let email: String?
+        public let phone: String?
         public let matchedField: String
     }
 
@@ -984,7 +968,7 @@ public struct MCPSearchMessagesOutput: Codable, Sendable {
         public let id: String
         public let subject: String
         public let sender: String
-        public let dateReceived: String
+        public let dateReceived: String?
         public let read: Bool
     }
 
@@ -1013,11 +997,11 @@ public struct MCPSearchNotesOutput: Codable, Sendable {
 public struct MCPSearchPhotosOutput: Codable, Sendable {
     public struct PhotosItem: Codable, Sendable {
         public let id: String
-        public let filename: String
-        public let name: String
-        public let date: String
+        public let filename: String?
+        public let name: String?
+        public let date: String?
         public let favorite: Bool
-        public let description: String
+        public let description: String?
     }
 
     public let total: Double
@@ -1030,7 +1014,7 @@ public struct MCPSearchRemindersOutput: Codable, Sendable {
         public let id: String
         public let name: String
         public let completed: Bool
-        public let dueDate: String
+        public let dueDate: String?
         public let priority: Double
         public let flagged: Bool
         public let list: String
@@ -5048,16 +5032,6 @@ public struct NumbersGetCellIntent: AppIntent {
             tool: "numbers_get_cell",
             args: ["document": document, "sheet": sheet, "cell": cell]
         )
-        guard let data = result.data(using: .utf8) else {
-            throw MCPIntentError.toolCallFailed(tool: "numbers_get_cell", message: "empty result from router")
-        }
-        let decoded = try JSONDecoder().decode(MCPNumbersGetCellOutput.self, from: data)
-        #if canImport(SwiftUI) && compiler(>=6.3)
-        if #available(macOS 26, iOS 26, *) {
-            return .result(value: result, view: MCPNumbersGetCellSnippetView(data: decoded))
-        }
-        #endif
-        _ = decoded
         return .result(value: result)
     }
 }
@@ -5085,16 +5059,6 @@ public struct NumbersGetFormulaIntent: AppIntent {
             tool: "numbers_get_formula",
             args: ["document": document, "sheet": sheet, "cell": cell]
         )
-        guard let data = result.data(using: .utf8) else {
-            throw MCPIntentError.toolCallFailed(tool: "numbers_get_formula", message: "empty result from router")
-        }
-        let decoded = try JSONDecoder().decode(MCPNumbersGetFormulaOutput.self, from: data)
-        #if canImport(SwiftUI) && compiler(>=6.3)
-        if #available(macOS 26, iOS 26, *) {
-            return .result(value: result, view: MCPNumbersGetFormulaSnippetView(data: decoded))
-        }
-        #endif
-        _ = decoded
         return .result(value: result)
     }
 }
@@ -5224,16 +5188,6 @@ public struct NumbersReadCellsIntent: AppIntent {
             tool: "numbers_read_cells",
             args: ["document": document, "sheet": sheet, "startRow": startRow, "startCol": startCol, "endRow": endRow, "endCol": endCol]
         )
-        guard let data = result.data(using: .utf8) else {
-            throw MCPIntentError.toolCallFailed(tool: "numbers_read_cells", message: "empty result from router")
-        }
-        let decoded = try JSONDecoder().decode(MCPNumbersReadCellsOutput.self, from: data)
-        #if canImport(SwiftUI) && compiler(>=6.3)
-        if #available(macOS 26, iOS 26, *) {
-            return .result(value: result, view: MCPNumbersReadCellsSnippetView(data: decoded))
-        }
-        #endif
-        _ = decoded
         return .result(value: result)
     }
 }
@@ -9306,79 +9260,6 @@ public struct MCPNowPlayingSnippetView: View {
     }
 }
 
-// Snippet view for: numbers_get_cell  (shape: scalar)
-@available(macOS 26, iOS 26, *)
-public struct MCPNumbersGetCellSnippetView: View {
-    public let data: MCPNumbersGetCellOutput
-    public init(data: MCPNumbersGetCellOutput) { self.data = data }
-    public var body: some View {
-        VStack(alignment: .leading, spacing: 2) {
-            HStack {
-                Text("Address")
-                Spacer()
-                Text(data.address)
-                    .lineLimit(1)
-                    .truncationMode(.tail)
-            }
-            HStack {
-                Text("Value")
-                Spacer()
-                Text(String(describing: data.value))
-                    .lineLimit(1)
-                    .truncationMode(.tail)
-            }
-            HStack {
-                Text("Formatted Value")
-                Spacer()
-                Text(String(describing: data.formattedValue))
-                    .lineLimit(1)
-                    .truncationMode(.tail)
-            }
-        }
-        .padding()
-    }
-}
-
-// Snippet view for: numbers_get_formula  (shape: scalar)
-@available(macOS 26, iOS 26, *)
-public struct MCPNumbersGetFormulaSnippetView: View {
-    public let data: MCPNumbersGetFormulaOutput
-    public init(data: MCPNumbersGetFormulaOutput) { self.data = data }
-    public var body: some View {
-        VStack(alignment: .leading, spacing: 2) {
-            HStack {
-                Text("Address")
-                Spacer()
-                Text(data.address)
-                    .lineLimit(1)
-                    .truncationMode(.tail)
-            }
-            HStack {
-                Text("Formula")
-                Spacer()
-                Text(String(describing: data.formula))
-                    .lineLimit(1)
-                    .truncationMode(.tail)
-            }
-            HStack {
-                Text("Value")
-                Spacer()
-                Text(String(describing: data.value))
-                    .lineLimit(1)
-                    .truncationMode(.tail)
-            }
-            HStack {
-                Text("Formatted Value")
-                Spacer()
-                Text(String(describing: data.formattedValue))
-                    .lineLimit(1)
-                    .truncationMode(.tail)
-            }
-        }
-        .padding()
-    }
-}
-
 // Snippet view for: numbers_list_documents  (shape: list-object)
 @available(macOS 26, iOS 26, *)
 public struct MCPNumbersListDocumentsSnippetView: View {
@@ -9424,53 +9305,6 @@ public struct MCPNumbersListTablesSnippetView: View {
                 Text(row.name)
                     .font(.body)
                     .lineLimit(1)
-            }
-        }
-        .padding()
-    }
-}
-
-// Snippet view for: numbers_read_cells  (shape: scalar)
-@available(macOS 26, iOS 26, *)
-public struct MCPNumbersReadCellsSnippetView: View {
-    public let data: MCPNumbersReadCellsOutput
-    public init(data: MCPNumbersReadCellsOutput) { self.data = data }
-    public var body: some View {
-        VStack(alignment: .leading, spacing: 2) {
-            HStack {
-                Text("Rows")
-                Spacer()
-                Text(String(describing: data.rows))
-                    .lineLimit(1)
-                    .truncationMode(.tail)
-            }
-            HStack {
-                Text("Start Row")
-                Spacer()
-                Text(data.startRow.formatted())
-                    .lineLimit(1)
-                    .truncationMode(.tail)
-            }
-            HStack {
-                Text("Start Col")
-                Spacer()
-                Text(data.startCol.formatted())
-                    .lineLimit(1)
-                    .truncationMode(.tail)
-            }
-            HStack {
-                Text("End Row")
-                Spacer()
-                Text(data.endRow.formatted())
-                    .lineLimit(1)
-                    .truncationMode(.tail)
-            }
-            HStack {
-                Text("End Col")
-                Spacer()
-                Text(data.endCol.formatted())
-                    .lineLimit(1)
-                    .truncationMode(.tail)
             }
         }
         .padding()

--- a/tests/app-owned-runtime-version-pin.test.js
+++ b/tests/app-owned-runtime-version-pin.test.js
@@ -29,6 +29,23 @@ describe("app-owned runtime npm package pin", () => {
     expect(onboarding).toContain("AirMcpConstants.npmPackageSpecifier");
   });
 
+  test("AppIntents prefer the token-gated app-owned HTTP runtime before stdio fallback", () => {
+    expect(appIntents).toContain("runAirMCPToolViaAppRuntime");
+    expect(appIntents).toContain("runAirMCPToolViaStdio");
+    expect(appIntents).toContain("return try await runAirMCPToolViaAppRuntime(toolName, args: args)");
+    expect(appIntents).toContain("return try await runAirMCPToolViaStdio(toolName, args: args)");
+    expect(appIntents).toContain("AppRuntimeToken.ensure()");
+    expect(appIntents).toContain("AirMcpConstants.appOwnedHttpURL");
+    expect(appIntents).toContain('request.setValue("Bearer \\(token)", forHTTPHeaderField: "Authorization")');
+    expect(appIntents).toContain('request.setValue(sessionID, forHTTPHeaderField: "Mcp-Session-Id")');
+    expect(appIntents).toContain('"application/json, text/event-stream"');
+    expect(appIntents).toContain('trimmed.hasPrefix("data:")');
+    expect(appIntents).toContain("allowsEmptyResponse: true");
+    expect(appIntents).toContain("case toolCallUncertain(Error)");
+    expect(appIntents).toContain("case .toolCallUncertain = transportError");
+    expect(appIntents).toContain("timeoutInterval: 30");
+  });
+
   test("TypeScript app-owned proxy helper uses the same pinned package specifier", () => {
     expect(config).toContain(`process.env.AIRMCP_NPM_PACKAGE_SPECIFIER || "${expectedSpecifier}"`);
   });

--- a/tests/cli-connect.test.js
+++ b/tests/cli-connect.test.js
@@ -116,6 +116,25 @@ async function request(child, reader, id, method, params = {}) {
   return reader.read((message) => message.id === id);
 }
 
+function parseStreamableHttpJson(body) {
+  try {
+    return JSON.parse(body);
+  } catch {
+    // Streamable HTTP commonly returns `text/event-stream` for JSON-RPC
+    // responses. AppIntents.swift has a tiny parser for this exact shape;
+    // keep the runtime contract behavioral here so a server transport
+    // change fails before Shortcuts/Siri does.
+    for (const line of body.split("\n")) {
+      const trimmed = line.trim();
+      if (!trimmed.startsWith("data:")) continue;
+      const payload = trimmed.slice("data:".length).trim();
+      if (!payload || payload === "[DONE]") continue;
+      return JSON.parse(payload);
+    }
+    throw new Error(`no JSON payload in Streamable HTTP response: ${body.slice(0, 200)}`);
+  }
+}
+
 afterEach(async () => {
   for (const child of children.splice(0)) {
     if (child.exitCode === null) child.kill();
@@ -144,6 +163,65 @@ describe("airmcp connect", () => {
     expect(probe.serverName).toBe("airmcp");
     expect(probe.toolCount).toBeGreaterThan(100);
     expect(probe.sampleTools.length).toBeGreaterThan(0);
+  }, 30_000);
+
+  test("manual Streamable HTTP sequence used by AppIntents returns session + SSE tool result", async () => {
+    const port = await getFreePort();
+    const token = "test-runtime-token";
+    const server = spawnAirMcp(["--http", "--port", String(port)], {
+      AIRMCP_ALLOW_NETWORK: "with-token",
+      AIRMCP_HTTP_TOKEN: token,
+    });
+    await waitForHealth(port, server);
+
+    const url = `http://127.0.0.1:${port}/mcp`;
+    const headers = {
+      "Content-Type": "application/json",
+      Accept: "application/json, text/event-stream",
+      Authorization: `Bearer ${token}`,
+    };
+    const initialized = await fetch(url, {
+      method: "POST",
+      headers,
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "initialize",
+        params: {
+          protocolVersion: "2025-03-26",
+          capabilities: {},
+          clientInfo: { name: "airmcp-appintent-http-test", version: "0" },
+        },
+      }),
+    });
+    const sessionId = initialized.headers.get("mcp-session-id");
+    expect(initialized.status).toBe(200);
+    expect(sessionId).toBeTruthy();
+    expect(parseStreamableHttpJson(await initialized.text()).result.serverInfo.name).toBe("airmcp");
+
+    const sessionHeaders = { ...headers, "Mcp-Session-Id": sessionId };
+    const notification = await fetch(url, {
+      method: "POST",
+      headers: sessionHeaders,
+      body: JSON.stringify({ jsonrpc: "2.0", method: "notifications/initialized", params: {} }),
+    });
+    expect(notification.status).toBe(202);
+    expect(await notification.text()).toBe("");
+
+    const called = await fetch(url, {
+      method: "POST",
+      headers: sessionHeaders,
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 2,
+        method: "tools/call",
+        params: { name: "discover_tools", arguments: { query: "calendar", limit: 1 } },
+      }),
+    });
+    expect(called.status).toBe(200);
+    const result = parseStreamableHttpJson(await called.text()).result;
+    expect(result.content[0].type).toBe("text");
+    expect(result.content[0].text).toContain("calendar");
   }, 30_000);
 
   test("bridges a stdio client to the token-gated app-owned HTTP runtime", async () => {

--- a/tests/codegen-helpers.test.js
+++ b/tests/codegen-helpers.test.js
@@ -27,6 +27,7 @@ import {
   wireExpr,
   isNullableUnion,
   nonNullType,
+  nonNullSchema,
   outputTypeNameFor,
   snippetViewNameFor,
   detectSnippetShape,
@@ -1137,6 +1138,38 @@ describe("isCodableSafe", () => {
     expect(isCodableSafe(null)).toBe(true);
     expect(isCodableSafe(undefined)).toBe(true);
   });
+
+  test("unconstrained schema nodes are not codable-safe", () => {
+    expect(isCodableSafe({})).toBe(false);
+    expect(
+      hasTypedOutput({
+        outputSchema: {
+          type: "object",
+          properties: { value: {} },
+          required: ["value"],
+        },
+      }),
+    ).toBe(false);
+  });
+
+  test("nullable anyOf recurses into its non-null member", () => {
+    expect(
+      isCodableSafe({
+        anyOf: [
+          {
+            type: "object",
+            properties: {},
+            additionalProperties: true,
+          },
+          { type: "null" },
+        ],
+      }),
+    ).toBe(false);
+  });
+
+  test("non-null anyOf output schemas fall back to string results", () => {
+    expect(isCodableSafe({ anyOf: [{ type: "string" }, { type: "number" }] })).toBe(false);
+  });
 });
 
 describe("swiftOutputType", () => {
@@ -1155,9 +1188,54 @@ describe("swiftOutputType", () => {
     expect(swiftOutputType({ type: ["null", "integer"] }, "Path", nested)).toBe("Int?");
   });
 
+  test("nullable anyOf adds Optional ? for required output fields", () => {
+    const nested = [];
+    expect(swiftOutputType({ anyOf: [{ type: "string" }, { type: "null" }] }, "Path", nested)).toBe("String?");
+    expect(swiftOutputType({ anyOf: [{ type: "integer" }, { type: "null" }] }, "Path", nested)).toBe("Int?");
+  });
+
+  test("nonNullSchema unwraps zod nullable anyOf without losing constraints", () => {
+    expect(
+      nonNullSchema({
+        anyOf: [
+          { type: "integer", minimum: 0, maximum: 100 },
+          { type: "null" },
+        ],
+      }),
+    ).toEqual({ type: "integer", minimum: 0, maximum: 100 });
+  });
+
   test("array wraps element type", () => {
     const nested = [];
     expect(swiftOutputType({ type: "array", items: { type: "string" } }, "Tags", nested)).toBe("[String]");
+  });
+
+  test("tuple-style homogeneous array items map to element arrays", () => {
+    const nested = [];
+    expect(
+      swiftOutputType(
+        {
+          type: "array",
+          items: [{ type: "number" }, { type: "number" }],
+        },
+        "Position",
+        nested,
+      ),
+    ).toBe("[Double]");
+  });
+
+  test("tuple-style mixed array items fall back to String element", () => {
+    const nested = [];
+    expect(
+      swiftOutputType(
+        {
+          type: "array",
+          items: [{ type: "string" }, { type: "number" }],
+        },
+        "Mixed",
+        nested,
+      ),
+    ).toBe("[String]");
   });
 
   test("array-of-object records nested struct named `<Path>Item`", () => {
@@ -1218,6 +1296,40 @@ describe("renderStruct", () => {
     // Wrong behavior would be `String??`; correct is single `?`.
     expect(swift).toContain("public let name: String?");
     expect(swift).not.toContain("String??");
+  });
+
+  test("required nullable anyOf field decodes as Optional<T>", () => {
+    const swift = renderStruct("BatteryOutput", {
+      type: "object",
+      properties: {
+        percentage: {
+          anyOf: [
+            { type: "integer", minimum: 0, maximum: 100 },
+            { type: "null" },
+          ],
+        },
+      },
+      required: ["percentage"],
+    });
+    expect(swift).toContain("public let percentage: Int?");
+    expect(swift).not.toContain("public let percentage: String");
+  });
+
+  test("required nullable tuple array field decodes as Optional<[Double]>", () => {
+    const swift = renderStruct("WindowOutput", {
+      type: "object",
+      properties: {
+        position: {
+          anyOf: [
+            { type: "array", items: [{ type: "number" }, { type: "number" }] },
+            { type: "null" },
+          ],
+        },
+      },
+      required: ["position"],
+    });
+    expect(swift).toContain("public let position: [Double]?");
+    expect(swift).not.toContain("public let position: [String]?");
   });
 
   test("nested object emits inner struct", () => {


### PR DESCRIPTION
## Summary
- Route macOS AppIntents through the token-gated app-owned HTTP runtime first, with stdio fallback only before a tool call is sent.
- Decode Streamable HTTP JSON/SSE responses and verify the manual initialize/initialized/tools-call sequence behaviorally.
- Fix AppIntent output codegen for nullable anyOf schemas and homogeneous tuple arrays; drop unsafe typed snippets for unconstrained Numbers cell values.

## Validation
- npm test
- npm run --silent typecheck
- npm run --silent mcp:validate
- npm run --silent build:mcpb:check
- npm run --silent version:check
- npm run --silent swift-build
- npm run --silent app-build
- npm run --silent lint
- npm audit --omit=dev --audit-level=moderate
