### PR TITLE
fix(security): make verification honest again

### DIFF
--- a/README.md
+++ b/README.md
@@ -848,7 +848,7 @@ Designed for AI coding agents (Claude Code, Cursor, Copilot, etc.) to invoke via
 
 ## Module Presets
 
-By default, new installations start with 5 core modules (Notes, Reminders, Calendar, Shortcuts, System) to keep things simple. You can enable more anytime:
+By default, new installations start with 7 starter modules (Notes, Reminders, Calendar, Shortcuts, System, Finder, Weather) to keep things simple. You can enable more anytime:
 
 ```bash
 # Re-run the setup wizard to change modules
@@ -964,7 +964,7 @@ swift build -c release -Xswiftc -DAIRMCP_ENABLE_FOUNDATION_MODELS
 ## Requirements
 
 - macOS
-- Node.js >= 18
+- Node.js >= 20
 - Per-app automation permissions (prompted on first run) — use `setup_permissions` tool to request all at once
 - Apple Intelligence preview: macOS 26+ with Apple Silicon and `AIRMCP_ENABLE_FOUNDATION_MODELS`
 

--- a/app/Sources/AirMCPApp/UpdateManager.swift
+++ b/app/Sources/AirMCPApp/UpdateManager.swift
@@ -48,16 +48,20 @@ final class UpdateManager {
     // MARK: - Update
 
     func performUpdate() {
-        guard !isUpdating else { return }
+        // Pin to the exact version resolved during the update check so the install
+        // can't be redirected to a newer/compromised `@latest` between check and
+        // install (TOCTOU). No availableVersion → nothing to install.
+        guard !isUpdating, let target = availableVersion else { return }
         isUpdating = true
         updateError = nil
 
         Task {
-            let success = await Self.runNpmInstall()
+            let success = await Self.runNpmInstall(version: target)
             if success {
                 availableVersion = nil
             } else {
-                updateError = "Update failed. Run manually: npm install -g airmcp@latest"
+                updateError =
+                    "Update failed. Run manually: npm install -g \(AirMcpConstants.npmPackageName)@\(target) --ignore-scripts"
             }
             isUpdating = false
         }
@@ -100,7 +104,7 @@ final class UpdateManager {
         }
     }
 
-    private nonisolated static func runNpmInstall() async -> Bool {
+    private nonisolated static func runNpmInstall(version: String) async -> Bool {
         await withCheckedContinuation { continuation in
             DispatchQueue.global().async {
                 guard let npmPath = NodeEnvironment.findExecutable(named: "npm") else {
@@ -110,7 +114,16 @@ final class UpdateManager {
 
                 let process = Process()
                 process.executableURL = URL(fileURLWithPath: npmPath)
-                process.arguments = ["install", "-g", "\(AirMcpConstants.npmPackageName)@latest"]
+                // Pinned exact version + `--ignore-scripts`: a notarized app must not
+                // auto-execute an unpinned `@latest`, nor run arbitrary npm lifecycle
+                // (pre/post-install) scripts at update time. airmcp ships a prebuilt
+                // `dist/` bin and declares no (pre|post)install script, so skipping
+                // lifecycle scripts is safe and does not break the global install.
+                process.arguments = [
+                    "install", "-g",
+                    "\(AirMcpConstants.npmPackageName)@\(version)",
+                    "--ignore-scripts",
+                ]
                 process.environment = NodeEnvironment.buildEnv()
                 process.standardOutput = FileHandle.nullDevice
                 process.standardError = FileHandle.nullDevice

--- a/docs/index.html
+++ b/docs/index.html
@@ -859,7 +859,7 @@
 <span class="opacity-40">$ </span><span class="opacity-70">npx airmcp</span></pre>
         </div>
       </div>
-      <p class="mt-6 text-xs opacity-25 reveal" data-delay="140" data-i18n="install_note">Requires Node.js 18+ and macOS. Works with Claude Code, Codex, and any MCP client.</p>
+      <p class="mt-6 text-xs opacity-25 reveal" data-delay="140" data-i18n="install_note">Requires Node.js 20+ and macOS. Works with Claude Code, Codex, and any MCP client.</p>
     </div>
   </section>
 

--- a/docs/locales/de.json
+++ b/docs/locales/de.json
@@ -150,7 +150,7 @@
   "install_label": "Installation",
   "install_title": "Start in Sekunden.",
   "install_sub": "Global installieren oder direkt mit npx ausführen.",
-  "install_note": "Erfordert Node.js 18+ und macOS. Kompatibel mit Claude Code, Codex und jedem MCP-Client.",
+  "install_note": "Erfordert Node.js 20+ und macOS. Kompatibel mit Claude Code, Codex und jedem MCP-Client.",
   "modal_try": "Ausprobieren",
   "modal_tools_label": "Werkzeuge",
   "modal_ex_notes": "\"Lies meine neuesten Notizen und fass sie zusammen\"",

--- a/docs/locales/en.json
+++ b/docs/locales/en.json
@@ -150,7 +150,7 @@
   "install_label": "Installation",
   "install_title": "Start in seconds.",
   "install_sub": "Install globally, or run directly with npx.",
-  "install_note": "Requires Node.js 18+ and macOS. Works with Claude Code, Codex, and any MCP client.",
+  "install_note": "Requires Node.js 20+ and macOS. Works with Claude Code, Codex, and any MCP client.",
   "modal_try": "Try it",
   "modal_tools_label": "Tools",
   "modal_ex_notes": "\"Read my latest notes and summarize them\"",

--- a/docs/locales/es.json
+++ b/docs/locales/es.json
@@ -150,7 +150,7 @@
   "install_label": "Instalación",
   "install_title": "Comienza en segundos.",
   "install_sub": "Instala globalmente o ejecuta directamente con npx.",
-  "install_note": "Requiere Node.js 18+ y macOS. Compatible con Claude Code, Codex y cualquier cliente MCP.",
+  "install_note": "Requiere Node.js 20+ y macOS. Compatible con Claude Code, Codex y cualquier cliente MCP.",
   "modal_try": "Pruébalo",
   "modal_tools_label": "Herramientas",
   "modal_ex_notes": "\"Lee mis últimas notas y hazme un resumen\"",

--- a/docs/locales/fr.json
+++ b/docs/locales/fr.json
@@ -150,7 +150,7 @@
   "install_label": "Installation",
   "install_title": "Démarrez en quelques secondes.",
   "install_sub": "Installez globalement ou exécutez directement avec npx.",
-  "install_note": "Nécessite Node.js 18+ et macOS. Compatible avec Claude Code, Codex et tout client MCP.",
+  "install_note": "Nécessite Node.js 20+ et macOS. Compatible avec Claude Code, Codex et tout client MCP.",
   "modal_try": "Essayez",
   "modal_tools_label": "Outils",
   "modal_ex_notes": "\"Lis mes dernières notes et fais-moi un résumé\"",

--- a/docs/locales/ja.json
+++ b/docs/locales/ja.json
@@ -150,7 +150,7 @@
   "install_label": "インストール",
   "install_title": "数秒で開始。",
   "install_sub": "グローバルインストール、またはnpxで直接実行。",
-  "install_note": "Node.js 18+とmacOSが必要です。Claude Code、Codex、あらゆるMCPクライアントに対応。",
+  "install_note": "Node.js 20+とmacOSが必要です。Claude Code、Codex、あらゆるMCPクライアントに対応。",
   "modal_try": "試してみよう",
   "modal_tools_label": "ツール一覧",
   "modal_ex_notes": "\"最新のメモを読んで要約して\"",

--- a/docs/locales/ko.json
+++ b/docs/locales/ko.json
@@ -150,7 +150,7 @@
   "install_label": "설치",
   "install_title": "몇 초면 시작.",
   "install_sub": "전역 설치하거나 npx로 바로 실행하세요.",
-  "install_note": "Node.js 18+와 macOS 필요. Claude Code, Codex 및 모든 MCP 클라이언트 지원.",
+  "install_note": "Node.js 20+와 macOS 필요. Claude Code, Codex 및 모든 MCP 클라이언트 지원.",
   "modal_try": "이렇게 말해보세요",
   "modal_tools_label": "도구 목록",
   "modal_ex_notes": "\"최근 메모를 읽고 요약해줘\"",

--- a/docs/locales/pt.json
+++ b/docs/locales/pt.json
@@ -150,7 +150,7 @@
   "install_label": "Instalação",
   "install_title": "Comece em segundos.",
   "install_sub": "Instale globalmente ou execute diretamente com npx.",
-  "install_note": "Requer Node.js 18+ e macOS. Compatível com Claude Code, Codex e qualquer cliente MCP.",
+  "install_note": "Requer Node.js 20+ e macOS. Compatível com Claude Code, Codex e qualquer cliente MCP.",
   "modal_try": "Experimente",
   "modal_tools_label": "Ferramentas",
   "modal_ex_notes": "\"Leia minhas últimas notas e faça um resumo\"",

--- a/docs/locales/zh-CN.json
+++ b/docs/locales/zh-CN.json
@@ -150,7 +150,7 @@
   "install_label": "安装",
   "install_title": "几秒即可开始。",
   "install_sub": "全局安装或通过npx直接运行。",
-  "install_note": "需要Node.js 18+和macOS。支持Claude Code、Codex及所有MCP客户端。",
+  "install_note": "需要Node.js 20+和macOS。支持Claude Code、Codex及所有MCP客户端。",
   "modal_try": "试一试",
   "modal_tools_label": "工具列表",
   "modal_ex_notes": "\"读一下我最新的备忘录，帮我总结一下\"",

--- a/docs/locales/zh-TW.json
+++ b/docs/locales/zh-TW.json
@@ -150,7 +150,7 @@
   "install_label": "安裝",
   "install_title": "幾秒即可開始。",
   "install_sub": "全域安裝或透過npx直接執行。",
-  "install_note": "需要Node.js 18+和macOS。支援Claude Code、Codex及所有MCP用戶端。",
+  "install_note": "需要Node.js 20+和macOS。支援Claude Code、Codex及所有MCP用戶端。",
   "modal_try": "試試看",
   "modal_tools_label": "工具列表",
   "modal_ex_notes": "\"讀一下我最新的備忘錄，幫我摘要\"",

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -308,7 +308,7 @@ Also check:
 
 | Error | Cause | Solution |
 |-------|-------|----------|
-| `--experimental-vm-modules is not available` | Node.js < 18 | Upgrade to Node.js >= 18 |
+| `--experimental-vm-modules is not available` | Node.js < 20 | Upgrade to Node.js >= 20 |
 | `Cannot find module '../dist/...'` | Missing build | Run `npm run build` before `npm test` |
 | `Error: Not authorized to send Apple events` | Missing Automation permission | System Settings > Privacy & Security > Automation |
 | `execution error: Application isn't running` | Target app not open | Open the app (Notes, Calendar, etc.) |

--- a/docs/tool-manifest.json
+++ b/docs/tool-manifest.json
@@ -4250,12 +4250,14 @@
             "type": "string",
             "minLength": 1,
             "maxLength": 500,
+            "pattern": "^[A-Za-z0-9][A-Za-z0-9._]*$",
             "description": "Resource (e.g. 'users.messages', 'files', 'spreadsheets.values')"
           },
           "method": {
             "type": "string",
             "minLength": 1,
             "maxLength": 64,
+            "pattern": "^[A-Za-z0-9]+$",
             "description": "Method (e.g. 'list', 'get', 'create', 'update', 'delete')"
           },
           "params": {

--- a/docs/tool-manifest.json
+++ b/docs/tool-manifest.json
@@ -3204,7 +3204,7 @@
       "annotations": {
         "readOnlyHint": true,
         "destructiveHint": false,
-        "sensitiveHint": false,
+        "sensitiveHint": true,
         "idempotentHint": true,
         "openWorldHint": false
       },
@@ -5415,7 +5415,7 @@
       "annotations": {
         "readOnlyHint": true,
         "destructiveHint": false,
-        "sensitiveHint": false,
+        "sensitiveHint": true,
         "idempotentHint": true,
         "openWorldHint": false
       },
@@ -5806,7 +5806,7 @@
       "annotations": {
         "readOnlyHint": true,
         "destructiveHint": false,
-        "sensitiveHint": false,
+        "sensitiveHint": true,
         "idempotentHint": true,
         "openWorldHint": false
       },
@@ -6175,7 +6175,7 @@
       "annotations": {
         "readOnlyHint": true,
         "destructiveHint": false,
-        "sensitiveHint": false,
+        "sensitiveHint": true,
         "idempotentHint": true,
         "openWorldHint": false
       },
@@ -6357,7 +6357,7 @@
       "annotations": {
         "readOnlyHint": true,
         "destructiveHint": false,
-        "sensitiveHint": false,
+        "sensitiveHint": true,
         "idempotentHint": true,
         "openWorldHint": false
       },
@@ -6481,7 +6481,7 @@
       "annotations": {
         "readOnlyHint": true,
         "destructiveHint": false,
-        "sensitiveHint": false,
+        "sensitiveHint": true,
         "idempotentHint": true,
         "openWorldHint": false
       },
@@ -7546,7 +7546,7 @@
       "annotations": {
         "readOnlyHint": true,
         "destructiveHint": false,
-        "sensitiveHint": false,
+        "sensitiveHint": true,
         "idempotentHint": true,
         "openWorldHint": false
       },
@@ -9203,7 +9203,7 @@
       "annotations": {
         "readOnlyHint": true,
         "destructiveHint": false,
-        "sensitiveHint": false,
+        "sensitiveHint": true,
         "idempotentHint": true,
         "openWorldHint": false
       },
@@ -9330,7 +9330,7 @@
       "annotations": {
         "readOnlyHint": true,
         "destructiveHint": false,
-        "sensitiveHint": false,
+        "sensitiveHint": true,
         "idempotentHint": true,
         "openWorldHint": false
       },
@@ -9813,7 +9813,7 @@
       "annotations": {
         "readOnlyHint": true,
         "destructiveHint": false,
-        "sensitiveHint": false,
+        "sensitiveHint": true,
         "idempotentHint": true,
         "openWorldHint": false
       },
@@ -10727,7 +10727,7 @@
       "annotations": {
         "readOnlyHint": true,
         "destructiveHint": false,
-        "sensitiveHint": false,
+        "sensitiveHint": true,
         "idempotentHint": true,
         "openWorldHint": false
       },
@@ -11141,7 +11141,7 @@
       "annotations": {
         "readOnlyHint": true,
         "destructiveHint": false,
-        "sensitiveHint": false,
+        "sensitiveHint": true,
         "idempotentHint": true,
         "openWorldHint": false
       },
@@ -11394,7 +11394,7 @@
       "annotations": {
         "readOnlyHint": true,
         "destructiveHint": false,
-        "sensitiveHint": false,
+        "sensitiveHint": true,
         "idempotentHint": true,
         "openWorldHint": false
       },
@@ -12653,7 +12653,7 @@
       "annotations": {
         "readOnlyHint": true,
         "destructiveHint": false,
-        "sensitiveHint": false,
+        "sensitiveHint": true,
         "idempotentHint": true,
         "openWorldHint": false
       },

--- a/jest.config.js
+++ b/jest.config.js
@@ -2,14 +2,15 @@
 export default {
   testEnvironment: 'node',
   transform: {},
-  // Stale git worktrees under `.claude/worktrees/*/` ship their own
-  // package.json + tests directory, which causes jest-haste-map to
-  // throw on duplicate module names (`Cannot find module 'name'`) and
-  // jest's test discovery to run pre-rebase versions of every suite.
-  // `testPathIgnorePatterns` only filters discovery; `modulePathIgnorePatterns`
-  // is what suppresses haste scanning. Both are needed.
-  testPathIgnorePatterns: ['/node_modules/', '/\\.claude/'],
-  modulePathIgnorePatterns: ['/\\.claude/'],
+  // Stale git worktrees under `.claude/worktrees/*/` and the generated
+  // `build/` bundle (build/mcpb/server/package.json) ship their own
+  // package.json, which causes jest-haste-map to throw on duplicate module
+  // names (`Cannot find module 'name'`) and jest's test discovery to run
+  // pre-rebase versions of every suite. `testPathIgnorePatterns` only filters
+  // discovery; `modulePathIgnorePatterns` is what suppresses haste scanning.
+  // Both are needed.
+  testPathIgnorePatterns: ['/node_modules/', '/\\.claude/', '/build/'],
+  modulePathIgnorePatterns: ['/\\.claude/', '/build/'],
   collectCoverageFrom: [
     'dist/**/*.js',
     '!dist/cli/**',

--- a/mcpb/manifest.template.json
+++ b/mcpb/manifest.template.json
@@ -4,7 +4,7 @@
   "display_name": "AirMCP",
   "version": "{{VERSION}}",
   "description": "{{DESCRIPTION}}",
-  "long_description": "AirMCP connects any MCP-compatible AI client to your Mac — Notes, Reminders, Calendar, Contacts, Mail, Messages, Music, Finder, Safari, Photos, System control, Apple Intelligence, and more. 270+ tools across 29 modules. Runs 100% on-device via native Swift bridges (EventKit, PhotoKit, HealthKit, Vision, Foundation Models).\n\nSafety first: HITL (human-in-the-loop) approval for sensitive actions, queryable audit log, rate limiter + emergency stop, declarative HTTP network policy.\n\niOS-ready: 228 auto-generated Apple App Intents expose AirMCP tools to Siri, Shortcuts, and Spotlight once the iOS companion ships.",
+  "long_description": "AirMCP connects any MCP-compatible AI client to your Mac — Notes, Reminders, Calendar, Contacts, Mail, Messages, Music, Finder, Safari, Photos, System control, Apple Intelligence, and more. 286 tools across 29 modules. Most tools are pure JXA and work out of the box on macOS; Swift-bridge-backed tools (HealthKit, Vision, Foundation Models, on-device semantic search) are not included in this bundle and require building the optional Swift bridge. No cloud calls unless you set a Gemini API key.\n\nSafety first: HITL (human-in-the-loop) approval for sensitive actions, queryable audit log, rate limiter + emergency stop, declarative HTTP network policy.\n\niOS-ready: 228 auto-generated Apple App Intents expose AirMCP tools to Siri, Shortcuts, and Spotlight once the iOS companion ships.",
   "author": {
     "name": "heznpc",
     "url": "https://github.com/heznpc"
@@ -62,7 +62,7 @@
     "load_all_modules": {
       "type": "boolean",
       "title": "Load all 29 modules on startup",
-      "description": "Off by default — only the 7 starter modules load (notes, calendar, reminders, contacts, mail, finder, system) to keep the surface small. Turn on to register all modules (messages, music, safari, photos, shortcuts, apple intelligence, TV, maps, weather, iWork, Google Workspace, health, bluetooth, etc.). Per-module disable can still be done via AIRMCP_DISABLE_<MODULE> env vars in advanced setups.",
+      "description": "Off by default — only the 7 starter modules load (notes, reminders, calendar, shortcuts, system, finder, weather) to keep the surface small. Turn on to register all modules (contacts, mail, messages, music, safari, photos, apple intelligence, TV, maps, iWork, Google Workspace, health, bluetooth, etc.). Per-module disable can still be done via AIRMCP_DISABLE_<MODULE> env vars in advanced setups.",
       "required": false,
       "default": false
     }

--- a/scripts/gen-swift-intents.mjs
+++ b/scripts/gen-swift-intents.mjs
@@ -54,7 +54,7 @@ import {
   enumDefaultLiteral,
   wireExpr,
   isNullableUnion,
-  nonNullType,
+  nonNullSchema,
   outputTypeNameFor,
   snippetViewNameFor,
   detectSnippetShape,
@@ -548,7 +548,7 @@ const FOLLOW_UP_MAP = {
 function renderScalarRow(key, propSchema, isRequired) {
   const ident = swiftIdent(key);
   const label = humanizeKey(key);
-  const schema = isNullableUnion(propSchema) ? { ...propSchema, type: nonNullType(propSchema) } : propSchema;
+  const schema = isNullableUnion(propSchema) ? nonNullSchema(propSchema) : propSchema;
   const isOptional = isNullableUnion(propSchema) || !isRequired;
   const accessor = `data.${ident}`;
 

--- a/src/cli/codex-mcp.ts
+++ b/src/cli/codex-mcp.ts
@@ -67,12 +67,38 @@ function sectionBody(toml: string, header: string): string {
   return body.join("\n");
 }
 
-export function codexConfigTomlRuntimeShape(toml: string): CodexConfigFileRuntimeShape {
+/** Extract the AIRMCP_HTTP_TOKEN value from a Codex `[mcp_servers.airmcp]`
+ *  block, covering BOTH the standalone `[mcp_servers.airmcp.env]` subsection
+ *  form and the inline-table `env = { AIRMCP_HTTP_TOKEN = "..." }` form.
+ *  Returns the literal token string, or null when absent. */
+function extractCodexHttpToken(serverBody: string, envBody: string): string | null {
+  // Standalone subsection: AIRMCP_HTTP_TOKEN = "value"
+  const subsection = envBody.match(/AIRMCP_HTTP_TOKEN\s*=\s*"([^"]*)"/);
+  if (subsection) return subsection[1] ?? null;
+  // Inline table on the server block: env = { ..., AIRMCP_HTTP_TOKEN = "value", ... }
+  const inline = serverBody.match(/AIRMCP_HTTP_TOKEN\s*=\s*"([^"]*)"/);
+  if (inline) return inline[1] ?? null;
+  return null;
+}
+
+/**
+ * Classify a Codex `config.toml`. When `liveToken` is provided, an app-owned
+ * proxy entry is only reported as `"app-owned"` if its stored token VALUE
+ * matches the live runtime token — a stale/wrong token falls through to
+ * `"unknown"` so the runtime repairs it. When `liveToken` is omitted the
+ * function is a pure structural parse (token presence only).
+ */
+export function codexConfigTomlRuntimeShape(toml: string, liveToken?: string): CodexConfigFileRuntimeShape {
   const server = sectionBody(toml, "[mcp_servers.airmcp]");
   if (!server) return "unknown";
   const env = sectionBody(toml, "[mcp_servers.airmcp.env]");
-  const hasToken = /AIRMCP_HTTP_TOKEN\s*=/.test(env);
-  if (server.includes(CODEX_APP_OWNED_URL) && server.includes('"connect"') && hasToken) return "app-owned";
+  const configToken = extractCodexHttpToken(server, env);
+  const hasToken = configToken !== null;
+  if (server.includes(CODEX_APP_OWNED_URL) && server.includes('"connect"') && hasToken) {
+    // Repair gate: a stale/wrong token must not pass as app-owned.
+    if (liveToken !== undefined && configToken !== liveToken) return "unknown";
+    return "app-owned";
+  }
   if (/command\s*=\s*"npx"/.test(server) && /airmcp(@|")/.test(server)) return "direct";
   return "unknown";
 }
@@ -80,7 +106,9 @@ export function codexConfigTomlRuntimeShape(toml: string): CodexConfigFileRuntim
 function codexConfigFileRuntimeShape(): CodexConfigFileRuntimeShape {
   try {
     if (!existsSync(CODEX_CONFIG_PATH)) return "unknown";
-    return codexConfigTomlRuntimeShape(readFileSync(CODEX_CONFIG_PATH, "utf8"));
+    // Pass the live runtime token so a config carrying a stale/wrong token
+    // is not classified app-owned — it falls through and gets repaired.
+    return codexConfigTomlRuntimeShape(readFileSync(CODEX_CONFIG_PATH, "utf8"), ensureAppRuntimeToken());
   } catch {
     return "unknown";
   }

--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -322,8 +322,9 @@ export async function runInit(): Promise<void> {
         "  For non-interactive setup, create the config manually:\n" +
         `    mkdir -p ${PATHS.CONFIG_DIR}\n` +
         `    echo '{}' > ${PATHS.CONFIG}\n` +
-        "  Or use the starter preset with all defaults:\n" +
-        "    AIRMCP_FULL=true npx airmcp",
+        "  Or run the default starter modules (no config needed):\n" +
+        "    npx airmcp\n" +
+        "  (set AIRMCP_FULL=true to load all modules instead)",
     );
     process.exit(1);
   }

--- a/src/google/tools.ts
+++ b/src/google/tools.ts
@@ -466,8 +466,20 @@ export function registerGoogleTools(server: McpServer, config: AirMcpConfig): vo
           .string()
           .min(1)
           .max(500)
+          // Must start alphanumeric, then only [A-Za-z0-9._]. Blocks a leading '-'
+          // (or any flag-shaped value) from being parsed as an option by the gws
+          // CLI when forwarded as a positional arg (CWE-88 argument injection).
+          .regex(
+            /^[A-Za-z0-9][A-Za-z0-9._]*$/,
+            "resource must start alphanumeric and contain only letters, digits, '.', or '_'",
+          )
           .describe("Resource (e.g. 'users.messages', 'files', 'spreadsheets.values')"),
-        method: z.string().min(1).max(64).describe("Method (e.g. 'list', 'get', 'create', 'update', 'delete')"),
+        method: z
+          .string()
+          .min(1)
+          .max(64)
+          .regex(/^[A-Za-z0-9]+$/, "method must be alphanumeric (no leading '-' / flags)")
+          .describe("Method (e.g. 'list', 'get', 'create', 'update', 'delete')"),
         params: z
           .record(z.string(), z.unknown())
           .optional()

--- a/src/mail/tools.ts
+++ b/src/mail/tools.ts
@@ -76,7 +76,13 @@ export function registerMailTools(server: McpServer, config: AirMcpConfig): void
           }),
         ),
       },
-      annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: false },
+      annotations: {
+        readOnlyHint: true,
+        destructiveHint: false,
+        sensitiveHint: true,
+        idempotentHint: true,
+        openWorldHint: false,
+      },
     },
     async ({ mailbox, account, limit, offset }) => {
       try {
@@ -121,7 +127,13 @@ export function registerMailTools(server: McpServer, config: AirMcpConfig): void
         mailbox: z.string(),
         account: z.string(),
       },
-      annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: false },
+      annotations: {
+        readOnlyHint: true,
+        destructiveHint: false,
+        sensitiveHint: true,
+        idempotentHint: true,
+        openWorldHint: false,
+      },
     },
     async ({ id, maxLength }) => {
       try {
@@ -154,7 +166,13 @@ export function registerMailTools(server: McpServer, config: AirMcpConfig): void
           }),
         ),
       },
-      annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: false },
+      annotations: {
+        readOnlyHint: true,
+        destructiveHint: false,
+        sensitiveHint: true,
+        idempotentHint: true,
+        openWorldHint: false,
+      },
     },
     async ({ query, mailbox, limit }) => {
       try {

--- a/src/memory/tools.ts
+++ b/src/memory/tools.ts
@@ -105,6 +105,7 @@ export function registerMemoryTools(server: McpServer, _config: AirMcpConfig): v
       annotations: {
         readOnlyHint: true,
         destructiveHint: false,
+        sensitiveHint: true,
         idempotentHint: true,
         openWorldHint: false,
       },

--- a/src/messages/tools.ts
+++ b/src/messages/tools.ts
@@ -84,7 +84,13 @@ export function registerMessagesTools(server: McpServer, config: AirMcpConfig): 
         limit: z.number().int().min(1).max(200).optional().default(50).describe("Max chats to return (default: 50)"),
       },
       outputSchema: chatListShape,
-      annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: false },
+      annotations: {
+        readOnlyHint: true,
+        destructiveHint: false,
+        sensitiveHint: true,
+        idempotentHint: true,
+        openWorldHint: false,
+      },
     },
     async ({ limit }) => {
       try {
@@ -104,7 +110,13 @@ export function registerMessagesTools(server: McpServer, config: AirMcpConfig): 
         chatId: z.string().max(500).describe("Chat ID"),
       },
       outputSchema: chatSchema.shape,
-      annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: false },
+      annotations: {
+        readOnlyHint: true,
+        destructiveHint: false,
+        sensitiveHint: true,
+        idempotentHint: true,
+        openWorldHint: false,
+      },
     },
     async ({ chatId }) => {
       try {
@@ -125,7 +137,13 @@ export function registerMessagesTools(server: McpServer, config: AirMcpConfig): 
         limit: z.number().int().min(1).max(100).optional().default(20).describe("Max results (default: 20)"),
       },
       outputSchema: chatListShape,
-      annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: false },
+      annotations: {
+        readOnlyHint: true,
+        destructiveHint: false,
+        sensitiveHint: true,
+        idempotentHint: true,
+        openWorldHint: false,
+      },
     },
     async ({ query, limit }) => {
       try {
@@ -203,7 +221,13 @@ export function registerMessagesTools(server: McpServer, config: AirMcpConfig): 
         chatId: z.string().max(500).describe("Chat ID"),
       },
       outputSchema: listParticipantsShape,
-      annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: false },
+      annotations: {
+        readOnlyHint: true,
+        destructiveHint: false,
+        sensitiveHint: true,
+        idempotentHint: true,
+        openWorldHint: false,
+      },
     },
     async ({ chatId }) => {
       try {

--- a/src/photos/tools.ts
+++ b/src/photos/tools.ts
@@ -147,7 +147,13 @@ export function registerPhotosTools(server: McpServer, _config: AirMcpConfig): v
           }),
         ),
       },
-      annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: false },
+      annotations: {
+        readOnlyHint: true,
+        destructiveHint: false,
+        sensitiveHint: true,
+        idempotentHint: true,
+        openWorldHint: false,
+      },
     },
     async ({ album, limit, offset }) => {
       try {
@@ -187,7 +193,13 @@ export function registerPhotosTools(server: McpServer, _config: AirMcpConfig): v
           }),
         ),
       },
-      annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: false },
+      annotations: {
+        readOnlyHint: true,
+        destructiveHint: false,
+        sensitiveHint: true,
+        idempotentHint: true,
+        openWorldHint: false,
+      },
     },
     async ({ query, limit }) => {
       try {
@@ -228,7 +240,13 @@ export function registerPhotosTools(server: McpServer, _config: AirMcpConfig): v
         favorite: z.boolean(),
         keywords: z.array(z.string()).nullable(),
       },
-      annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: false },
+      annotations: {
+        readOnlyHint: true,
+        destructiveHint: false,
+        sensitiveHint: true,
+        idempotentHint: true,
+        openWorldHint: false,
+      },
     },
     async ({ id }) => {
       try {
@@ -269,7 +287,13 @@ export function registerPhotosTools(server: McpServer, _config: AirMcpConfig): v
           }),
         ),
       },
-      annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: false },
+      annotations: {
+        readOnlyHint: true,
+        destructiveHint: false,
+        sensitiveHint: true,
+        idempotentHint: true,
+        openWorldHint: false,
+      },
     },
     async ({ limit }) => {
       try {
@@ -423,7 +447,13 @@ export function registerPhotosTools(server: McpServer, _config: AirMcpConfig): v
         favorites: z.boolean().optional().describe("Only favorites"),
         limit: z.number().int().min(1).max(200).optional().default(50).describe("Max results (default: 50)"),
       },
-      annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: false },
+      annotations: {
+        readOnlyHint: true,
+        destructiveHint: false,
+        sensitiveHint: true,
+        idempotentHint: true,
+        openWorldHint: false,
+      },
     },
     async ({ mediaType, startDate, endDate, favorites, limit }) => {
       try {

--- a/src/server/http-transport.ts
+++ b/src/server/http-transport.ts
@@ -466,29 +466,35 @@ export async function startHttpServer(options: HttpServerOptions): Promise<NodeH
   // enabled-module list via closure so it reflects the live module
   // selection once `createServer` runs (depends on config + OS gates).
   let enabledModuleNames: string[] = [];
+  // True until the background warmup resolves the live module list. While
+  // false the module list is not yet known, so the discovery card must NOT
+  // claim `modules: []` — it advertises a `warming` status instead so a
+  // crawler hitting the warmup window can distinguish "no modules" from
+  // "not resolved yet". Tools are read live from toolRegistry and stay valid.
+  let modulesWarming = true;
   app.get("/.well-known/mcp.json", (_req, res) => {
-    res.json(
-      buildServerCard({
-        name: NPM_PACKAGE_NAME,
-        version: pkg.version,
-        description: pkg.description,
-        license: pkg.license,
-        homepage: pkg.homepage,
-        websiteUrl: WEBSITE_URL,
-        icon: SERVER_ICON,
-        httpToken,
-        allowNetwork,
-        allowedOrigins: [...allowedOrigins],
-        // Read tool inventory at request time so a hot-reload or a
-        // later `listChanged` notification doesn't leave the card stale.
-        tools: {
-          count: toolRegistry.getToolCount(),
-          names: toolRegistry.getToolNames(),
-        },
-        modules: enabledModuleNames,
-        oauth: oauth ?? undefined,
-      }),
-    );
+    const card = buildServerCard({
+      name: NPM_PACKAGE_NAME,
+      version: pkg.version,
+      description: pkg.description,
+      license: pkg.license,
+      homepage: pkg.homepage,
+      websiteUrl: WEBSITE_URL,
+      icon: SERVER_ICON,
+      httpToken,
+      allowNetwork,
+      allowedOrigins: [...allowedOrigins],
+      // Read tool inventory at request time so a hot-reload or a
+      // later `listChanged` notification doesn't leave the card stale.
+      tools: {
+        count: toolRegistry.getToolCount(),
+        names: toolRegistry.getToolNames(),
+      },
+      modules: enabledModuleNames,
+      oauth: oauth ?? undefined,
+    });
+    if (modulesWarming) card.warming = true;
+    res.json(card);
   });
 
   // RFC 9728 — OAuth protected resource metadata. Emitted only when
@@ -670,7 +676,6 @@ export async function startHttpServer(options: HttpServerOptions): Promise<NodeH
   // probes can distinguish "socket is up" from "module warmup is still busy".
   // First real MCP sessions still create their own server instance; prewarm is
   // only a cache/discovery optimization.
-  let bannerPrinted = false;
   const warmupPromise = (async () => {
     const {
       bannerInfo: bi,
@@ -683,6 +688,7 @@ export async function startHttpServer(options: HttpServerOptions): Promise<NodeH
     // card's closure so registry crawlers see what's actually loaded
     // on this host (module enablement depends on config + OS gates).
     enabledModuleNames = bi.modulesEnabled;
+    modulesWarming = false;
     return bi;
   })();
   const host = bindAll ? "0.0.0.0" : "127.0.0.1";
@@ -711,8 +717,6 @@ export async function startHttpServer(options: HttpServerOptions): Promise<NodeH
   });
   void warmupPromise
     .then(async (bi) => {
-      if (bannerPrinted) return;
-      bannerPrinted = true;
       const address = httpServer.address();
       bi.transport = "http";
       bi.port = address && typeof address !== "string" ? address.port : port;

--- a/src/shared/audit.ts
+++ b/src/shared/audit.ts
@@ -136,7 +136,10 @@ let flushTimer: ReturnType<typeof setTimeout> | null = null;
 
 async function ensureDir(): Promise<void> {
   if (initialized) return;
-  await mkdir(PATHS.VECTOR_STORE, { recursive: true });
+  // 0o700: the audit dir holds audit.jsonl + audit.checkpoint. Files are already
+  // 0600, but match the sibling app-runtime-token dir's owner-only mode so other
+  // local users can't even enumerate audit filenames / rotation timestamps.
+  await mkdir(PATHS.VECTOR_STORE, { recursive: true, mode: 0o700 });
   initialized = true;
 }
 

--- a/src/shared/esc.ts
+++ b/src/shared/esc.ts
@@ -24,9 +24,12 @@ export function escAS(str: string): string {
     .replace(/"/g, '\\"')
     .replace(/\n/g, "\\n")
     .replace(/\r/g, "\\r")
-    .replace(/\t/g, "\\t")
-    .replace(/\u2028/g, "\\u2028")
-    .replace(/\u2029/g, "\\u2029");
+    .replace(/\t/g, "\\t");
+  // U+2028/U+2029 are intentionally NOT escaped for AppleScript. Unlike JS/JXA,
+  // AppleScript has no `\u` escape, so emitting "\u2028" produces an un-parseable
+  // token (osascript compile error -2741) and the send silently fails. Raw LS/PS
+  // are ordinary characters inside an AppleScript double-quoted literal \u2014 they do
+  // not terminate the string \u2014 so they pass through safely.
 }
 
 /** Escape a string for safe interpolation inside shell double-quoted arguments via doShellScript. */

--- a/src/shared/hitl-guard.ts
+++ b/src/shared/hitl-guard.ts
@@ -59,7 +59,13 @@ function isManagedClient(server: McpServer): boolean {
   }
 }
 
-function shouldRequireApproval(
+/**
+ * Pure gating predicate: does a tool with these annotations require HITL
+ * approval at the given level? Exported so tests can lock the monotonic
+ * ordering off ⊆ destructive-only ⊆ sensitive-only ⊆ all-writes ⊆ all
+ * (review finding #3/#5). No side effects.
+ */
+export function shouldRequireApproval(
   level: HitlLevel,
   annotations: ToolAnnotations,
   whitelist: Set<string>,
@@ -74,7 +80,15 @@ function shouldRequireApproval(
     case "sensitive-only":
       return annotations.destructiveHint === true || annotations.sensitiveHint === true;
     case "all-writes":
-      return annotations.readOnlyHint === false;
+      // Must be a superset of "sensitive-only": the init wizard presents
+      // Recommended(sensitive-only) then Strict(all-writes) as increasing
+      // strictness, so anything sensitive-only gates must also gate here.
+      // Plain `readOnlyHint === false` missed sensitive-but-readonly tools
+      // (health_*, get_clipboard, capture_screen, ui_read) which carry
+      // readOnlyHint: true + sensitiveHint: true — breaking monotonicity.
+      return (
+        annotations.readOnlyHint === false || annotations.destructiveHint === true || annotations.sensitiveHint === true
+      );
     case "all":
       return true;
   }

--- a/src/shared/privacy-sensitive-tools.ts
+++ b/src/shared/privacy-sensitive-tools.ts
@@ -1,0 +1,97 @@
+/**
+ * Single source of truth for privacy-sensitive READ classification.
+ *
+ * A "privacy readout" is a read-only tool that returns private user data
+ * crossing a privacy boundary — clipboard contents, mail/message content,
+ * chat participants (phone/email handles), photo content + EXIF GPS,
+ * HealthKit data, precise location, the personal memory store, and the
+ * screen / accessibility tree. These must carry `sensitiveHint: true` so
+ * they gate under the default `sensitive-only` HITL level.
+ *
+ * WHY THIS FILE EXISTS — drift control. Per-file annotation edits
+ * repeatedly missed siblings (smart_clipboard, memory_query, the mail /
+ * photo / chat readers) because the privacy-readout list lived as a
+ * hand-maintained array in one test and was sampled, not derived.
+ * Centralizing here + the drift-guard tests in
+ * tests/safety-annotations.test.js closes that gap:
+ *   - forward:    every name here that is registered must be gated;
+ *   - reverse:    every registered read-only + sensitive tool must be here
+ *                 (so a new sensitive read cannot be added without landing
+ *                 in this list);
+ *   - anti-drift: any registered read-only tool whose NAME matches an
+ *                 obvious privacy pattern below must be here (so a new
+ *                 clipboard / photo / health / message reader added
+ *                 unmarked fails CI — the smart_clipboard miss).
+ *
+ * This set is intended to also back the OAuth scope gate once the
+ * sensitive→scope propagation (review finding #6) is ratified.
+ */
+export const PRIVACY_READOUT_TOOLS: ReadonlySet<string> = new Set([
+  // clipboard
+  "get_clipboard",
+  "smart_clipboard",
+  // screen / windows / accessibility tree
+  "list_all_windows",
+  "list_windows",
+  "ui_read",
+  "ui_traverse",
+  "ui_diff",
+  "ui_accessibility_query",
+  // health (HealthKit reads; registered only where HealthKit is available)
+  "health_summary",
+  "health_today_steps",
+  "health_heart_rate",
+  "health_sleep",
+  // precise location
+  "get_current_location",
+  // personal memory store
+  "memory_query",
+  // mail content
+  "read_message",
+  "search_messages",
+  "list_messages",
+  // photos: content + EXIF GPS
+  "get_photo_info",
+  "search_photos",
+  "list_photos",
+  "list_favorites",
+  "query_photos",
+  // messages: chat metadata / participant handles (PII / social graph)
+  "list_chats",
+  "read_chat",
+  "search_chats",
+  "list_participants",
+]);
+
+/**
+ * Tight name patterns for the anti-drift guard. The test asserts every
+ * registered READ-ONLY tool whose name matches one of these is present in
+ * PRIVACY_READOUT_TOOLS (i.e. curated + gated). A new clipboard / photo /
+ * health / location / mail / chat reader added unmarked therefore fails.
+ *
+ * Deliberately NOT exhaustive — non-obvious readers (memory_query, the ui_*
+ * tree) are covered by the explicit set above, and benign read-only tools
+ * (memory_stats, get_screen_info) must NOT match here. Keep patterns
+ * specific enough that the matched set stays a subset of PRIVACY_READOUT_TOOLS.
+ */
+export const PRIVACY_READOUT_NAME_PATTERNS: readonly RegExp[] = [
+  /clipboard/i,
+  /photo/i,
+  /(^|_)location(_|$)/i,
+  /(^|_)health_/i,
+  /(^|_)(message|messages|chat|chats|participant|participants)(_|$)/i,
+  /(^|_)(all_)?windows?(_|$)/i,
+  /^ui_(read|traverse|diff|accessibility)/i,
+];
+
+/**
+ * Read-only tools whose NAME matches a privacy pattern above but which are
+ * confirmed NOT privacy readouts — keeping the patterns broad (good
+ * anti-drift coverage) without false-positive failures. Each entry needs a
+ * one-line justification; do not add a tool here to silence a real gap.
+ */
+export const PRIVACY_PATTERN_EXEMPT: ReadonlySet<string> = new Set([
+  "ai_chat", // FoundationModels chat completion — not the Messages chat store
+  "share_location", // formats an Apple Maps URL from caller-supplied coords; reads nothing
+  "get_location_permission", // returns the CoreLocation authorization flag, not a location
+]);

--- a/src/speech/tools.ts
+++ b/src/speech/tools.ts
@@ -76,7 +76,13 @@ export function registerSpeechTools(server: McpServer, _config: AirMcpConfig): v
       description:
         "Get clipboard content with automatic type detection (text, URL, email, phone, date, file path, image). More structured than raw clipboard access.",
       inputSchema: {},
-      annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: false },
+      annotations: {
+        readOnlyHint: true,
+        destructiveHint: false,
+        sensitiveHint: true,
+        idempotentHint: true,
+        openWorldHint: false,
+      },
     },
     async () => {
       const bridgeErr = await checkSwiftBridge();

--- a/swift/Sources/AirMCPKit/Generated/MCPIntents.swift
+++ b/swift/Sources/AirMCPKit/Generated/MCPIntents.swift
@@ -2867,6 +2867,7 @@ public struct GetLocationPermissionIntent: AppIntent {
 }
 
 // Tool: get_photo_info
+@available(iOS 18, macOS 15, *)
 public struct GetPhotoInfoIntent: AppIntent {
     nonisolated(unsafe) public static var title: LocalizedStringResource = "Get Photo Info"
     nonisolated(unsafe) public static var description = IntentDescription("Get detailed metadata for a specific photo by ID.")
@@ -2879,6 +2880,10 @@ public struct GetPhotoInfoIntent: AppIntent {
 
     @MainActor
     public func perform() async throws -> some IntentResult & ReturnsValue<String> {
+        try await requestConfirmation(
+            actionName: .go,
+            dialog: IntentDialog("Get Photo Info with AirMCP? Get detailed metadata for a specific photo by ID.")
+        )
         let result = try await MCPIntentRouter.shared.call(
             tool: "get_photo_info",
             args: ["id": id]
@@ -3848,6 +3853,7 @@ public struct ListCalendarsIntent: AppIntent {
 }
 
 // Tool: list_chats
+@available(iOS 18, macOS 15, *)
 public struct ListChatsIntent: AppIntent {
     nonisolated(unsafe) public static var title: LocalizedStringResource = "List Chats"
     nonisolated(unsafe) public static var description = IntentDescription("List recent chats in Messages with participants and last update time.")
@@ -3860,6 +3866,10 @@ public struct ListChatsIntent: AppIntent {
 
     @MainActor
     public func perform() async throws -> some IntentResult & ReturnsValue<String> {
+        try await requestConfirmation(
+            actionName: .go,
+            dialog: IntentDialog("List Chats with AirMCP? List recent chats in Messages with participants and last update time.")
+        )
         let result = try await MCPIntentRouter.shared.call(
             tool: "list_chats",
             args: ["limit": limit]
@@ -3996,6 +4006,7 @@ public struct ListEventsIntent: AppIntent {
 }
 
 // Tool: list_favorites
+@available(iOS 18, macOS 15, *)
 public struct ListFavoritesIntent: AppIntent {
     nonisolated(unsafe) public static var title: LocalizedStringResource = "List Favorite Photos"
     nonisolated(unsafe) public static var description = IntentDescription("List photos marked as favorites.")
@@ -4008,6 +4019,10 @@ public struct ListFavoritesIntent: AppIntent {
 
     @MainActor
     public func perform() async throws -> some IntentResult & ReturnsValue<String> {
+        try await requestConfirmation(
+            actionName: .go,
+            dialog: IntentDialog("List Favorite Photos with AirMCP? List photos marked as favorites.")
+        )
         let result = try await MCPIntentRouter.shared.call(
             tool: "list_favorites",
             args: ["limit": limit]
@@ -4145,6 +4160,7 @@ public struct ListMailboxesIntent: AppIntent {
 }
 
 // Tool: list_messages
+@available(iOS 18, macOS 15, *)
 public struct ListMessagesIntent: AppIntent {
     nonisolated(unsafe) public static var title: LocalizedStringResource = "List Messages"
     nonisolated(unsafe) public static var description = IntentDescription("List recent messages in a mailbox (e.g. 'INBOX'). Returns subject, sender, date, read status.")
@@ -4171,6 +4187,10 @@ public struct ListMessagesIntent: AppIntent {
         if let v = account { args["account"] = v }
         args["limit"] = limit
         args["offset"] = offset
+        try await requestConfirmation(
+            actionName: .go,
+            dialog: IntentDialog("List Messages with AirMCP? List recent messages in a mailbox (e.g. 'INBOX'). Returns subject, sender, date, read status.")
+        )
         let result = try await MCPIntentRouter.shared.call(
             tool: "list_messages",
             args: args
@@ -4231,6 +4251,7 @@ public struct ListNotesIntent: AppIntent {
 }
 
 // Tool: list_participants
+@available(iOS 18, macOS 15, *)
 public struct ListParticipantsIntent: AppIntent {
     nonisolated(unsafe) public static var title: LocalizedStringResource = "List Chat Participants"
     nonisolated(unsafe) public static var description = IntentDescription("List all participants in a specific chat.")
@@ -4243,6 +4264,10 @@ public struct ListParticipantsIntent: AppIntent {
 
     @MainActor
     public func perform() async throws -> some IntentResult & ReturnsValue<String> {
+        try await requestConfirmation(
+            actionName: .go,
+            dialog: IntentDialog("List Chat Participants with AirMCP? List all participants in a specific chat.")
+        )
         let result = try await MCPIntentRouter.shared.call(
             tool: "list_participants",
             args: ["chatId": chatId]
@@ -4262,6 +4287,7 @@ public struct ListParticipantsIntent: AppIntent {
 }
 
 // Tool: list_photos
+@available(iOS 18, macOS 15, *)
 public struct ListPhotosIntent: AppIntent {
     nonisolated(unsafe) public static var title: LocalizedStringResource = "List Photos"
     nonisolated(unsafe) public static var description = IntentDescription("List photos in an album with metadata. Use list_albums to find album names first.")
@@ -4280,6 +4306,10 @@ public struct ListPhotosIntent: AppIntent {
 
     @MainActor
     public func perform() async throws -> some IntentResult & ReturnsValue<String> {
+        try await requestConfirmation(
+            actionName: .go,
+            dialog: IntentDialog("List Photos with AirMCP? List photos in an album with metadata. Use list_albums to find album names first.")
+        )
         let result = try await MCPIntentRouter.shared.call(
             tool: "list_photos",
             args: ["album": album, "limit": limit, "offset": offset]
@@ -4769,6 +4799,7 @@ public struct MemoryPutIntent: AppIntent {
 }
 
 // Tool: memory_query
+@available(iOS 18, macOS 15, *)
 public struct MemoryQueryIntent: AppIntent {
     nonisolated(unsafe) public static var title: LocalizedStringResource = "Query Context Memory"
     nonisolated(unsafe) public static var description = IntentDescription("List non-expired memory entries. All filters are AND-combined. Returns entries sorted by `updatedAt` descending by default. Safe read-only — use before composing LLM prompts so recent user-supplied context is recalled.")
@@ -4799,6 +4830,10 @@ public struct MemoryQueryIntent: AppIntent {
         if let v = tags { args["tags"] = v }
         if let v = limit { args["limit"] = v }
         if let v = order { args["order"] = v.rawValue }
+        try await requestConfirmation(
+            actionName: .go,
+            dialog: IntentDialog("Query Context Memory with AirMCP? List non-expired memory entries. All filters are AND-combined. Returns entries sorted by `updatedAt` descending by default. Safe read-only — use before composing LLM prompts so recent…")
+        )
         let result = try await MCPIntentRouter.shared.call(
             tool: "memory_query",
             args: args
@@ -5575,6 +5610,7 @@ public struct ProofreadTextIntent: AppIntent {
 }
 
 // Tool: query_photos
+@available(iOS 18, macOS 15, *)
 public struct QueryPhotosIntent: AppIntent {
     nonisolated(unsafe) public static var title: LocalizedStringResource = "Query Photos"
     nonisolated(unsafe) public static var description = IntentDescription("Query the Photos library with filters: media type, date range, favorites. Returns photo metadata (identifier, filename, date, dimensions). Requires Swift bridge.")
@@ -5605,6 +5641,10 @@ public struct QueryPhotosIntent: AppIntent {
         if let v = endDate { args["endDate"] = v }
         if let v = favorites { args["favorites"] = v }
         args["limit"] = limit
+        try await requestConfirmation(
+            actionName: .go,
+            dialog: IntentDialog("Query Photos with AirMCP? Query the Photos library with filters: media type, date range, favorites. Returns photo metadata (identifier, filename, date, dimensions). Requires Swift bridge.")
+        )
         let result = try await MCPIntentRouter.shared.call(
             tool: "query_photos",
             args: args
@@ -5614,6 +5654,7 @@ public struct QueryPhotosIntent: AppIntent {
 }
 
 // Tool: read_chat
+@available(iOS 18, macOS 15, *)
 public struct ReadChatIntent: AppIntent {
     nonisolated(unsafe) public static var title: LocalizedStringResource = "Read Chat"
     nonisolated(unsafe) public static var description = IntentDescription("Read chat details including participants and last update time by chat ID.")
@@ -5626,6 +5667,10 @@ public struct ReadChatIntent: AppIntent {
 
     @MainActor
     public func perform() async throws -> some IntentResult & ReturnsValue<String> {
+        try await requestConfirmation(
+            actionName: .go,
+            dialog: IntentDialog("Read Chat with AirMCP? Read chat details including participants and last update time by chat ID.")
+        )
         let result = try await MCPIntentRouter.shared.call(
             tool: "read_chat",
             args: ["chatId": chatId]
@@ -5707,6 +5752,7 @@ public struct ReadEventIntent: AppIntent {
 }
 
 // Tool: read_message
+@available(iOS 18, macOS 15, *)
 public struct ReadMessageIntent: AppIntent {
     nonisolated(unsafe) public static var title: LocalizedStringResource = "Read Message"
     nonisolated(unsafe) public static var description = IntentDescription("Read full content of an email message by ID. Content length is configurable (default: 5000 chars, max: 100000).")
@@ -5722,6 +5768,10 @@ public struct ReadMessageIntent: AppIntent {
 
     @MainActor
     public func perform() async throws -> some IntentResult & ReturnsValue<String> {
+        try await requestConfirmation(
+            actionName: .go,
+            dialog: IntentDialog("Read Message with AirMCP? Read full content of an email message by ID. Content length is configurable (default: 5000 chars, max: 100000).")
+        )
         let result = try await MCPIntentRouter.shared.call(
             tool: "read_message",
             args: ["id": id, "maxLength": maxLength]
@@ -6051,6 +6101,7 @@ public struct ScanNotesIntent: AppIntent {
 }
 
 // Tool: search_chats
+@available(iOS 18, macOS 15, *)
 public struct SearchChatsIntent: AppIntent {
     nonisolated(unsafe) public static var title: LocalizedStringResource = "Search Chats"
     nonisolated(unsafe) public static var description = IntentDescription("Search chats by participant name, handle, or chat name.")
@@ -6066,6 +6117,10 @@ public struct SearchChatsIntent: AppIntent {
 
     @MainActor
     public func perform() async throws -> some IntentResult & ReturnsValue<String> {
+        try await requestConfirmation(
+            actionName: .go,
+            dialog: IntentDialog("Search Chats with AirMCP? Search chats by participant name, handle, or chat name.")
+        )
         let result = try await MCPIntentRouter.shared.call(
             tool: "search_chats",
             args: ["query": query, "limit": limit]
@@ -6221,6 +6276,7 @@ public struct SearchLocationIntent: AppIntent {
 }
 
 // Tool: search_messages
+@available(iOS 18, macOS 15, *)
 public struct SearchMessagesIntent: AppIntent {
     nonisolated(unsafe) public static var title: LocalizedStringResource = "Search Messages"
     nonisolated(unsafe) public static var description = IntentDescription("Search messages by keyword in subject or sender within a mailbox.")
@@ -6239,6 +6295,10 @@ public struct SearchMessagesIntent: AppIntent {
 
     @MainActor
     public func perform() async throws -> some IntentResult & ReturnsValue<String> {
+        try await requestConfirmation(
+            actionName: .go,
+            dialog: IntentDialog("Search Messages with AirMCP? Search messages by keyword in subject or sender within a mailbox.")
+        )
         let result = try await MCPIntentRouter.shared.call(
             tool: "search_messages",
             args: ["query": query, "mailbox": mailbox, "limit": limit]
@@ -6326,6 +6386,7 @@ public struct SearchNotesIntent: AppIntent {
 }
 
 // Tool: search_photos
+@available(iOS 18, macOS 15, *)
 public struct SearchPhotosIntent: AppIntent {
     nonisolated(unsafe) public static var title: LocalizedStringResource = "Search Photos"
     nonisolated(unsafe) public static var description = IntentDescription("Search photos by filename, name, or description keyword.")
@@ -6341,6 +6402,10 @@ public struct SearchPhotosIntent: AppIntent {
 
     @MainActor
     public func perform() async throws -> some IntentResult & ReturnsValue<String> {
+        try await requestConfirmation(
+            actionName: .go,
+            dialog: IntentDialog("Search Photos with AirMCP? Search photos by filename, name, or description keyword.")
+        )
         let result = try await MCPIntentRouter.shared.call(
             tool: "search_photos",
             args: ["query": query, "limit": limit]
@@ -7080,6 +7145,7 @@ public struct SkillSenderToTasksIntent: AppIntent {
 }
 
 // Tool: smart_clipboard
+@available(iOS 18, macOS 15, *)
 public struct SmartClipboardIntent: AppIntent {
     nonisolated(unsafe) public static var title: LocalizedStringResource = "Smart Clipboard"
     nonisolated(unsafe) public static var description = IntentDescription("Get clipboard content with automatic type detection (text, URL, email, phone, date, file path, image). More structured than raw clipboard access.")
@@ -7089,6 +7155,10 @@ public struct SmartClipboardIntent: AppIntent {
 
     @MainActor
     public func perform() async throws -> some IntentResult & ReturnsValue<String> {
+        try await requestConfirmation(
+            actionName: .go,
+            dialog: IntentDialog("Smart Clipboard with AirMCP? Get clipboard content with automatic type detection (text, URL, email, phone, date, file path, image). More structured than raw clipboard access.")
+        )
         let result = try await MCPIntentRouter.shared.call(
             tool: "smart_clipboard",
             args: [String: any Sendable]()
@@ -7935,7 +8005,7 @@ public struct MCPGetBatteryStatusSnippetView: View {
             HStack {
                 Text("Percentage")
                 Spacer()
-                Text(String(describing: data.percentage))
+                Text((data.percentage?.formatted() ?? "—"))
                     .lineLimit(1)
                     .truncationMode(.tail)
             }
@@ -7949,14 +8019,14 @@ public struct MCPGetBatteryStatusSnippetView: View {
             HStack {
                 Text("Source")
                 Spacer()
-                Text(String(describing: data.source))
+                Text((data.source ?? "—"))
                     .lineLimit(1)
                     .truncationMode(.tail)
             }
             HStack {
                 Text("Time Remaining")
                 Spacer()
-                Text(String(describing: data.timeRemaining))
+                Text((data.timeRemaining ?? "—"))
                     .lineLimit(1)
                     .truncationMode(.tail)
             }
@@ -7982,7 +8052,7 @@ public struct MCPGetBrightnessSnippetView: View {
             HStack {
                 Text("Brightness")
                 Spacer()
-                Text(String(describing: data.brightness))
+                Text((data.brightness?.formatted() ?? "—"))
                     .lineLimit(1)
                     .truncationMode(.tail)
             }
@@ -8206,28 +8276,28 @@ public struct MCPGetPhotoInfoSnippetView: View {
             HStack {
                 Text("Filename")
                 Spacer()
-                Text(String(describing: data.filename))
+                Text((data.filename ?? "—"))
                     .lineLimit(1)
                     .truncationMode(.tail)
             }
             HStack {
                 Text("Name")
                 Spacer()
-                Text(String(describing: data.name))
+                Text((data.name ?? "—"))
                     .lineLimit(1)
                     .truncationMode(.tail)
             }
             HStack {
                 Text("Description")
                 Spacer()
-                Text(String(describing: data.description))
+                Text((data.description ?? "—"))
                     .lineLimit(1)
                     .truncationMode(.tail)
             }
             HStack {
                 Text("Date")
                 Spacer()
-                Text(String(describing: data.date))
+                Text((data.date ?? "—"))
                     .lineLimit(1)
                     .truncationMode(.tail)
             }
@@ -8248,7 +8318,7 @@ public struct MCPGetPhotoInfoSnippetView: View {
             HStack {
                 Text("Altitude")
                 Spacer()
-                Text(String(describing: data.altitude))
+                Text((data.altitude?.formatted() ?? "—"))
                     .lineLimit(1)
                     .truncationMode(.tail)
             }
@@ -8476,7 +8546,7 @@ public struct MCPGetTrackInfoSnippetView: View {
             HStack {
                 Text("Date Added")
                 Spacer()
-                Text(String(describing: data.dateAdded))
+                Text((data.dateAdded ?? "—"))
                     .lineLimit(1)
                     .truncationMode(.tail)
             }
@@ -8586,35 +8656,35 @@ public struct MCPGetWifiStatusSnippetView: View {
             HStack {
                 Text("Ssid")
                 Spacer()
-                Text(String(describing: data.ssid))
+                Text((data.ssid ?? "—"))
                     .lineLimit(1)
                     .truncationMode(.tail)
             }
             HStack {
                 Text("Bssid")
                 Spacer()
-                Text(String(describing: data.bssid))
+                Text((data.bssid ?? "—"))
                     .lineLimit(1)
                     .truncationMode(.tail)
             }
             HStack {
                 Text("Signal Strength")
                 Spacer()
-                Text(String(describing: data.signalStrength))
+                Text((data.signalStrength?.formatted() ?? "—"))
                     .lineLimit(1)
                     .truncationMode(.tail)
             }
             HStack {
                 Text("Noise Level")
                 Spacer()
-                Text(String(describing: data.noiseLevel))
+                Text((data.noiseLevel?.formatted() ?? "—"))
                     .lineLimit(1)
                     .truncationMode(.tail)
             }
             HStack {
                 Text("Channel")
                 Spacer()
-                Text(String(describing: data.channel))
+                Text((data.channel ?? "—"))
                     .lineLimit(1)
                     .truncationMode(.tail)
             }
@@ -8661,21 +8731,21 @@ public struct MCPIsAppRunningSnippetView: View {
             HStack {
                 Text("Bundle Identifier")
                 Spacer()
-                Text(String(describing: data.bundleIdentifier))
+                Text((data.bundleIdentifier ?? "—"))
                     .lineLimit(1)
                     .truncationMode(.tail)
             }
             HStack {
                 Text("Pid")
                 Spacer()
-                Text(String(describing: data.pid))
+                Text((data.pid?.formatted() ?? "—"))
                     .lineLimit(1)
                     .truncationMode(.tail)
             }
             HStack {
                 Text("Visible")
                 Spacer()
-                Text(String(describing: data.visible))
+                Text((data.visible.map { $0 ? "Yes" : "No" } ?? "—"))
                     .lineLimit(1)
                     .truncationMode(.tail)
             }
@@ -9399,28 +9469,28 @@ public struct MCPReadContactSnippetView: View {
             HStack {
                 Text("Organization")
                 Spacer()
-                Text(String(describing: data.organization))
+                Text((data.organization ?? "—"))
                     .lineLimit(1)
                     .truncationMode(.tail)
             }
             HStack {
                 Text("Job Title")
                 Spacer()
-                Text(String(describing: data.jobTitle))
+                Text((data.jobTitle ?? "—"))
                     .lineLimit(1)
                     .truncationMode(.tail)
             }
             HStack {
                 Text("Department")
                 Spacer()
-                Text(String(describing: data.department))
+                Text((data.department ?? "—"))
                     .lineLimit(1)
                     .truncationMode(.tail)
             }
             HStack {
                 Text("Note")
                 Spacer()
-                Text(String(describing: data.note))
+                Text((data.note ?? "—"))
                     .lineLimit(1)
                     .truncationMode(.tail)
             }
@@ -9519,7 +9589,7 @@ public struct MCPReadMessageSnippetView: View {
             HStack {
                 Text("Date Sent")
                 Spacer()
-                Text(String(describing: data.dateSent))
+                Text((data.dateSent ?? "—"))
                     .lineLimit(1)
                     .truncationMode(.tail)
             }
@@ -9716,7 +9786,7 @@ public struct MCPReadReminderSnippetView: View {
             HStack {
                 Text("Completion Date")
                 Spacer()
-                Text(String(describing: data.completionDate))
+                Text((data.completionDate ?? "—"))
                     .lineLimit(1)
                     .truncationMode(.tail)
             }
@@ -9737,7 +9807,7 @@ public struct MCPReadReminderSnippetView: View {
             HStack {
                 Text("Due Date")
                 Spacer()
-                Text(String(describing: data.dueDate))
+                Text((data.dueDate ?? "—"))
                     .lineLimit(1)
                     .truncationMode(.tail)
             }

--- a/tests/codex-mcp.test.js
+++ b/tests/codex-mcp.test.js
@@ -104,12 +104,57 @@ describe("codex MCP setup", () => {
         `args = ["-y", "/Users/ren/IdeaProjects/MCP/AirMCP", "connect", "--url", "${CODEX_APP_OWNED_URL}"]`,
         "",
         "[mcp_servers.airmcp.env]",
-        'AIRMCP_HTTP_TOKEN = "token"',
+        'AIRMCP_HTTP_TOKEN = "test-runtime-token"',
         "",
       ].join("\n"),
     );
 
     expect(codexAirmcpRuntimeShape()).toBe("app-owned-pending-restart");
+  });
+
+  test("treats a config.toml carrying a stale token as not-app-owned so it gets repaired", () => {
+    // CLI output is stale-direct; config.toml has the app-owned proxy shape but
+    // a token that no longer matches the live runtime token. The runtime path
+    // must NOT report app-owned (which would suppress repair).
+    codexGetOutput = ["airmcp", "  transport: stdio", "  command: npx", "  args: -y airmcp@2.12.0"].join("\n");
+    writeFileSync(
+      process.env.AIRMCP_CODEX_CONFIG_PATH,
+      [
+        "[mcp_servers.airmcp]",
+        'command = "npx"',
+        `args = ["-y", "airmcp", "connect", "--url", "${CODEX_APP_OWNED_URL}"]`,
+        "",
+        "[mcp_servers.airmcp.env]",
+        'AIRMCP_HTTP_TOKEN = "stale-old-token"',
+        "",
+      ].join("\n"),
+    );
+
+    expect(codexAirmcpRuntimeShape()).toBe("direct");
+  });
+
+  test("detects the inline-table env form of the app-owned proxy", () => {
+    expect(
+      codexConfigTomlRuntimeShape(
+        [
+          "[mcp_servers.airmcp]",
+          'command = "npx"',
+          `args = ["-y", "airmcp", "connect", "--url", "${CODEX_APP_OWNED_URL}"]`,
+          'env = { AIRMCP_HTTP_TOKEN = "token" }',
+        ].join("\n"),
+      ),
+    ).toBe("app-owned");
+  });
+
+  test("compares the inline-table token value against the live token", () => {
+    const toml = [
+      "[mcp_servers.airmcp]",
+      'command = "npx"',
+      `args = ["-y", "airmcp", "connect", "--url", "${CODEX_APP_OWNED_URL}"]`,
+      'env = { AIRMCP_HTTP_TOKEN = "live-token" }',
+    ].join("\n");
+    expect(codexConfigTomlRuntimeShape(toml, "live-token")).toBe("app-owned");
+    expect(codexConfigTomlRuntimeShape(toml, "different-token")).toBe("unknown");
   });
 
   test("parses Codex config.toml app-owned proxy shape", () => {

--- a/tests/embeddings-local-only.test.js
+++ b/tests/embeddings-local-only.test.js
@@ -38,6 +38,13 @@ jest.unstable_mockModule('../dist/shared/swift.js', () => swiftMock);
 
 const embeddings = await import('../dist/semantic/embeddings.js');
 
+// Capture the real fetch once. Each test installs a deterministic stub by
+// assigning globalThis.fetch directly and afterEach restores this original.
+// (jest.spyOn(globalThis,'fetch')+mockRestore is fragile: Node's global fetch
+// is a lazy getter, so restoring it can leave `fetch` undefined for the next
+// test — the isolation failure this guards against.)
+const originalFetch = globalThis.fetch;
+
 const savedEnv = {};
 function setEnv(key, value) {
   if (!(key in savedEnv)) savedEnv[key] = process.env[key];
@@ -57,6 +64,7 @@ afterEach(() => {
     else process.env[k] = v;
   }
   for (const k of Object.keys(savedEnv)) delete savedEnv[k];
+  globalThis.fetch = originalFetch;
 });
 
 describe('detectProvider — LOCAL_ONLY semantics', () => {
@@ -130,10 +138,11 @@ describe('embedText hybrid — fallback audit + LOCAL_ONLY refusal', () => {
     // First runSwift call is the swift embed → throws; the gemini path
     // is exercised via global fetch which we stub.
     swiftMock.runSwift.mockRejectedValue(new Error('swift bridge transient failure'));
-    const fetchSpy = jest.spyOn(globalThis, 'fetch').mockResolvedValue({
+    const fetchSpy = jest.fn().mockResolvedValue({
       ok: true,
       json: async () => ({ embedding: { values: [0.1, 0.2, 0.3] } }),
     });
+    globalThis.fetch = fetchSpy;
     try {
       const v = await embeddings.embedText('hello world', 'hybrid');
       expect(v).toEqual([0.1, 0.2, 0.3]);
@@ -147,7 +156,7 @@ describe('embedText hybrid — fallback audit + LOCAL_ONLY refusal', () => {
       expect(auditCalls[0].args.reason.length).toBeLessThanOrEqual(200);
       expect(auditCalls[0].status).toBe('ok');
     } finally {
-      fetchSpy.mockRestore();
+      globalThis.fetch = originalFetch;
     }
   });
 
@@ -155,10 +164,11 @@ describe('embedText hybrid — fallback audit + LOCAL_ONLY refusal', () => {
     setEnv('AIRMCP_LOCAL_ONLY', 'true');
     setEnv('GEMINI_API_KEY', 'fake-key');
     swiftMock.runSwift.mockRejectedValue(new Error('swift bridge transient failure'));
-    const fetchSpy = jest.spyOn(globalThis, 'fetch').mockResolvedValue({
+    const fetchSpy = jest.fn().mockResolvedValue({
       ok: true,
       json: async () => ({ embedding: { values: [0.1] } }),
     });
+    globalThis.fetch = fetchSpy;
     try {
       // Use a distinct text so the embedCache from the previous test
       // doesn't short-circuit this one (cache key includes the text).
@@ -168,7 +178,7 @@ describe('embedText hybrid — fallback audit + LOCAL_ONLY refusal', () => {
       expect(fetchSpy).not.toHaveBeenCalled();
       expect(auditCalls).toHaveLength(0);
     } finally {
-      fetchSpy.mockRestore();
+      globalThis.fetch = originalFetch;
     }
   });
 });

--- a/tests/esc.test.js
+++ b/tests/esc.test.js
@@ -112,12 +112,17 @@ describe('escAS (AppleScript double-quoted strings)', () => {
     expect(escAS('col1\tcol2')).toBe('col1\\tcol2');
   });
 
-  test('escapes unicode line separator (\\u2028)', () => {
-    expect(escAS('before\u2028after')).toBe('before\\u2028after');
+  // U+2028/U+2029 are deliberately NOT escaped for AppleScript: AS has no `\u`
+  // escape, so emitting "\u2028" yields an un-parseable token (osascript -2741)
+  // and the send silently fails. Raw LS/PS are ordinary characters inside an
+  // AppleScript double-quoted literal and pass through safely. See escAS in
+  // src/shared/esc.ts. (escJxaShell, which targets JS/JXA, still escapes them.)
+  test('passes U+2028 line separator through unescaped (AppleScript has no \\u)', () => {
+    expect(escAS('before\u2028after')).toBe('before\u2028after');
   });
 
-  test('escapes unicode paragraph separator (\\u2029)', () => {
-    expect(escAS('before\u2029after')).toBe('before\\u2029after');
+  test('passes U+2029 paragraph separator through unescaped (AppleScript has no \\u)', () => {
+    expect(escAS('before\u2029after')).toBe('before\u2029after');
   });
 
   test('combined attack string with multiple special chars', () => {
@@ -130,8 +135,11 @@ describe('escAS (AppleScript double-quoted strings)', () => {
     expect(result).toContain('\\n');
     expect(result).toContain('\\r');
     expect(result).toContain('\\t');
-    expect(result).toContain('\\u2028');
-    expect(result).toContain('\\u2029');
+    // LS/PS survive verbatim (AppleScript-safe) and are never \u-encoded.
+    expect(result).toContain('\u2028');
+    expect(result).toContain('\u2029');
+    expect(result).not.toContain('\\u2028');
+    expect(result).not.toContain('\\u2029');
   });
 
   test('injection attempt is escaped', () => {

--- a/tests/hitl-guard-monotonicity.test.js
+++ b/tests/hitl-guard-monotonicity.test.js
@@ -1,0 +1,68 @@
+/**
+ * HITL level monotonicity (review finding #3/#5).
+ *
+ * The HITL levels are presented to users as increasing strictness:
+ *   off ⊂ destructive-only ⊂ sensitive-only ⊂ all-writes ⊂ all
+ * (the init wizard offers Recommended=sensitive-only then Strict=all-writes).
+ * So for ANY fixed annotation shape, once a tool is gated at some level it
+ * must stay gated at every stricter level. Before the fix, all-writes gated
+ * only readOnlyHint===false and so DROPPED sensitive-but-readonly tools
+ * (health_*, get_clipboard, capture_screen, ui_read) that sensitive-only
+ * gated — making Strict weaker than Recommended. This locks the ordering.
+ */
+import { describe, test, expect } from '@jest/globals';
+
+const { shouldRequireApproval } = await import('../dist/shared/hitl-guard.js');
+
+// Increasing strictness, low → high.
+const LEVELS = ['off', 'destructive-only', 'sensitive-only', 'all-writes', 'all'];
+
+const SHAPES = {
+  plainRead: { readOnlyHint: true, destructiveHint: false, sensitiveHint: false },
+  sensitiveRead: { readOnlyHint: true, destructiveHint: false, sensitiveHint: true },
+  plainWrite: { readOnlyHint: false, destructiveHint: false, sensitiveHint: false },
+  sensitiveWrite: { readOnlyHint: false, destructiveHint: false, sensitiveHint: true },
+  destructive: { readOnlyHint: false, destructiveHint: true, sensitiveHint: false },
+};
+
+describe('HITL level monotonicity', () => {
+  test('gating grows monotonically across off ⊂ destructive-only ⊂ sensitive-only ⊂ all-writes ⊂ all', () => {
+    const failures = [];
+    for (const [shapeName, ann] of Object.entries(SHAPES)) {
+      let everGated = false;
+      let gatedAt = null;
+      for (const level of LEVELS) {
+        const gated = shouldRequireApproval(level, ann, new Set(), 'tool_x');
+        if (everGated && !gated) {
+          failures.push(
+            `${shapeName}: gated at "${gatedAt}" but NOT at the stricter "${level}" — ordering is non-monotonic`,
+          );
+        }
+        if (gated && !everGated) {
+          everGated = true;
+          gatedAt = level;
+        }
+      }
+    }
+    if (failures.length > 0) {
+      throw new Error(`HITL levels are not monotonic:\n  ${failures.join('\n  ')}`);
+    }
+  });
+
+  test('sensitive-readonly tools (the #3/#5 regression) are gated at sensitive-only AND all-writes AND all', () => {
+    const ann = SHAPES.sensitiveRead;
+    expect(shouldRequireApproval('sensitive-only', ann, new Set(), 't')).toBe(true);
+    expect(shouldRequireApproval('all-writes', ann, new Set(), 't')).toBe(true);
+    expect(shouldRequireApproval('all', ann, new Set(), 't')).toBe(true);
+    // and NOT gated at the looser levels
+    expect(shouldRequireApproval('off', ann, new Set(), 't')).toBe(false);
+    expect(shouldRequireApproval('destructive-only', ann, new Set(), 't')).toBe(false);
+  });
+
+  test('whitelisted tools are never gated at any level', () => {
+    const wl = new Set(['safe_tool']);
+    for (const level of LEVELS) {
+      expect(shouldRequireApproval(level, SHAPES.destructive, wl, 'safe_tool')).toBe(false);
+    }
+  });
+});

--- a/tests/http-transport.test.js
+++ b/tests/http-transport.test.js
@@ -445,6 +445,40 @@ describe('startHttpServer live middleware', () => {
     }
   });
 
+  test('discovery card never serves bare empty modules during the warmup window', async () => {
+    // The card must be internally consistent at every instant after the socket
+    // binds: either the live module list is published, or a `warming` marker is
+    // set. It must never silently advertise `modules: []` with no warming flag,
+    // which is what a registry crawler hitting the warmup window used to see.
+    const { createServer } = await import('../dist/server/mcp-setup.js');
+    createServer.mockResolvedValueOnce({
+      server: { connect: jest.fn(), close: jest.fn(), sendResourceListChanged: jest.fn() },
+      bannerInfo: { transport: 'http', version: '2.6.0', modulesEnabled: ['calendar', 'reminders'] },
+      cleanupEventListeners: jest.fn(),
+    });
+    const server = await startHttpServer(options());
+    try {
+      // Immediately after bind: modules may not be resolved yet, but if they
+      // aren't, `warming` must be true (no bare empty list).
+      const early = await (await fetch(serverUrl(server, '/.well-known/mcp.json'))).json();
+      if (!Array.isArray(early.modules) || early.modules.length === 0) {
+        expect(early.warming).toBe(true);
+      }
+      // After warmup converges: the live module list is published and the
+      // warming marker is dropped.
+      let card;
+      for (let i = 0; i < 50; i += 1) {
+        card = await (await fetch(serverUrl(server, '/.well-known/mcp.json'))).json();
+        if (!card.warming) break;
+        await new Promise((r) => setTimeout(r, 10));
+      }
+      expect(card.warming).toBeUndefined();
+      expect(card.modules).toEqual(['calendar', 'reminders']);
+    } finally {
+      await closeServer(server);
+    }
+  });
+
   test('with-token+origin rejects an unlisted Origin before MCP handling', async () => {
     process.env.AIRMCP_ALLOWED_ORIGINS = 'https://allowed.example';
     const server = await startHttpServer(options({ allowNetwork: 'with-token+origin' }));

--- a/tests/safety-annotations.test.js
+++ b/tests/safety-annotations.test.js
@@ -90,6 +90,9 @@ const { registerSpeechTools } = await import('../dist/speech/tools.js');
 const { registerCrossTools } = await import('../dist/cross/tools.js');
 const { registerSemanticTools } = await import('../dist/semantic/tools.js');
 const { registerMemoryTools } = await import('../dist/memory/tools.js');
+const { PRIVACY_READOUT_TOOLS, PRIVACY_READOUT_NAME_PATTERNS, PRIVACY_PATTERN_EXEMPT } = await import(
+  '../dist/shared/privacy-sensitive-tools.js'
+);
 
 // ── Test suite ──────────────────────────────────────────────────────
 
@@ -447,34 +450,28 @@ describe('Safety Annotations consistency', () => {
   });
 
   // ── 11. Live privacy readouts must be sensitive-gated ─────────────
+  //
+  // The privacy-readout list is the single source of truth in
+  // src/shared/privacy-sensitive-tools.ts. Three directions lock it
+  // against the drift that previously let smart_clipboard / memory_query
+  // / the mail / photo / chat readers slip through unmarked:
+  //   (a) forward  — every listed tool that is registered is gated;
+  //   (b) reverse  — every registered read-only + sensitive tool is listed;
+  //   (c) anti-drift — every registered read-only tool whose NAME matches an
+  //                    obvious privacy pattern is listed.
 
-  test('known live privacy readouts are gated by sensitive-only HITL', () => {
-    const LIVE_PRIVACY_READOUTS = [
-      'get_clipboard',
-      'list_all_windows',
-      'capture_screen',
-      'capture_window',
-      'capture_area',
-      'list_windows',
-      'health_summary',
-      'health_today_steps',
-      'health_heart_rate',
-      'health_sleep',
-      'health_authorize',
-      'get_current_location',
-      'ui_open_app',
-      'ui_read',
-      'ui_accessibility_query',
-      'ui_traverse',
-      'ui_diff',
-    ];
+  test('(a) every privacy readout in the SSOT is gated by sensitive-only HITL', () => {
     const tools = getAllTools();
     const failures = [];
 
-    for (const name of LIVE_PRIVACY_READOUTS) {
+    for (const name of PRIVACY_READOUT_TOOLS) {
       const tool = tools.find((t) => t.name === name);
+      // Some readouts (health_*) only register where the platform exposes
+      // them; skip names absent from this fully-registered test server only
+      // if genuinely unregistered. Here every module is registered, so an
+      // absent name is a real regression.
       if (!tool) {
-        failures.push(`${name}: not registered`);
+        failures.push(`${name}: in PRIVACY_READOUT_TOOLS but not registered`);
         continue;
       }
       if (tool.annotations?.destructiveHint !== true && tool.annotations?.sensitiveHint !== true) {
@@ -487,6 +484,45 @@ describe('Safety Annotations consistency', () => {
     if (failures.length > 0) {
       throw new Error(
         `live privacy readout tool(s) are not gated by sensitive-only HITL:\n  ${failures.join('\n  ')}`,
+      );
+    }
+  });
+
+  test('(b) every registered read-only + sensitive tool is in the privacy-readout SSOT', () => {
+    const tools = getAllTools();
+    const orphans = tools
+      .filter(
+        (t) =>
+          t.annotations?.readOnlyHint === true &&
+          t.annotations?.sensitiveHint === true &&
+          !PRIVACY_READOUT_TOOLS.has(t.name),
+      )
+      .map((t) => t.name);
+
+    if (orphans.length > 0) {
+      throw new Error(
+        `read-only + sensitive tool(s) missing from PRIVACY_READOUT_TOOLS ` +
+          `(add them to src/shared/privacy-sensitive-tools.ts):\n  ${orphans.join('\n  ')}`,
+      );
+    }
+  });
+
+  test('(c) read-only tools whose name matches a privacy pattern are in the SSOT', () => {
+    const tools = getAllTools();
+    const matched = tools.filter(
+      (t) =>
+        t.annotations?.readOnlyHint === true &&
+        PRIVACY_READOUT_NAME_PATTERNS.some((re) => re.test(t.name)),
+    );
+    const unlisted = matched
+      .filter((t) => !PRIVACY_READOUT_TOOLS.has(t.name) && !PRIVACY_PATTERN_EXEMPT.has(t.name))
+      .map((t) => t.name);
+
+    if (unlisted.length > 0) {
+      throw new Error(
+        `read-only tool(s) look like privacy readers by name but are not in ` +
+          `PRIVACY_READOUT_TOOLS — mark them sensitiveHint:true and add them, ` +
+          `or tighten the pattern in src/shared/privacy-sensitive-tools.ts:\n  ${unlisted.join('\n  ')}`,
       );
     }
   });


### PR DESCRIPTION
## Purpose
Make verification honest again before any experiment work. Removes the current red tests, generated-manifest drift, and README/docs/package contradictions so later claims rest on a green, truthful baseline. **No positioning/novelty copy; no release-asset/notarization/registry work.**

## Note on commits
This branch is based on `fix/codex-redteam-hardening` (2 commits, never separately pushed/PR'd). Those red-team commits are included here because `d3ac460` is what introduced the red `esc` suite this PR closes. Net effect: the branch lands the red-team hardening **with** honest, green verification. If you'd rather split them, say so and I'll restructure.

## Changes (verification truthfulness only)
- **esc** — align tests to the AppleScript-correct `escAS` contract (U+2028/U+2029 pass through unescaped; AppleScript has no `\u` escape → osascript -2741). Implementation unchanged; only stale tests move.
- **embeddings local-only** — fix `fetch`-spy test isolation (capture real fetch once, restore in `afterEach`) so the no-cloud-fallback privacy guard is actually green. Production refusal path unchanged.
- **gws_raw** — regenerate `docs/tool-manifest.json` to match runtime schema (2 missing regex `pattern` fields); `gen:manifest:check` passes.
- **docs** — Node `18`→`20` across README, docs/index.html, 10 locales, testing.md (matches `engines >=20`); starter set corrected to the 7-module code SSOT in README, mcpb manifest, and the init.ts hint.
- **mcpb manifest** — drop "270+ tools" / "100% on-device via native bridges" overclaim → 286 tools + honest bundle note (Swift bridge not shipped in the `.mcpb`), consistent with docs/mcpb.md.
- **jest** — ignore generated `build/` to stop the haste module-name collision.

## Gates run locally (all green)
| gate | result |
|---|---|
| lint / typecheck | pass |
| test | 142 suites / 2124 tests pass |
| smoke / mcp:validate | 112 tools |
| gen:manifest:check | pass |
| build:mcpb:check / stats:check / llms:check / version:check | pass |
| swift test / ios swift test | 29 / 21 pass |

## Out of scope (deliberately not in this PR)
- prior-art / "secure MCP" positioning copy
- release assets, notarization, marketplace/registry freshness
- ablation experiment design or results
