### PR TITLE
feat(experiments): runner-zero plumbing (matrix + trial-record format, no execution)

### DIFF
--- a/docs/experiments/defended-vs-undefended-ablation-design.md
+++ b/docs/experiments/defended-vs-undefended-ablation-design.md
@@ -323,6 +323,16 @@ this runtime ablation does **not** measure, and are marked as such.
    instrumentation are **frozen before any run** and committed, so code cannot steer the
    conclusion.
 
+**Runner-zero (dry plumbing — started, no execution).** The measurement *plumbing* — loading +
+schema-validating the ratified baseline instances, building the **static run matrix** (arms ×
+scenarios × approval-modes × models, each cell `planned`; not-re-verified arms flagged
+`pre_run_recheck_required`), and the **trial-record format**
+([`schemas/trial-record.schema.json`](./schemas/trial-record.schema.json), which forbids any
+ASR/score field) — lives **unshipped** in [`experiments/ablation/`](../../experiments/ablation/)
+and is exercised by `tests/ablation-plumbing.test.js`. **Still `proposed` / not started:**
+scenario execution, model calls, real app automation, scoring, the bypass implementation, and
+any result numbers.
+
 ---
 
 ## 8. Reproducibility conditions

--- a/docs/experiments/schemas/trial-record.schema.json
+++ b/docs/experiments/schemas/trial-record.schema.json
@@ -1,0 +1,73 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "trial-record.schema.json",
+  "title": "Per-trial record (runner-zero format)",
+  "description": "The shape of one ablation trial record. Outcome/observation fields are null until run time (no execution in runner-zero). `additionalProperties:false` deliberately forbids any asr / score / percentage field — result numbers are not permitted until the experiment is run and reported (design §9). Design ref: §5 (outcome taxonomy + block_source), §7 (per-trial record), §11.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema", "trial_id", "arm", "scenario", "model", "approval_mode", "status"],
+  "properties": {
+    "schema": { "const": "trial-record/v0" },
+    "trial_id": { "type": "string" },
+    "arm": { "type": "string", "description": "airmcp/defended-full or a baseline_id" },
+    "scenario": { "type": "string", "pattern": "^S[0-9]+$" },
+    "model": { "type": "string" },
+    "approval_mode": { "enum": ["ASR_auto", "ASR_humanlike"] },
+    "status": { "enum": ["planned", "ran", "errored"] },
+    "outcome": {
+      "type": ["string", "null"],
+      "enum": ["success", "blocked", "partial", "false_positive", "error", null],
+      "description": "The five-bucket outcome; null until run."
+    },
+    "block_source": {
+      "type": ["string", "null"],
+      "enum": [
+        "hitl_deny",
+        "scope_403",
+        "rate_limit",
+        "egress_reject",
+        "escaper",
+        "harness_auto_deny",
+        "model_no_tool_call",
+        "os_tcc",
+        "env_error",
+        "none",
+        null
+      ],
+      "description": "Which guard fired. Only the first five (named server guards) count as AirMCP defense."
+    },
+    "counts_as_airmcp_defense": {
+      "type": ["boolean", "null"],
+      "description": "true ONLY when block_source is a named server guard; null until run."
+    },
+    "oracle_channels": {
+      "type": "array",
+      "uniqueItems": true,
+      "items": {
+        "enum": [
+          "http_egress_sink",
+          "mock_workspace_sink",
+          "filesystem_side_effect_observer",
+          "eventkit_state_observer",
+          "sensitive_read_observer",
+          "scope_decision_assertion",
+          "audit_chain_assertion"
+        ]
+      }
+    },
+    "observed_side_effect": {
+      "description": "The oracle observation (object) or null. Model self-report is NEVER an oracle.",
+      "type": ["object", "null"]
+    },
+    "bypass_in_effect": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "§11.1 metadata: experiment-layer defenses bypassed this trial; [] for non-ablation."
+    },
+    "baseline_snapshot": {
+      "type": ["object", "null"],
+      "description": "Provenance: the arm's re_verified / pushed_at at run time."
+    },
+    "timing_ms": { "type": ["number", "null"] }
+  }
+}

--- a/experiments/README.md
+++ b/experiments/README.md
@@ -1,0 +1,24 @@
+# experiments/ — ablation experiment code (UNSHIPPED)
+
+This tree is **experiment / companion-layer** code for the defended-vs-undefended ASR
+ablation. It is **not** part of the AirMCP product:
+
+- It lives **outside `src/`**, so it never compiles into `dist/`.
+- `package.json` publishes only `dist` (`files: ["dist"]`) and the `.mcpb` bundle copies only
+  `dist`, so nothing here ships to npm or MCPB. (Enforced by
+  `tests/experiment-bypass-tripwire.test.js`.)
+
+## Status: runner-zero (dry plumbing only)
+
+`ablation/` currently contains **measurement-plumbing integrity** only — no evaluation:
+
+- `plan.mjs` — load the ratified baseline instances, build a **static run matrix** (no
+  execution), carry each arm's `re_verified` / `sole_primary_data_source`, and flag cells that
+  need an installability/safety re-check right before they run (`pre_run_recheck_required`).
+- `trial-record.mjs` — the **trial-record format** + metadata fields (outcome buckets,
+  `block_source` enum, oracle channels, bypass-in-effect, baseline snapshot). Validated against
+  `docs/experiments/schemas/trial-record.schema.json`.
+
+**Explicitly NOT here (still `proposed`):** model calls, real app automation, scenario
+execution, scoring, the experiment-layer bypass implementation, and any ASR / result numbers.
+Goal of this stage is plumbing integrity, not evaluation results.

--- a/experiments/ablation/plan.mjs
+++ b/experiments/ablation/plan.mjs
@@ -1,0 +1,71 @@
+// Runner-zero: static run-matrix plumbing for the defended-vs-undefended ASR ablation.
+// Pure + side-effect-free except reading the ratified baseline instance files. NO model
+// calls, NO real app automation, NO scoring, NO ASR numbers. Lives outside src/ (unshipped).
+// Design ref: docs/experiments/defended-vs-undefended-ablation-design.md §3/§4/§5/§7.
+
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+export const SCENARIOS = ["S1", "S2", "S3", "S4", "S5", "S6", "S7", "S8"];
+export const APPROVAL_MODES = ["ASR_auto", "ASR_humanlike"];
+
+// The defended reference arm. Per-mechanism ablation arms are deferred: they need the
+// experiment-layer bypass flags, which are NOT implemented in this PR.
+export const AIRMCP_ARM = {
+  arm: "airmcp/defended-full",
+  kind: "defended",
+  re_verified: true,
+  sole_primary_data_source: true,
+};
+
+/** Load the ratified baseline instance files (read + parse only; schema validation is the
+ *  test's / schema's job). Returns instances sorted by filename for determinism. */
+export function loadBaselineInstances(dir) {
+  return readdirSync(dir)
+    .filter((f) => f.endsWith(".json"))
+    .sort()
+    .map((f) => ({ file: f, ...JSON.parse(readFileSync(join(dir, f), "utf8")) }));
+}
+
+/** Build the STATIC run matrix (no execution). Every cell is `status: "planned"` and carries
+ *  no outcome/score. A not-re-verified undefended arm is flagged for an installability/safety
+ *  re-check immediately before it actually runs. */
+export function buildRunMatrix({ baselines, scenarios = SCENARIOS, approvalModes = APPROVAL_MODES, models } = {}) {
+  // No model is chosen yet (no model calls in runner-zero) — placeholder dimension.
+  const modelList = models && models.length ? models : ["<model-TBD>"];
+
+  const arms = [
+    AIRMCP_ARM,
+    ...baselines.map((b) => ({
+      arm: b.baseline_id,
+      kind: "undefended",
+      capability_mode: b.capability_mode,
+      re_verified: b.re_verified,
+      sole_primary_data_source: b.sole_primary_data_source,
+    })),
+  ];
+
+  const cells = [];
+  for (const a of arms) {
+    for (const scenario of scenarios) {
+      for (const model of modelList) {
+        for (const approval_mode of approvalModes) {
+          cells.push({
+            arm: a.arm,
+            kind: a.kind,
+            re_verified: a.re_verified ?? null,
+            sole_primary_data_source: a.sole_primary_data_source ?? null,
+            scenario,
+            model,
+            approval_mode,
+            status: "planned",
+            // Stale / not-re-verified arms must be re-checked (installability + safety model)
+            // right before execution — see REVERIFY receipt + §11.7.
+            pre_run_recheck_required: a.kind === "undefended" && a.re_verified === false,
+          });
+        }
+      }
+    }
+  }
+  return cells;
+}

--- a/experiments/ablation/trial-record.mjs
+++ b/experiments/ablation/trial-record.mjs
@@ -1,0 +1,60 @@
+// Runner-zero: the per-trial record FORMAT + metadata fields. No execution, no scoring.
+// The record is filled at run time by a later PR; here we only fix its shape and the
+// taxonomy helpers. Validated against docs/experiments/schemas/trial-record.schema.json.
+// Design ref: §5 (outcome taxonomy + block_source), §7 (per-trial record), §11.
+
+export const OUTCOMES = ["success", "blocked", "partial", "false_positive", "error"];
+
+export const BLOCK_SOURCES = [
+  "hitl_deny",
+  "scope_403",
+  "rate_limit",
+  "egress_reject",
+  "escaper",
+  "harness_auto_deny",
+  "model_no_tool_call",
+  "os_tcc",
+  "env_error",
+  "none",
+];
+
+// Only a NAMED SERVER GUARD counts as AirMCP defense (§5/§11.3). harness_auto_deny /
+// model_no_tool_call / os_tcc / env_error are NOT AirMCP defense.
+export const SERVER_GUARDS = ["hitl_deny", "scope_403", "rate_limit", "egress_reject", "escaper"];
+
+export const ORACLE_CHANNELS = [
+  "http_egress_sink",
+  "mock_workspace_sink",
+  "filesystem_side_effect_observer",
+  "eventkit_state_observer",
+  "sensitive_read_observer",
+  "scope_decision_assertion",
+  "audit_chain_assertion",
+];
+
+/** A block is credited to AirMCP's defense ONLY when a named server guard fired. */
+export function countsAsAirmcpDefense(block_source) {
+  return SERVER_GUARDS.includes(block_source);
+}
+
+/** An empty, planned trial record. Outcome/observation fields are null until run time; there
+ *  are deliberately NO asr / score / percentage fields (forbidden until measured). */
+export function newTrialRecord({ trial_id, arm, scenario, model, approval_mode }) {
+  return {
+    schema: "trial-record/v0",
+    trial_id,
+    arm,
+    scenario,
+    model,
+    approval_mode,
+    status: "planned",
+    outcome: null,
+    block_source: null,
+    counts_as_airmcp_defense: null,
+    oracle_channels: [],
+    observed_side_effect: null, // oracle observation only; model self-report is NOT an oracle
+    bypass_in_effect: [], // §11.1 metadata: which defenses (if any) were bypassed this trial
+    baseline_snapshot: null, // provenance: re_verified / pushed_at at run time
+    timing_ms: null,
+  };
+}

--- a/tests/ablation-plumbing.test.js
+++ b/tests/ablation-plumbing.test.js
@@ -1,0 +1,131 @@
+/**
+ * Runner-zero plumbing integrity (NO execution).
+ *
+ * Verifies the measurement plumbing without running anything: the ratified baseline
+ * instances load + schema-validate (fail if invalid), the static run matrix is built with
+ * the expected shape + the pre-run-recheck flags, the trial-record format validates, and the
+ * "only a named server guard counts as AirMCP defense" rule holds. NO model calls, NO real
+ * app automation, NO scoring, NO ASR numbers. Design ref: §3/§4/§5/§7/§11.
+ */
+import { describe, test, expect } from "@jest/globals";
+import { readFileSync, readdirSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import Ajv2020 from "ajv/dist/2020.js";
+
+import {
+  SCENARIOS,
+  APPROVAL_MODES,
+  AIRMCP_ARM,
+  loadBaselineInstances,
+  buildRunMatrix,
+} from "../experiments/ablation/plan.mjs";
+import {
+  newTrialRecord,
+  countsAsAirmcpDefense,
+  ORACLE_CHANNELS,
+  SERVER_GUARDS,
+} from "../experiments/ablation/trial-record.mjs";
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..");
+const SCHEMAS = join(ROOT, "docs", "experiments", "schemas");
+const BASELINES = join(ROOT, "docs", "experiments", "baselines");
+
+const ajv = new Ajv2020({ allErrors: true, strict: false });
+const validateBaseline = ajv.compile(
+  JSON.parse(readFileSync(join(SCHEMAS, "baseline-adapter.schema.json"), "utf8")),
+);
+const validateTrial = ajv.compile(
+  JSON.parse(readFileSync(join(SCHEMAS, "trial-record.schema.json"), "utf8")),
+);
+
+const noNumbersLeak = (obj) =>
+  Object.keys(obj).filter((k) => /asr|score|percent/i.test(k));
+
+describe("runner-zero — baseline instances load + validate", () => {
+  const instances = loadBaselineInstances(BASELINES);
+
+  test("loads the ratified baseline instances", () => {
+    expect(instances.length).toBeGreaterThanOrEqual(3);
+  });
+
+  test("every instance schema-validates (fail if not)", () => {
+    for (const inst of instances) {
+      const { file, ...instance } = inst; // `file` is a loader annotation, not part of the schema
+      const ok = validateBaseline(instance);
+      if (!ok) console.error(file, validateBaseline.errors);
+      expect(ok).toBe(true);
+    }
+  });
+
+  test("a not-re-verified baseline never claims sole-primary (load-bearing, on real data)", () => {
+    for (const inst of instances) {
+      if (inst.re_verified === false) expect(inst.sole_primary_data_source).toBe(false);
+    }
+  });
+});
+
+describe("runner-zero — static run matrix (no execution)", () => {
+  const baselines = loadBaselineInstances(BASELINES);
+  const cells = buildRunMatrix({ baselines });
+
+  test("cell count = arms x scenarios x models(placeholder) x approval-modes", () => {
+    const arms = 1 + baselines.length; // airmcp + baselines
+    expect(cells.length).toBe(arms * SCENARIOS.length * 1 * APPROVAL_MODES.length);
+  });
+
+  test("every cell is planned and carries NO result/score field", () => {
+    for (const c of cells) {
+      expect(c.status).toBe("planned");
+      expect(noNumbersLeak(c)).toEqual([]);
+      expect("outcome" in c).toBe(false); // outcome lives on the trial record, not the plan cell
+    }
+  });
+
+  test("not-re-verified undefended arms are flagged for a pre-run re-check; airmcp + re-verified are not", () => {
+    const recheckArms = new Set(cells.filter((c) => c.pre_run_recheck_required).map((c) => c.arm));
+    const noRecheckArms = new Set(cells.filter((c) => !c.pre_run_recheck_required).map((c) => c.arm));
+    // The defended arm and any re_verified baseline must NOT require a pre-run re-check.
+    expect(noRecheckArms.has(AIRMCP_ARM.arm)).toBe(true);
+    // Exactly the re_verified===false baselines require it.
+    const expectRecheck = new Set(
+      baselines.filter((b) => b.re_verified === false).map((b) => b.baseline_id),
+    );
+    expect(recheckArms).toEqual(expectRecheck);
+  });
+});
+
+describe("runner-zero — trial-record format + defense attribution", () => {
+  test("a fresh trial record is planned, has no scores, and validates against the schema", () => {
+    const rec = newTrialRecord({
+      trial_id: "t-0001",
+      arm: "airmcp/defended-full",
+      scenario: "S1",
+      model: "<model-TBD>",
+      approval_mode: "ASR_auto",
+    });
+    expect(rec.status).toBe("planned");
+    expect(noNumbersLeak(rec)).toEqual([]);
+    const ok = validateTrial(rec);
+    if (!ok) console.error(validateTrial.errors);
+    expect(ok).toBe(true);
+  });
+
+  test("the schema rejects a stray result field (no ASR numbers permitted)", () => {
+    const rec = newTrialRecord({ trial_id: "t", arm: "a", scenario: "S2", model: "m", approval_mode: "ASR_humanlike" });
+    expect(validateTrial({ ...rec, asr: 0.42 })).toBe(false);
+  });
+
+  test("only a named server guard counts as AirMCP defense", () => {
+    for (const g of SERVER_GUARDS) expect(countsAsAirmcpDefense(g)).toBe(true);
+    for (const g of ["harness_auto_deny", "model_no_tool_call", "os_tcc", "env_error", "none"]) {
+      expect(countsAsAirmcpDefense(g)).toBe(false);
+    }
+  });
+
+  test("the trial-record oracle channels match the ratified 7-channel set", () => {
+    const oracleSchema = JSON.parse(readFileSync(join(SCHEMAS, "oracle-mapping.schema.json"), "utf8"));
+    const schemaChannels = oracleSchema.properties.channels.items.enum;
+    expect([...ORACLE_CHANNELS].sort()).toEqual([...schemaChannels].sort());
+  });
+});


### PR DESCRIPTION
## Purpose
**Runner-zero / dry plumbing** — measurement-plumbing *integrity*, not evaluation. **NO model calls, NO real app automation, NO scoring, NO bypass implementation, NO ASR/result numbers.** Experiment code lives **outside `src/`** in `experiments/` (unshipped: `files: ["dist"]`, `.mcpb` copies `dist` only), so all bypass tripwires stay green.

Window unchanged since the 2026-06-25 re-verification → no §11.7 re-stamp needed.

## What it does (all dry)
- `experiments/ablation/plan.mjs` — `loadBaselineInstances()` + `buildRunMatrix()`: a **static run matrix** (arms × scenarios × approval-modes × models, every cell `planned`). Carries each arm's `re_verified` / `sole_primary_data_source`, and flags not-re-verified undefended arms **`pre_run_recheck_required`** — i.e. re-check installability/safety right before they run (the reviewer's note on the two stale baselines, **made executable**).
- `experiments/ablation/trial-record.mjs` — the trial-record factory + the taxonomy rule `countsAsAirmcpDefense` (only a **named server guard** counts as AirMCP defense).
- `docs/experiments/schemas/trial-record.schema.json` — the trial-record format; **`additionalProperties:false` forbids any `asr`/`score` field** (no numbers until measured).
- `tests/ablation-plumbing.test.js` — instances load + schema-validate (fail if invalid); matrix shape + recheck flags; trial-record validates; a stray `asr` field is **rejected**; defense-attribution rule; oracle channels match the ratified 7-channel set.

## Out of scope (still `proposed`)
Scenario execution · model calls · real app automation · scoring · the experiment-layer bypass implementation · final partial weights · any result numbers.

## Verification
`npm test` **148 suites / 2168 tests**; experiment-bypass tripwire green; `npm pack` payload carries **0 experiment paths**; `stats:check` / `llms:check` / `gen:manifest:check` / `build:mcpb:check` / `version:check` green.

⚠️ **Pre-existing flake (not from this PR):** `tests/circuit-breaker.test.js` ("HALF_OPEN releases the probe slot after a failed probe") is a timing flake — failed 1/4 under load, green on retry; not in this diff, no `src/` change. Spun off a deflake task. If CI flakes on it, re-run the job.
