### PR TITLE
fix(circuit-breaker): deflake timing tests via injected clock seam

### DIFF
--- a/src/shared/circuit-breaker.ts
+++ b/src/shared/circuit-breaker.ts
@@ -43,6 +43,8 @@ export interface BreakerOptions {
   openMs: number;
   /** Optional identifier for log lines (e.g. "open-meteo"). */
   name?: string;
+  /** Test seam: monotonic clock source in ms. Default: `Date.now`. */
+  now?: () => number;
 }
 
 export class BreakerOpenError extends Error {
@@ -69,17 +71,19 @@ export class CircuitBreaker {
   private readonly name: string;
   private readonly failureThreshold: number;
   private readonly openMs: number;
+  private readonly now: () => number;
 
   constructor(opts: BreakerOptions) {
     this.name = opts.name ?? "anonymous";
     this.failureThreshold = opts.failureThreshold;
     this.openMs = opts.openMs;
+    this.now = opts.now ?? Date.now;
   }
 
   /** Run `fn` through the breaker. Throws `BreakerOpenError` when OPEN. */
   async execute<T>(fn: () => Promise<T>): Promise<T> {
     if (this.state === "open") {
-      const elapsed = Date.now() - this.openedAt;
+      const elapsed = this.now() - this.openedAt;
       if (elapsed < this.openMs) {
         throw new BreakerOpenError(this.name, this.openMs - elapsed);
       }
@@ -148,7 +152,7 @@ export class CircuitBreaker {
 
   private trip(reason: "probe-failed" | "threshold-reached"): void {
     this.state = "open";
-    this.openedAt = Date.now();
+    this.openedAt = this.now();
     this.probeInFlight = false;
     const event = reason === "probe-failed" ? "re-opened" : "tripped — opening";
     log.warn(`circuit breaker ${event}`, {
@@ -176,6 +180,7 @@ export function getBreaker(name: string, opts?: Partial<BreakerOptions>): Circui
       failureThreshold: opts?.failureThreshold ?? 5,
       openMs: opts?.openMs ?? 30_000,
       name,
+      now: opts?.now,
     });
     breakers.set(name, b);
   }

--- a/tests/circuit-breaker.test.js
+++ b/tests/circuit-breaker.test.js
@@ -35,6 +35,18 @@ afterEach(() => {
   else process.env.AIRMCP_TEST_MODE = ORIG_TEST_MODE;
 });
 
+// Deterministic clock seam — replaces real setTimeout waits so the
+// open->half_open eligibility never races under CI load.
+function clock(start = 0) {
+  let t = start;
+  return {
+    now: () => t,
+    advance: (ms) => {
+      t += ms;
+    },
+  };
+}
+
 describe("CircuitBreaker", () => {
   test("CLOSED stays CLOSED on success", async () => {
     const b = new CircuitBreaker({ failureThreshold: 3, openMs: 1000, name: "t" });
@@ -79,12 +91,13 @@ describe("CircuitBreaker", () => {
   });
 
   test("OPEN → HALF_OPEN → CLOSED on successful probe", async () => {
-    const b = new CircuitBreaker({ failureThreshold: 1, openMs: 10, name: "t" });
+    const c = clock();
+    const b = new CircuitBreaker({ failureThreshold: 1, openMs: 10, name: "t", now: c.now });
     await expect(b.execute(async () => { throw new Error("trip"); })).rejects.toThrow("trip");
     expect(b.getState()).toBe("open");
 
-    // Wait past openMs.
-    await new Promise((r) => setTimeout(r, 20));
+    // Advance past openMs deterministically.
+    c.advance(20);
 
     // First post-openMs call: probe runs, succeeds → state should close.
     const r = await b.execute(async () => "probe-ok");
@@ -94,11 +107,12 @@ describe("CircuitBreaker", () => {
   });
 
   test("OPEN → HALF_OPEN → OPEN on failed probe", async () => {
-    const b = new CircuitBreaker({ failureThreshold: 1, openMs: 10, name: "t" });
+    const c = clock();
+    const b = new CircuitBreaker({ failureThreshold: 1, openMs: 10, name: "t", now: c.now });
     await expect(b.execute(async () => { throw new Error("trip"); })).rejects.toThrow("trip");
     expect(b.getState()).toBe("open");
 
-    await new Promise((r) => setTimeout(r, 20));
+    c.advance(20);
 
     // Probe fails — back to OPEN immediately.
     await expect(b.execute(async () => { throw new Error("probe-fail"); })).rejects.toThrow("probe-fail");
@@ -130,10 +144,11 @@ describe("CircuitBreaker", () => {
     // Regression for the 2nd-pass audit (2026-05-21) — prior implementation
     // let two concurrent callers both transition to HALF_OPEN and both run
     // their fn() in parallel, violating the single-probe contract.
-    const b = new CircuitBreaker({ failureThreshold: 1, openMs: 10, name: "race" });
+    const c = clock();
+    const b = new CircuitBreaker({ failureThreshold: 1, openMs: 10, name: "race", now: c.now });
     await expect(b.execute(async () => { throw new Error("trip"); })).rejects.toThrow("trip");
     expect(b.getState()).toBe("open");
-    await new Promise((r) => setTimeout(r, 20));
+    c.advance(20);
 
     let probeCalls = 0;
     const slowProbe = async () => {
@@ -164,9 +179,10 @@ describe("CircuitBreaker", () => {
     // the in-flight flag (it transitions back to OPEN, so subsequent
     // callers get a normal BreakerOpenError with retryInMs > 0, not an
     // immediate-retry response based on a stuck flag).
-    const b = new CircuitBreaker({ failureThreshold: 1, openMs: 10, name: "race-fail" });
+    const c = clock();
+    const b = new CircuitBreaker({ failureThreshold: 1, openMs: 10, name: "race-fail", now: c.now });
     await expect(b.execute(async () => { throw new Error("trip"); })).rejects.toThrow("trip");
-    await new Promise((r) => setTimeout(r, 20));
+    c.advance(20);
 
     await expect(b.execute(async () => { throw new Error("probe-fail"); })).rejects.toThrow("probe-fail");
     expect(b.getState()).toBe("open");


### PR DESCRIPTION
## Purpose
Narrow **deflake** of the known `circuit-breaker` timing flake — *before* any real runner execution, so flaky CI can't corrupt trust in later runner failures (the evaluation chain is now gate-heavy). No product behavior change.

## The flake
`tests/circuit-breaker.test.js` → "HALF_OPEN releases the probe slot after a failed probe" failed ~1/4 under load. The HALF_OPEN tests used `openMs: 10` + a real `setTimeout(20)` wait, so under CI/GC load real time could cross `openMs` between two awaited statements — the breaker became HALF_OPEN-eligible again and the short-circuit assertion raced.

## Fix
- `src/shared/circuit-breaker.ts`: add a `now?: () => number` **clock seam** to `BreakerOptions` (default `Date.now` — **production behavior unchanged**); replace the two `Date.now()` reads with `this.now()`; thread `now` through `getBreaker`.
- `tests/circuit-breaker.test.js`: the four time-based tests drive a deterministic in-test clock (`c.advance(20)`) instead of sleeping → no real-timer race (and faster).

## Verification
`circuit-breaker` suite **13/13 green five runs in a row** (was ~1/4 fail); full `npm test` **148 suites / 2168 tests**; `lint` + `typecheck` green. Diff: 2 files.
