### PR TITLE
docs(experiments): unify baseline primary/secondary across design, preflight, schema

### DIFF
--- a/docs/experiments/defended-vs-undefended-ablation-design.md
+++ b/docs/experiments/defended-vs-undefended-ablation-design.md
@@ -147,21 +147,23 @@ push well outside window — metadata bumps don't count); non-overlapping/offlin
 (e.g. static export query); already defended; surface-broadening confounds (e.g. added
 shell/SSH exec) disqualify a *primary matched* comparator (allowed only as secondary).
 
-| Candidate | `pushed_at` | Status | Safety model | Role |
+| Candidate | `pushed_at` | Status | Safety model | Role (comparison tier / run-set) |
 |---|---|---|---|---|
-| `steipete/macos-automator-mcp` | 2026-06-23 (in-window) | active | TCC-only; arbitrary AppleScript/JXA reaches the full scriptable surface | **Primary** (maintained, undefended, max-capability) |
-| `joshrutkowski/applescript-mcp` | 2025-04-19 `[historical]` | not archived but ~14mo stale | TCC-only; discrete typed tools (notes/reminders/calendar/clipboard/files/system) | **Secondary — matched-shape** (closest tool-catalog to AirMCP), with explicit staleness caveat |
-| `peakmojo/applescript-mcp` | 2026-02-22 (~4mo, just outside 90d) | active | TCC-only; **adds shell exec + SSH** | Secondary (second executor; surface-broadening flagged) |
+| `steipete/macos-automator-mcp` | 2026-06-23 (in-window) | active | TCC-only; arbitrary AppleScript/JXA reaches the full scriptable surface | **Run set**, `capability-matched`; also the `capability-native` **secondary** arm (its raw script surface) |
+| `joshrutkowski/applescript-mcp` | 2025-04-19 `[historical]` | not archived but ~14mo stale | TCC-only; discrete typed tools (notes/reminders/calendar/clipboard/files/system) | **Run set**, `capability-matched` (matched-shape); **staleness caveat — not a sole primary data source until re-verified** |
+| `peakmojo/applescript-mcp` | 2026-02-22 (~4mo, just outside 90d) | active | TCC-only; **adds shell exec + SSH** | Secondary, **only after re-verification** (surface-broadening flagged) |
 | `supermemoryai/apple-mcp` (was `dhravya/apple-mcp`) | 2025-08-11 `[historical]` | **archived** ~2026-01 | TCC-only ("explicit access request" = OS prompts only) | Archived reference only (best PIM overlap), with archived caveat |
 | `the-momentum/apple-health-mcp-server` | 2026-02-10 | **EOL/superseded** by "Open Wearables" | offline XML-over-DuckDB; never touches live OS APIs | **Excluded** — mechanism mismatch + EOL |
 
-*Ratified (§11.5).* **Primary baselines: `steipete/macos-automator-mcp` +
-`joshrutkowski/applescript-mcp`** — covering "maximally-capable undefended" and
-"same-tool-shape undefended" (joshrutkowski keeps its `2025-04` staleness caveat).
-**`peakmojo` is secondary only, and only after re-verification at harness-PR time.**
-Arbitrary-script baselines get **no extra degrees of freedom**: they are driven through the
-**same task interface (an adapter)** as the tool-catalog server, so the *task* — not the
-baseline's surface — is the held-constant variable. Baseline version pins are first-class
+*Ratified (§11.5).* The **primary comparison is `capability-matched`**: every baseline is
+driven through the **same task interface (an adapter)** with the **same allowed action set**
+as AirMCP's tool catalog, so the *task* — not the baseline's surface — is the held-constant
+variable. The **run set is `steipete/macos-automator-mcp` + `joshrutkowski/applescript-mcp`**,
+both in capability-matched mode (an arbitrary-script executor and a matched-shape catalog).
+`steipete`'s raw arbitrary-script surface is additionally reported as the **`capability-native`
+*secondary* arm** — labeled, never the headline. `joshrutkowski` keeps its `2025-04` staleness
+caveat and is **not a sole primary data source until re-verified**. **`peakmojo` is secondary
+only, after re-verification at harness-PR time.** Baseline version pins are first-class
 reproducibility inputs (§8); staleness/archival caveats are reported, never hidden.
 
 ---
@@ -380,10 +382,11 @@ The only candidate contributions are the **integrated Apple-native shipping arti
 4. **N / power** — **pilot `N=5`** (harness stability only); **main `N≥30`** per
    `(arm, scenario, model, approval-mode)` with **Wilson / bootstrap CIs**; a smaller `N`
    is labeled **exploratory** with weakened efficacy language. (§7)
-5. **Baseline matrix** — **primary: `steipete/macos-automator-mcp` +
-   `joshrutkowski/applescript-mcp`**; **`peakmojo` secondary, only after re-verification**;
-   arbitrary-script baselines driven through the **same task-interface adapter** (no extra
-   freedom). (§3)
+5. **Baseline matrix** — primary comparison = **`capability-matched`** (every baseline through
+   the **same task-interface adapter**, same allowed action set). **Run set: `steipete` +
+   `joshrutkowski`** (both matched); `steipete`'s raw surface is the **`capability-native`
+   secondary** arm. `joshrutkowski` keeps its staleness caveat (not a sole primary source
+   until re-verified); **`peakmojo` secondary, only after re-verification**. (§3)
 6. **Egress sink + fixture** — **synthetic fixture only** (no real user data), **resettable
    per trial**; sink records **payload / headers / timestamp / trial-id**; **observed side
    effect is the oracle**, not model self-report. (§5/§7)

--- a/docs/experiments/harness-safety-preflight.md
+++ b/docs/experiments/harness-safety-preflight.md
@@ -50,7 +50,12 @@ public env surface, `src/`, the published file set, or product docs.
 *Contract.* Schema: [`schemas/baseline-adapter.schema.json`](./schemas/baseline-adapter.schema.json).
 
 - **`capability-matched` is primary**; **`capability-native` (arbitrary-script's real broader
-  surface) is secondary and explicitly labeled.**
+  surface) is secondary and explicitly labeled.** "Primary/secondary" here is the
+  **comparison tier (capability mode)**, *not* run-priority: the **run set** is `steipete`
+  (which also supplies the native secondary arm) + `joshrutkowski`, both run in
+  capability-matched mode. `joshrutkowski` (code-frozen `2025-04`) carries a staleness caveat
+  and is not a sole primary data source until re-verified; `peakmojo` is secondary, only after
+  re-verification. (Canonical; design §3 / §11.5 align to this.)
 - Every arm uses the **same fixture source, same task interface, same allowed action set, and
   same scenario corpus**. For `capability-matched`, the adapter's allowed action set **equals**
   the shared tool catalog.

--- a/docs/experiments/schemas/baseline-adapter.schema.json
+++ b/docs/experiments/schemas/baseline-adapter.schema.json
@@ -25,7 +25,10 @@
       "type": "string",
       "description": "e.g. steipete/macos-automator-mcp, joshrutkowski/applescript-mcp, peakmojo/applescript-mcp"
     },
-    "role": { "enum": ["primary", "secondary"] },
+    "role": {
+      "enum": ["primary", "secondary"],
+      "description": "Comparison tier — tracks capability_mode, NOT run-priority. capability-matched => primary; capability-native (or re-verification-pending) => secondary. Run-set membership (which baselines run) is recorded separately, not via this field."
+    },
     "capability_mode": {
       "enum": ["capability-matched", "capability-native"],
       "description": "capability-matched: allowed action set equals the shared catalog (primary, clean ablation). capability-native: the baseline's real broader surface (secondary, labeled)."
@@ -44,6 +47,10 @@
     "no_per_arm_exploit": {
       "const": true,
       "description": "No arm receives a bespoke attack; the corpus is applied identically."
+    },
+    "caveat": {
+      "type": "string",
+      "description": "Optional staleness/archival caveat (e.g. code-frozen date). A caveated baseline is not a sole primary data source until re-verified at harness-PR time."
     }
   },
   "allOf": [


### PR DESCRIPTION
## Purpose
Close the baseline primary/secondary inconsistency flagged before the runner PR. The label was stated **three ways** — design §3 table (steipete primary / joshrutkowski secondary), design ratified paragraph + §11.5 (both primary), preflight (capability-matched primary / native secondary). **Doc/schema descriptions only — no runner, scoring, model calls, fixture execution, or README/product changes.**

## Root cause + fix
"primary/secondary" was overloaded across two axes (run-priority vs capability-mode). Canonicalize on the **preflight** framing and disambiguate:
- **Comparison tier = capability mode:** `capability-matched` = **primary**, `capability-native` (steipete's raw arbitrary-script surface) = **secondary-labeled**.
- **Run-set membership stated separately:** `steipete` + `joshrutkowski`, both run in capability-matched mode; steipete also supplies the native secondary arm. No longer called "primary/secondary".
- `joshrutkowski` (code-frozen `2025-04`) keeps its **staleness caveat** — not a sole primary data source until re-verified. `peakmojo` secondary, only after re-verification.

## Aligned sites
design §3 table Role column · design §3 ratified paragraph · design §11.5 item · preflight §2 · `baseline-adapter.schema.json` (`role` description clarified + optional `caveat` field added).

## Verification (all green)
`npm test` 145 suites / 2137 tests · `stats:check` · `llms:check` · `gen:manifest:check` · `build:mcpb:check`. Baseline schema is valid JSON. No residual conflicting phrasing.

## Acknowledged for the (later) harness PR — not in this PR
- P2: tripwire proves *shipped-surface* absence; add real `npm pack --dry-run` / MCPB payload inspection when the harness touches packaging.
- P3: add JSON-Schema *instance* validation tests when policy/oracle/baseline instances are introduced.
