### PR TITLE
docs(experiments): §11.7 current-state re-verification (baseline instances + receipt)

### DIFF
--- a/docs/experiments/baselines/REVERIFY-2026-06-25.md
+++ b/docs/experiments/baselines/REVERIFY-2026-06-25.md
@@ -1,0 +1,77 @@
+# Baseline + prior-art current-state re-verification — 2026-06-25
+
+> §11.7 receipt. **Doc/data only** — no runner, scoring, model calls, or real app automation.
+> This is the current-state evidence that backs the `re_verified` / `sole_primary_data_source`
+> values in the baseline instance files in this directory.
+
+**Time anchor.** `NOW = 2026-06-25 16:06 KST` · `NOW_DATE = 2026-06-25` ·
+`WINDOW_START = 2026-03-27`. Current-state window = `2026-03-27 .. 2026-06-25`.
+
+**Method.** Archived / `pushed_at` come from the **GitHub REST API (authoritative)**, queried
+`2026-06-25`. Safety-model / installability / prior-art / new-entrant facts come from
+**date-anchored** web queries; pages without a clear date were **discarded** as current-state
+evidence; sources dated before `WINDOW_START` are marked `[historical]`. No current-state claim
+is made from training memory.
+
+## Baselines (→ instance files in this directory)
+
+| Baseline | archived | `pushed_at` | in-window | safety model | `re_verified` | `sole_primary_data_source` |
+|---|---|---|---|---|---|---|
+| [`steipete/macos-automator-mcp`](./steipete-macos-automator-mcp.json) | no | **2026-06-23** | **yes** | TCC-only, no app-layer defense | **true** | **true** (matched + re-verified) |
+| [`joshrutkowski/applescript-mcp`](./joshrutkowski-applescript-mcp.json) | no | 2025-04-19 `[historical]` | no (~14mo) | TCC-only | **false** | false |
+| [`peakmojo/applescript-mcp`](./peakmojo-applescript-mcp.json) | no | 2026-02-22 | no (~4mo, pre-window) | TCC-only + shell/SSH | **false** | false |
+
+`steipete` is maintained (npm `@steipete/macos-automator-mcp` 0.4.3, 2026-06-19; 830★) and
+confirmed undefended. `joshrutkowski` is code-frozen since 2025-04 (metadata-only updates → no
+revival possible). `peakmojo` last pushed 2026-02-22 (just outside the window) and broadens the
+surface with shell/SSH → `capability-native`, secondary.
+
+**Partial-failure disclosure (honest).** The `joshrutkowski` and `peakmojo` date-anchored
+web-detail agents **failed transiently** ("connection closed mid-response"). Their
+`re_verified = false` rests on the **authoritative GitHub API `pushed_at`** (both outside the
+window), which is conservative and rules out revival (no in-window code push). Not re-run
+because the determination is fixed and the safety models were already established in the prior
+baseline study; re-running would not change the outcome.
+
+## Prior-art freshness (claim-prohibition line)
+
+**Still current — no scoop.** GAAP (`arXiv:2604.19657`, 2026-04-21), MCP-SafetyBench
+(`2512.15163`, ICLR 2026), MSB (`2510.15994`), MCPTox (`2508.14925`), OWASP MCP Top 10 (still
+**v0.1 beta**), and the taint/IFC line (CaMeL / FIDES / RTBAS / "Ghost in the Agent"
+`2604.23374`, 2026-04-25) all remain the relevant prior art, so the §9 mechanism-novelty
+prohibition is unchanged. New in-window MCP-security work (MCP-DPT `2604.07551`; Agent-Human
+reframing `2605.24309`; MCPSecBench `2508.13220`; TIP `2603.24203`) is all **generic / cloud /
+web** — **none measures a defended-vs-undefended ASR delta on an Apple-native macOS
+personal-data MCP server**, so the open gap is **intact**. One citation hardened: the NSA egress
+guidance now anchors to NSA CSI *"MCP: Security Design Considerations"* (2026-05-20, in-window).
+*No mechanism-novelty claim is added — this only keeps the prohibition line current.*
+
+## New Apple-native MCP entrants (baseline-matrix scan)
+
+- **`griches/apple-mcp` — DEFENDED, flag, do NOT treat as undefended.** Created 2026-03-03,
+  commits through 2026-03-17 (≈10 days **before** window-open; near-window), 105★. Ships
+  app-layer defense: a `--read-only` mode and a `--confirm-destructive` per-call HITL flag.
+  Note/PIM-only (no files/clipboard/health) and **no integrated governance stack** (no audit
+  chain, scope tiers, or egress allowlist). Relevance: AirMCP is no longer the *only* Apple-native
+  server with *any* app-layer defense, but it remains the only one with the integrated stack —
+  and **no ASR measurement exists on any of them**, so the gap holds. If ever added to the matrix
+  it must be classified **defended (partial)**, never undefended.
+- **New undefended candidates (eligible, not required):** `sweetrb/apple-notes-mcp`
+  (last commit 2026-06-24, in-window, Notes-only, TCC-only), `FradSer/mcp-server-apple-events`
+  (2026-05-27, in-window, Reminders+Calendar via EventKit, TCC-only). Both are eligible
+  additional undefended baselines but add no surface beyond the existing set; none covers Health.
+- **Excluded:** `supermemoryai/apple-mcp` (archived 2026-01-01); `vlad-ds/maccy-clipboard-mcp`
+  (last commit 2025-07-21 `[historical]`).
+
+## Sources (date-anchored)
+
+- GitHub REST API — `repos/{steipete/macos-automator-mcp, joshrutkowski/applescript-mcp, peakmojo/applescript-mcp}` (queried 2026-06-25; authoritative archived/`pushed_at`)
+- npm registry — `@steipete/macos-automator-mcp` 0.4.3 (2026-06-19)
+- GAAP <https://arxiv.org/abs/2604.19657> (2026-04-21) · MCP-SafetyBench <https://arxiv.org/abs/2512.15163> (2026-03-05) · MSB <https://arxiv.org/abs/2510.15994> · MCPTox <https://arxiv.org/abs/2508.14925> · Ghost-in-the-Agent <https://arxiv.org/abs/2604.23374> (2026-04-25) · MCP-DPT <https://arxiv.org/abs/2604.07551> (2026-04-08) · Agent-Human <https://arxiv.org/abs/2605.24309> (2026-05-23)
+- NSA CSI "MCP: Security Design Considerations" <https://www.nsa.gov/Press-Room/Press-Releases-Statements/Press-Release-View/Article/4496698/> (2026-05-20) · Equixly NSA↔OWASP mapping (2026-06-04)
+- New entrants — `griches/apple-mcp`, `sweetrb/apple-notes-mcp`, `FradSer/mcp-server-apple-events` (GitHub, dates queried 2026-06-25)
+
+**Caveat.** Web evidence is small-model extraction over abstracts/READMEs; ASR figures are
+indicative, not quoted into the design. "No Apple-native defended-vs-undefended ASR paper exists"
+is a negative-from-absence claim — a non-indexed last-few-days preprint cannot be fully excluded.
+Re-stamp and re-run at the actual harness PR if the window has moved.

--- a/docs/experiments/baselines/joshrutkowski-applescript-mcp.json
+++ b/docs/experiments/baselines/joshrutkowski-applescript-mcp.json
@@ -1,0 +1,23 @@
+{
+  "version": "0.2.0-proposed",
+  "status": "proposed",
+  "baseline_id": "joshrutkowski/applescript-mcp",
+  "capability_mode": "capability-matched",
+  "re_verified": false,
+  "sole_primary_data_source": false,
+  "caveat": "Re-verified 2026-06-25 (GitHub API authoritative): not archived but code-frozen — pushed_at 2025-04-19 [historical, ~14mo]; updated_at 2026-06-22 is metadata-only (no in-window code activity, so no revival possible). Closest matched-shape baseline (discrete typed tools) and TCC-only undefended, but NOT re-verified as current, so it cannot be a sole primary data source until re-verified. NOTE: the date-anchored web-detail agent failed transiently; this determination rests on the authoritative GitHub API pushed_at, which conservatively yields re_verified=false.",
+  "same_fixture_source": true,
+  "same_task_interface": true,
+  "same_allowed_action_set": true,
+  "same_scenario_corpus": true,
+  "no_per_scenario_exploit": true,
+  "no_per_arm_exploit": true,
+  "conformance": {
+    "no_content_modification": true,
+    "no_self_gating_beyond_shared_approver": true,
+    "no_sanitization_or_rewriting": true,
+    "passes_through_errors_and_results": true,
+    "out_of_set_refusal_owner": "harness_dispatcher",
+    "native_tcc_prompt_counts_as_defense": false
+  }
+}

--- a/docs/experiments/baselines/peakmojo-applescript-mcp.json
+++ b/docs/experiments/baselines/peakmojo-applescript-mcp.json
@@ -1,0 +1,23 @@
+{
+  "version": "0.2.0-proposed",
+  "status": "proposed",
+  "baseline_id": "peakmojo/applescript-mcp",
+  "capability_mode": "capability-native",
+  "re_verified": false,
+  "sole_primary_data_source": false,
+  "caveat": "Re-verified 2026-06-25 (GitHub API authoritative): not archived; pushed_at 2026-02-22 — just OUTSIDE the 2026-03-27 window start (~4mo). Adds shell exec + SSH (surface-broadening beyond AirMCP's catalog) -> classified capability-native, secondary only. Not re-verified as current. NOTE: the date-anchored web-detail agent failed transiently; this determination rests on the authoritative GitHub API pushed_at.",
+  "same_fixture_source": true,
+  "same_task_interface": true,
+  "same_allowed_action_set": false,
+  "same_scenario_corpus": true,
+  "no_per_scenario_exploit": true,
+  "no_per_arm_exploit": true,
+  "conformance": {
+    "no_content_modification": true,
+    "no_self_gating_beyond_shared_approver": true,
+    "no_sanitization_or_rewriting": true,
+    "passes_through_errors_and_results": true,
+    "out_of_set_refusal_owner": "harness_dispatcher",
+    "native_tcc_prompt_counts_as_defense": false
+  }
+}

--- a/docs/experiments/baselines/steipete-macos-automator-mcp.json
+++ b/docs/experiments/baselines/steipete-macos-automator-mcp.json
@@ -1,0 +1,23 @@
+{
+  "version": "0.2.0-proposed",
+  "status": "proposed",
+  "baseline_id": "steipete/macos-automator-mcp",
+  "capability_mode": "capability-matched",
+  "re_verified": true,
+  "sole_primary_data_source": true,
+  "caveat": "Re-verified 2026-06-25 (GitHub API + date-anchored web): not archived; pushed_at 2026-06-23 (in-window); npm @steipete/macos-automator-mcp 0.4.3 published 2026-06-19; 830 stars; MIT; Node >=24. TCC-only thin wrapper with NO app-layer defense (no per-call HITL, no permission tiers, no egress allowlist, no audit log). Maintained + installable. This baseline also supplies the capability-native secondary arm (its raw arbitrary-script surface).",
+  "same_fixture_source": true,
+  "same_task_interface": true,
+  "same_allowed_action_set": true,
+  "same_scenario_corpus": true,
+  "no_per_scenario_exploit": true,
+  "no_per_arm_exploit": true,
+  "conformance": {
+    "no_content_modification": true,
+    "no_self_gating_beyond_shared_approver": true,
+    "no_sanitization_or_rewriting": true,
+    "passes_through_errors_and_results": true,
+    "out_of_set_refusal_owner": "harness_dispatcher",
+    "native_tcc_prompt_counts_as_defense": false
+  }
+}

--- a/docs/experiments/defended-vs-undefended-ablation-design.md
+++ b/docs/experiments/defended-vs-undefended-ablation-design.md
@@ -166,6 +166,17 @@ caveat and is **not a sole primary data source until re-verified**. **`peakmojo`
 only, after re-verification at harness-PR time.** Baseline version pins are first-class
 reproducibility inputs (§8); staleness/archival caveats are reported, never hidden.
 
+*Re-verified 2026-06-25* (§11.7 receipt: [`baselines/REVERIFY-2026-06-25.md`](./baselines/REVERIFY-2026-06-25.md); per-baseline instances under [`baselines/`](./baselines/)). Outcome:
+`steipete` **`re_verified=true`** (pushed 2026-06-23, npm 0.4.3, maintained, TCC-only) → eligible
+`sole_primary_data_source`; `joshrutkowski` (code-frozen 2025-04-19) and `peakmojo` (pushed
+2026-02-22, pre-window; shell/SSH) stay **`re_verified=false` / not sole-primary**. New-entrant
+scan flag: **`griches/apple-mcp` is a *defended* Apple-native server** (read-only +
+confirm-destructive HITL, note/PIM-only, no integrated governance stack) — it is **not** an
+undefended baseline and must never be classified as one; new *undefended* candidates
+(`sweetrb/apple-notes-mcp`, `FradSer/mcp-server-apple-events`) are eligible but add no surface
+beyond the set. Prior-art line re-checked: **still current, no scoop** — the Apple-native
+defended-vs-undefended ASR gap is intact (§10).
+
 ---
 
 ## 4. Scenario set
@@ -419,7 +430,10 @@ implementation itself remains *proposed work, not yet started*):
 
 7. **Re-stamp the time anchor** at harness-PR start (`NOW / NOW_DATE / WINDOW_START`) and
    **re-verify** the baseline maintenance/archival facts (§3) and the prior-art (§10);
-   current-state facts in this document **expire** after the window.
+   current-state facts in this document **expire** after the window. **Performed once on
+   2026-06-25** — receipt + per-baseline instances under [`baselines/`](./baselines/)
+   (steipete `re_verified=true`; joshrutkowski/peakmojo `false`; prior-art intact, no scoop;
+   `griches/apple-mcp` flagged *defended*). **Re-run when the window moves** before the harness runs.
 
 ---
 

--- a/tests/baseline-adapter-schema.test.js
+++ b/tests/baseline-adapter-schema.test.js
@@ -7,7 +7,7 @@
  * pass or must be rejected. Design ref: harness-safety-preflight §2; ablation §3/§11.5.
  */
 import { describe, test, expect } from "@jest/globals";
-import { readFileSync } from "node:fs";
+import { readFileSync, readdirSync, existsSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import Ajv2020 from "ajv/dist/2020.js";
@@ -99,6 +99,24 @@ describe("baseline-adapter schema — negative fixtures are rejected", () => {
   for (const [name, instance] of Object.entries(INVALID)) {
     test(name, () => {
       expect(validate(instance)).toBe(false);
+    });
+  }
+});
+
+describe("baseline-adapter schema — on-disk baseline instances conform", () => {
+  const dir = join(ROOT, "docs", "experiments", "baselines");
+  const files = existsSync(dir) ? readdirSync(dir).filter((f) => f.endsWith(".json")) : [];
+
+  test("at least one baseline instance exists", () => {
+    expect(files.length).toBeGreaterThan(0);
+  });
+
+  for (const f of files) {
+    test(`${f} conforms to baseline-adapter.schema.json`, () => {
+      const instance = JSON.parse(readFileSync(join(dir, f), "utf8"));
+      const ok = validate(instance);
+      if (!ok) console.error(f, validate.errors);
+      expect(ok).toBe(true);
     });
   }
 });


### PR DESCRIPTION
## Purpose
§11.7 **current-state re-verification** — the un-blocker before any runner. Re-stamps the time anchor, re-verifies the baselines + prior-art with date-anchored evidence, and fills the actual baseline instances per the schema. **Doc/data only — no runner, scoring, model calls, or real app automation. README/product copy untouched.**

**Time anchor:** `NOW=2026-06-25 16:06 KST` · window `2026-03-27 .. 2026-06-25`.

## Baselines (GitHub REST API authoritative + date-anchored web)
| baseline | pushed_at | in-window | `re_verified` | `sole_primary_data_source` |
|---|---|---|---|---|
| `steipete/macos-automator-mcp` | **2026-06-23** | yes | **true** | **true** (matched + re-verified; npm 0.4.3, 830★, TCC-only) |
| `joshrutkowski/applescript-mcp` | 2025-04-19 `[historical]` | no | **false** | false |
| `peakmojo/applescript-mcp` | 2026-02-22 (pre-window) | no | **false** | false (capability-native; shell/SSH) |

The schema invariants are **executable-enforced on the real instances** — `baseline-adapter-schema.test.js` now validates every file in `docs/experiments/baselines/`, so a not-re-verified baseline cannot carry `sole_primary_data_source:true`.

## Prior-art + new entrants
- **Prior-art: still current, no scoop.** The Apple-native defended-vs-undefended ASR gap is intact; NSA CSI *"MCP: Security Design Considerations"* (2026-05-20) added as a hard anchor. No mechanism-novelty claim added.
- **Flag: `griches/apple-mcp` is a DEFENDED Apple-native server** (read-only + confirm-destructive HITL, note/PIM-only, no integrated governance stack) → **not** an undefended baseline. New undefended candidates (`sweetrb/apple-notes-mcp`, `FradSer/mcp-server-apple-events`) eligible but add no surface.

## Honest note
The `joshrutkowski`/`peakmojo` date-anchored web-detail agents failed transiently; their `re_verified=false` rests on the **authoritative GitHub API `pushed_at`** (conservative — rules out revival since no in-window push). Not re-run because the outcome is fixed.

## Deliverables
3 baseline instances + `REVERIFY-2026-06-25.md` receipt under `docs/experiments/baselines/`; on-disk instance validation test; design §3 + §11.7 updates.

## Verification
`npm test` **147 suites / 2158 tests**, `stats:check`, `llms:check`, `gen:manifest:check`, `build:mcpb:check` green.
