### PR TITLE
test(security): close remaining verification-debt gaps

### DIFF
--- a/scripts/count-stats.mjs
+++ b/scripts/count-stats.mjs
@@ -16,11 +16,7 @@ import { fileURLToPath } from "node:url";
 
 const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..");
 const SRC = join(ROOT, "src");
-const mode = process.argv.includes("--check")
-  ? "check"
-  : process.argv.includes("--sync")
-    ? "sync"
-    : "print";
+const mode = process.argv.includes("--check") ? "check" : process.argv.includes("--sync") ? "sync" : "print";
 
 // ── Count from source ──────────────────────────────────────────────
 
@@ -95,12 +91,8 @@ for (const line of resLines) {
 }
 
 const configContent = readFileSync(join(SRC, "shared", "config.ts"), "utf-8");
-const moduleBlock = configContent.match(
-  /export const MODULE_NAMES = \[([\s\S]*?)\] as const/,
-);
-const modules = moduleBlock
-  ? (moduleBlock[1].match(/"/g) || []).length / 2
-  : 0;
+const moduleBlock = configContent.match(/export const MODULE_NAMES = \[([\s\S]*?)\] as const/);
+const modules = moduleBlock ? (moduleBlock[1].match(/"/g) || []).length / 2 : 0;
 
 const stats = { tools, prompts, resources, modules, mcpApps, appIntents };
 
@@ -192,8 +184,12 @@ for (const page of docsPages) {
 }
 
 // MCPB manifest template — the long_description string lives in the user
-// install dialog, so a stale count is highly visible.
+// install dialog, so a stale count is highly visible. Guard the tool /
+// module / AppIntent counts so the blurb can't re-drift (e.g. the old
+// "270+ tools" that slipped past this guard before).
 syncFile("mcpb/manifest.template.json", [
+  { pattern: /(\d+) tools across/g, value: tools },
+  { pattern: /across (\d+) modules/g, value: modules },
   { pattern: /(\d+) auto-generated Apple App Intents/g, value: appIntents },
 ]);
 
@@ -202,12 +198,8 @@ syncFile("docs/skills.md", [
   { pattern: /(\d+) tools/g, value: tools },
   { pattern: /(\d+) modules/g, value: modules },
 ]);
-syncFile("docs/shortcuts.md", [
-  { pattern: /(\d+) tools are auto-registered/g, value: tools },
-]);
-syncFile("docs/REGISTRY_SUBMISSIONS.md", [
-  { pattern: /(\d+) AppIntents/g, value: appIntents },
-]);
+syncFile("docs/shortcuts.md", [{ pattern: /(\d+) tools are auto-registered/g, value: tools }]);
+syncFile("docs/REGISTRY_SUBMISSIONS.md", [{ pattern: /(\d+) AppIntents/g, value: appIntents }]);
 syncFile("docs/TERMS_OF_SERVICE.md", [
   { pattern: /(\d+) tools/g, value: tools },
   { pattern: /(\d+) modules/g, value: modules },
@@ -242,8 +234,7 @@ syncFile("server.json", [
 // Locale files — each uses different words for "modules"
 const localeDir = join(ROOT, "docs", "locales");
 if (existsSync(localeDir)) {
-  const moduleWords =
-    /(\d+)([\s\u00a0]*(?:modules?|개 모듈|モジュール|个模块|個模組|Modulen|módulos))/g;
+  const moduleWords = /(\d+)([\s\u00a0]*(?:modules?|개 모듈|モジュール|个模块|個模組|Modulen|módulos))/g;
   for (const f of readdirSync(localeDir).filter((f) => f.endsWith(".json"))) {
     syncFile(`docs/locales/${f}`, [{ pattern: moduleWords, value: modules }]);
   }
@@ -252,9 +243,7 @@ if (existsSync(localeDir)) {
 console.log("");
 
 if (mode === "check" && dirty) {
-  console.error(
-    "Stats mismatch detected. Run: node scripts/count-stats.mjs --sync",
-  );
+  console.error("Stats mismatch detected. Run: node scripts/count-stats.mjs --sync");
   process.exit(1);
 }
 

--- a/tests/audit-dir-permissions.test.js
+++ b/tests/audit-dir-permissions.test.js
@@ -1,0 +1,68 @@
+/**
+ * Audit directory permission pin.
+ *
+ * ensureDir() creates the audit dir (VECTOR_STORE — holds audit.jsonl +
+ * audit.checkpoint) owner-only (0o700) so other local users can't even
+ * enumerate audit filenames / rotation timestamps. It runs once per process
+ * (guarded by `initialized`), so this lives in its own file: a fresh module
+ * load guarantees the first flush actually calls mkdir. (Closes the
+ * "audit dir 0o700 — NOT tested" gap from the security audit.)
+ */
+import { describe, test, expect, beforeEach, jest } from "@jest/globals";
+
+const appendFile = jest.fn();
+const mkdir = jest.fn();
+const stat = jest.fn();
+const chmod = jest.fn();
+const rename = jest.fn();
+const readFile = jest.fn();
+const readdir = jest.fn();
+const writeFile = jest.fn();
+
+jest.unstable_mockModule("node:fs/promises", () => ({
+  appendFile,
+  mkdir,
+  stat,
+  chmod,
+  rename,
+  readFile,
+  readdir,
+  writeFile,
+}));
+
+const { auditLog, _testReset, _testFlush } = await import("../dist/shared/audit.js");
+
+beforeEach(() => {
+  _testReset();
+  appendFile.mockReset();
+  mkdir.mockReset();
+  stat.mockReset();
+  chmod.mockReset();
+  rename.mockReset();
+  readFile.mockReset();
+  readdir.mockReset();
+  writeFile.mockReset();
+
+  appendFile.mockResolvedValue(undefined);
+  mkdir.mockResolvedValue(undefined);
+  stat.mockRejectedValue(Object.assign(new Error("ENOENT"), { code: "ENOENT" }));
+  chmod.mockResolvedValue(undefined);
+  rename.mockResolvedValue(undefined);
+  readFile.mockRejectedValue(Object.assign(new Error("ENOENT"), { code: "ENOENT" }));
+  readdir.mockRejectedValue(Object.assign(new Error("ENOENT"), { code: "ENOENT" }));
+  writeFile.mockResolvedValue(undefined);
+});
+
+describe("audit directory permissions", () => {
+  test("ensureDir creates the audit dir recursively with owner-only mode 0o700", async () => {
+    auditLog({ timestamp: "T1", tool: "t", status: "ok" });
+    await _testFlush();
+
+    expect(mkdir).toHaveBeenCalled();
+    const dirCall = mkdir.mock.calls.find(
+      (c) => c[1] && c[1].recursive === true && Object.prototype.hasOwnProperty.call(c[1], "mode"),
+    );
+    expect(dirCall).toBeDefined();
+    expect(dirCall[1].mode).toBe(0o700);
+  });
+});

--- a/tests/google-tools.test.js
+++ b/tests/google-tools.test.js
@@ -1,11 +1,11 @@
-import { describe, test, expect, jest } from '@jest/globals';
+import { describe, test, expect, jest } from "@jest/globals";
 
-jest.unstable_mockModule('../dist/google/gws.js', () => ({
+jest.unstable_mockModule("../dist/google/gws.js", () => ({
   runGws: jest.fn(),
   checkGws: jest.fn(),
 }));
 
-const { registerGoogleTools } = await import('../dist/google/tools.js');
+const { registerGoogleTools } = await import("../dist/google/tools.js");
 
 function createMockServer() {
   const tools = new Map();
@@ -22,7 +22,7 @@ function createMockServer() {
   };
 }
 
-describe('Google Workspace tools registration', () => {
+describe("Google Workspace tools registration", () => {
   let server;
 
   beforeAll(() => {
@@ -30,50 +30,50 @@ describe('Google Workspace tools registration', () => {
     registerGoogleTools(server, {});
   });
 
-  test('registers all 16 google workspace tools', () => {
+  test("registers all 16 google workspace tools", () => {
     expect(server.tools.size).toBe(16);
     const expected = [
-      'gws_status',
-      'gws_gmail_list',
-      'gws_gmail_read',
-      'gws_gmail_send',
-      'gws_drive_list',
-      'gws_drive_read',
-      'gws_drive_search',
-      'gws_sheets_read',
-      'gws_sheets_write',
-      'gws_calendar_list',
-      'gws_calendar_create',
-      'gws_docs_read',
-      'gws_tasks_list',
-      'gws_tasks_create',
-      'gws_people_search',
-      'gws_raw',
+      "gws_status",
+      "gws_gmail_list",
+      "gws_gmail_read",
+      "gws_gmail_send",
+      "gws_drive_list",
+      "gws_drive_read",
+      "gws_drive_search",
+      "gws_sheets_read",
+      "gws_sheets_write",
+      "gws_calendar_list",
+      "gws_calendar_create",
+      "gws_docs_read",
+      "gws_tasks_list",
+      "gws_tasks_create",
+      "gws_people_search",
+      "gws_raw",
     ];
     for (const name of expected) {
       expect(server.tools.has(name)).toBe(true);
     }
   });
 
-  test('all tools have titles and descriptions', () => {
+  test("all tools have titles and descriptions", () => {
     for (const [, { config }] of server.tools) {
-      expect(typeof config.title).toBe('string');
+      expect(typeof config.title).toBe("string");
       expect(config.title.length).toBeGreaterThan(0);
-      expect(typeof config.description).toBe('string');
+      expect(typeof config.description).toBe("string");
       expect(config.description.length).toBeGreaterThan(0);
     }
   });
 
-  test('all tools have annotations', () => {
+  test("all tools have annotations", () => {
     for (const [, { config }] of server.tools) {
       expect(config.annotations).toBeDefined();
-      expect(typeof config.annotations.readOnlyHint).toBe('boolean');
-      expect(typeof config.annotations.destructiveHint).toBe('boolean');
+      expect(typeof config.annotations.readOnlyHint).toBe("boolean");
+      expect(typeof config.annotations.destructiveHint).toBe("boolean");
     }
   });
 
-  test('cloud write tools require destructive-level approval/scope', () => {
-    for (const name of ['gws_sheets_write', 'gws_calendar_create', 'gws_tasks_create']) {
+  test("cloud write tools require destructive-level approval/scope", () => {
+    for (const name of ["gws_sheets_write", "gws_calendar_create", "gws_tasks_create"]) {
       const { config } = server.tools.get(name);
       expect(config.annotations.readOnlyHint).toBe(false);
       expect(config.annotations.openWorldHint).toBe(true);
@@ -82,7 +82,7 @@ describe('Google Workspace tools registration', () => {
   });
 });
 
-describe('gws_raw security whitelist', () => {
+describe("gws_raw security whitelist", () => {
   let server;
 
   beforeAll(() => {
@@ -90,63 +90,114 @@ describe('gws_raw security whitelist', () => {
     registerGoogleTools(server, { allowSendMail: false });
   });
 
-  test('rejects unknown service', async () => {
-    const result = await server.callTool('gws_raw', {
-      service: 'malicious_service', resource: 'foo', method: 'list',
+  test("rejects unknown service", async () => {
+    const result = await server.callTool("gws_raw", {
+      service: "malicious_service",
+      resource: "foo",
+      method: "list",
     });
-    expect(result.content[0].text).toContain('Unknown service');
-    expect(result.content[0].text).toContain('malicious_service');
+    expect(result.content[0].text).toContain("Unknown service");
+    expect(result.content[0].text).toContain("malicious_service");
   });
 
-  test('allows known services', async () => {
-    const { runGws } = await import('../dist/google/gws.js');
+  test("allows known services", async () => {
+    const { runGws } = await import("../dist/google/gws.js");
     runGws.mockResolvedValue({ ok: true });
 
-    const result = await server.callTool('gws_raw', {
-      service: 'gmail', resource: 'users.messages', method: 'list',
+    const result = await server.callTool("gws_raw", {
+      service: "gmail",
+      resource: "users.messages",
+      method: "list",
     });
-    expect(result.content[0].text).not.toContain('Unknown service');
+    expect(result.content[0].text).not.toContain("Unknown service");
   });
 
-  test('blocks destructive methods when allowSendMail is false', async () => {
-    for (const method of ['delete', 'trash', 'remove', 'purge']) {
-      const result = await server.callTool('gws_raw', {
-        service: 'drive', resource: 'files', method,
+  test("blocks destructive methods when allowSendMail is false", async () => {
+    for (const method of ["delete", "trash", "remove", "purge"]) {
+      const result = await server.callTool("gws_raw", {
+        service: "drive",
+        resource: "files",
+        method,
       });
-      expect(result.content[0].text).toContain('Destructive method');
+      expect(result.content[0].text).toContain("Destructive method");
       expect(result.content[0].text).toContain(method);
     }
   });
 
-  test('blocks gmail send when allowSendMail is false', async () => {
-    const result = await server.callTool('gws_raw', {
-      service: 'gmail', resource: 'users.messages', method: 'send',
+  test("blocks gmail send when allowSendMail is false", async () => {
+    const result = await server.callTool("gws_raw", {
+      service: "gmail",
+      resource: "users.messages",
+      method: "send",
     });
-    expect(result.content[0].text).toContain('disabled');
+    expect(result.content[0].text).toContain("disabled");
   });
 
-  test('allows destructive methods when allowSendMail is true', async () => {
+  test("allows destructive methods when allowSendMail is true", async () => {
     const permissiveServer = createMockServer();
     registerGoogleTools(permissiveServer, { allowSendMail: true });
 
-    const { runGws } = await import('../dist/google/gws.js');
+    const { runGws } = await import("../dist/google/gws.js");
     runGws.mockResolvedValue({ deleted: true });
 
-    const result = await permissiveServer.callTool('gws_raw', {
-      service: 'drive', resource: 'files', method: 'delete',
+    const result = await permissiveServer.callTool("gws_raw", {
+      service: "drive",
+      resource: "files",
+      method: "delete",
     });
-    expect(result.content[0].text).not.toContain('Destructive method');
+    expect(result.content[0].text).not.toContain("Destructive method");
   });
 
-  test('allows non-destructive methods freely', async () => {
-    const { runGws } = await import('../dist/google/gws.js');
+  test("allows non-destructive methods freely", async () => {
+    const { runGws } = await import("../dist/google/gws.js");
     runGws.mockResolvedValue({ items: [] });
 
-    for (const method of ['list', 'get', 'create', 'update']) {
-      const result = await server.callTool('gws_raw', {
-        service: 'sheets', resource: 'spreadsheets', method,
+    for (const method of ["list", "get", "create", "update"]) {
+      const result = await server.callTool("gws_raw", {
+        service: "sheets",
+        resource: "spreadsheets",
+        method,
       });
-      expect(result.content[0].text).not.toContain('Destructive method');
+      expect(result.content[0].text).not.toContain("Destructive method");
+    }
+  });
+});
+
+describe("gws_raw CWE-88 argument-injection guard (inputSchema regex)", () => {
+  // The mock callTool() invokes the handler directly and bypasses Zod, so the
+  // service-whitelist tests above never exercise the resource/method regex.
+  // Pull the real Zod schemas off the registered tool and validate them
+  // directly — a leading '-' (or any flag-shaped value) must be rejected
+  // before it can be forwarded to the gws CLI as a positional option (CWE-88).
+  let resourceSchema;
+  let methodSchema;
+
+  beforeAll(() => {
+    const server = createMockServer();
+    registerGoogleTools(server, {});
+    const { config } = server.tools.get("gws_raw");
+    resourceSchema = config.inputSchema.resource;
+    methodSchema = config.inputSchema.method;
+  });
+
+  test("rejects leading-dash / flag-shaped resource", () => {
+    for (const bad of ["-flag", "--output=/tmp/x", "-rf", ".hidden", "_x", "-"]) {
+      expect(resourceSchema.safeParse(bad).success).toBe(false);
+    }
+  });
+
+  test("rejects leading-dash / non-alphanumeric method", () => {
+    for (const bad of ["-x", "--delete", "list-all", "get.thing", "-"]) {
+      expect(methodSchema.safeParse(bad).success).toBe(false);
+    }
+  });
+
+  test("accepts legitimate resource and method values", () => {
+    for (const good of ["users.messages", "files", "spreadsheets.values", "A1"]) {
+      expect(resourceSchema.safeParse(good).success).toBe(true);
+    }
+    for (const good of ["list", "get", "create", "update", "delete"]) {
+      expect(methodSchema.safeParse(good).success).toBe(true);
     }
   });
 });

--- a/tests/mcpb-manifest.test.js
+++ b/tests/mcpb-manifest.test.js
@@ -134,9 +134,7 @@ describe("mcpb manifest template — tools_generated / prompts_generated", () =>
 
 describe("mcpb manifest template — well-formedness", () => {
   test("renders to valid JSON with no leftover template placeholders", () => {
-    const rendered = template
-      .replaceAll("{{VERSION}}", "1.0.0")
-      .replaceAll("{{DESCRIPTION}}", "test");
+    const rendered = template.replaceAll("{{VERSION}}", "1.0.0").replaceAll("{{DESCRIPTION}}", "test");
     expect(rendered).not.toContain("{{");
     expect(() => JSON.parse(rendered)).not.toThrow();
   });
@@ -157,5 +155,21 @@ describe("mcpb manifest template — well-formedness", () => {
     const m = render();
     expect(Array.isArray(m.privacy_policies)).toBe(true);
     expect(m.privacy_policies[0]).toMatch(/^https:\/\//);
+  });
+});
+
+describe("mcpb manifest template — long_description count tracks the canonical surface", () => {
+  // Guards the "270+ tools" drift class: the install-dialog blurb must track
+  // docs/tool-manifest.json (the generated SSOT), not be hand-set. count-stats
+  // also syncs this file, but pin it in the suite so `npm test` catches drift.
+  const manifestSurface = JSON.parse(readFileSync(join(ROOT, "docs", "tool-manifest.json"), "utf-8"));
+  const canonicalToolCount =
+    typeof manifestSurface.toolCount === "number" ? manifestSurface.toolCount : (manifestSurface.tools?.length ?? 0);
+
+  test("'N tools across' in long_description equals the generated tool count", () => {
+    const m = render();
+    const match = /(\d+) tools across/.exec(m.long_description);
+    expect(match).not.toBeNull();
+    expect(Number(match[1])).toBe(canonicalToolCount);
   });
 });

--- a/tests/update-manager-pin.test.js
+++ b/tests/update-manager-pin.test.js
@@ -1,0 +1,43 @@
+/**
+ * Self-update supply-chain pin (source contract).
+ *
+ * The macOS app's auto-update must (a) install the EXACT version resolved at
+ * check time — never `@latest` (closes the check→install TOCTOU / unpinned
+ * redirect), and (b) pass `--ignore-scripts` so a compromised package can't
+ * run npm lifecycle hooks during a privileged global install.
+ *
+ * UpdateManager.swift is not exercised by the JS runtime, so this pins the
+ * contract by scanning the source — the same pattern as
+ * app-owned-runtime-version-pin.test.js. (Closes the "self-update pin —
+ * UNTESTED" gap from the security audit.)
+ */
+import { describe, expect, test } from "@jest/globals";
+import { readFileSync } from "node:fs";
+
+const updateManager = readFileSync(new URL("../app/Sources/AirMCPApp/UpdateManager.swift", import.meta.url), "utf8");
+
+describe("self-update version pin", () => {
+  test("performUpdate installs the version resolved during the check (TOCTOU close)", () => {
+    expect(updateManager).toContain("let target = availableVersion");
+    expect(updateManager).toContain("runNpmInstall(version: target)");
+  });
+
+  test("runNpmInstall pins an exact version and never installs @latest", () => {
+    // Pinned specifier interpolates the passed `version`, not a floating tag.
+    expect(updateManager).toContain('"\\(AirMcpConstants.npmPackageName)@\\(version)"');
+
+    // Scope the negative to the actual install arguments array so the
+    // explanatory comments (which legitimately mention `@latest`) don't
+    // produce a false pass.
+    const installFn = updateManager.slice(updateManager.indexOf("func runNpmInstall"));
+    const argsStart = installFn.indexOf("process.arguments = [");
+    const argsBlock = installFn.slice(argsStart, installFn.indexOf("]", argsStart) + 1);
+    expect(argsBlock).toContain('"install", "-g"');
+    expect(argsBlock).toContain("@\\(version)");
+    expect(argsBlock.toLowerCase()).not.toContain("latest");
+  });
+
+  test("runNpmInstall skips npm lifecycle scripts (--ignore-scripts)", () => {
+    expect(updateManager).toContain('"--ignore-scripts"');
+  });
+});


### PR DESCRIPTION
## Purpose
Close the four remaining "verification debt" items the prior audit flagged, so the security surface is actually verifiable before the ablation work. **Verification coverage only — no positioning/novelty copy, no refactor, no release/registry work.**

## Changes
- **self-update pin** — `tests/update-manager-pin.test.js` scans `UpdateManager.swift`: `performUpdate` installs the check-time `availableVersion` (never `@latest`); `runNpmInstall` uses the pinned `@\(version)` specifier + `--ignore-scripts`. (Same source-contract pattern as `app-owned-runtime-version-pin.test.js`.)
- **gws_raw CWE-88** — new cases in `tests/google-tools.test.js` pull the real Zod `inputSchema` off the registered tool and assert leading-dash / flag-shaped `resource` & `method` are rejected, valid values accepted. (The mock `callTool` bypasses Zod, so the schema is validated directly.)
- **audit dir 0o700** — `tests/audit-dir-permissions.test.js` (own file so a fresh module load guarantees `ensureDir`'s one-shot `mkdir` runs) asserts the audit dir is created `recursive` + `mode 0o700`.
- **mcpb re-drift guard** — `count-stats.mjs` now syncs the mcpb manifest `long_description` tool/module counts (not just AppIntents), and `mcpb-manifest.test.js` pins the "N tools" blurb to the generated `tool-manifest` count so `270+` can't return.

## Gates run locally (all green)
| gate | result |
|---|---|
| build | pass |
| test | 144 suites / 2132 tests pass |
| gen:manifest:check | pass (286 tools) |
| build:mcpb:check / stats:check / version:check | pass |
| smoke / mcp:validate | 112 tools |

## Out of scope (deliberately not here)
- GAAP/OWASP/prior-art or "secure MCP" positioning copy
- ablation design/results in product docs
- release assets / notarization / registry freshness
- larger refactors
