### PR TITLE
feat(experiments): trial-record consistency guard (4-split invariants + validate-or-die)

### DIFF
--- a/docs/experiments/defended-vs-undefended-ablation-design.md
+++ b/docs/experiments/defended-vs-undefended-ablation-design.md
@@ -326,10 +326,19 @@ this runtime ablation does **not** measure, and are marked as such.
 **Runner-zero (dry plumbing — started, no execution).** The measurement *plumbing* — loading +
 schema-validating the ratified baseline instances, building the **static run matrix** (arms ×
 scenarios × approval-modes × models, each cell `planned`; not-re-verified arms flagged
-`pre_run_recheck_required`), and the **trial-record format**
-([`schemas/trial-record.schema.json`](./schemas/trial-record.schema.json), which forbids any
-ASR/score field) — lives **unshipped** in [`experiments/ablation/`](../../experiments/ablation/)
-and is exercised by `tests/ablation-plumbing.test.js`. **Still `proposed` / not started:**
+`pre_run_recheck_required`), and the **consistency-guarded trial-record format** — live
+**unshipped** in [`experiments/ablation/`](../../experiments/ablation/), exercised by
+`tests/ablation-plumbing.test.js` + `tests/trial-record-consistency.test.js`. The trial record
+([`schemas/trial-record.schema.json`](./schemas/trial-record.schema.json)) forbids any ASR/score
+field and enforces cross-field consistency **four ways**: **structural** couplings via schema
+`if/then` (`planned` ⇒ measured fields null; `errored` ⇒ `outcome=error` + `block_source=env_error`;
+`success` ⇒ `block_source=none`; `blocked`/`false_positive` ⇒ a real guard); **derived** —
+`counts_as_airmcp_defense` is **not stored** but computed from `block_source` via
+`countsAsAirmcpDefense()` (named server guard ⇒ true), so it can never contradict the record;
+**relational** date ordering via `trialRecordInvariantErrors()`; and a **validate-or-die**
+contract (`assertValidTrialRecord()`) the runner must call before recording any trial.
+baseline-snapshot **freshness** (its window still covers `NOW`) is a **runner-time fail-closed
+gate** (`isBaselineSnapshotFresh()`), **not** a static invariant. **Still `proposed` / not started:**
 scenario execution, model calls, real app automation, scoring, the bypass implementation, and
 any result numbers.
 

--- a/docs/experiments/schemas/trial-record.schema.json
+++ b/docs/experiments/schemas/trial-record.schema.json
@@ -1,11 +1,20 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "trial-record.schema.json",
-  "title": "Per-trial record (runner-zero format)",
-  "description": "The shape of one ablation trial record. Outcome/observation fields are null until run time (no execution in runner-zero). `additionalProperties:false` deliberately forbids any asr / score / percentage field — result numbers are not permitted until the experiment is run and reported (design §9). Design ref: §5 (outcome taxonomy + block_source), §7 (per-trial record), §11.",
+  "title": "Per-trial record (consistency-guarded format)",
+  "description": "One ablation trial record. STRUCTURAL cross-field invariants are enforced here by `allOf` if/then. `counts_as_airmcp_defense` is NOT a field — it is DERIVED from block_source via countsAsAirmcpDefense() at scoring time, so a stored value can never contradict the record. `additionalProperties:false` forbids any asr/score field AND a stored counts field. Invariants the schema cannot express (date ordering inside baseline_snapshot) live in trialRecordInvariantErrors(); the runner must call assertValidTrialRecord() (validate-or-die) before recording any trial. baseline_snapshot FRESHNESS (window still covers NOW) is a RUNNER-TIME fail-closed gate (isBaselineSnapshotFresh), NOT enforced statically here. Design ref: §5 / §7 / §9 / §11.",
   "type": "object",
   "additionalProperties": false,
-  "required": ["schema", "trial_id", "arm", "scenario", "model", "approval_mode", "status"],
+  "required": [
+    "schema",
+    "trial_id",
+    "arm",
+    "scenario",
+    "model",
+    "approval_mode",
+    "status",
+    "pre_run_recheck_required"
+  ],
   "properties": {
     "schema": { "const": "trial-record/v0" },
     "trial_id": { "type": "string" },
@@ -14,13 +23,8 @@
     "model": { "type": "string" },
     "approval_mode": { "enum": ["ASR_auto", "ASR_humanlike"] },
     "status": { "enum": ["planned", "ran", "errored"] },
-    "outcome": {
-      "type": ["string", "null"],
-      "enum": ["success", "blocked", "partial", "false_positive", "error", null],
-      "description": "The five-bucket outcome; null until run."
-    },
+    "outcome": { "enum": ["success", "blocked", "partial", "false_positive", "error", null] },
     "block_source": {
-      "type": ["string", "null"],
       "enum": [
         "hitl_deny",
         "scope_403",
@@ -34,11 +38,7 @@
         "none",
         null
       ],
-      "description": "Which guard fired. Only the first five (named server guards) count as AirMCP defense."
-    },
-    "counts_as_airmcp_defense": {
-      "type": ["boolean", "null"],
-      "description": "true ONLY when block_source is a named server guard; null until run."
+      "description": "Which guard fired. counts_as_airmcp_defense is DERIVED from this (named server guard => true); never stored."
     },
     "oracle_channels": {
       "type": "array",
@@ -56,18 +56,127 @@
       }
     },
     "observed_side_effect": {
-      "description": "The oracle observation (object) or null. Model self-report is NEVER an oracle.",
-      "type": ["object", "null"]
+      "type": ["object", "null"],
+      "description": "The oracle observation (object) or null. Model self-report is NEVER an oracle."
     },
     "bypass_in_effect": {
       "type": "array",
       "items": { "type": "string" },
       "description": "§11.1 metadata: experiment-layer defenses bypassed this trial; [] for non-ablation."
     },
+    "pre_run_recheck_required": {
+      "type": "boolean",
+      "description": "Mirrored from the run-matrix cell. When true, a fresh baseline_snapshot must be attached before the trial may run (fail-closed)."
+    },
     "baseline_snapshot": {
       "type": ["object", "null"],
-      "description": "Provenance: the arm's re_verified / pushed_at at run time."
+      "description": "Provenance attached at run time: pushed_at / re_verified_at / window. Internal date ordering is checked by trialRecordInvariantErrors; freshness vs NOW is a runner-time gate."
     },
     "timing_ms": { "type": ["number", "null"] }
-  }
+  },
+  "allOf": [
+    {
+      "if": { "properties": { "status": { "const": "planned" } } },
+      "then": {
+        "properties": {
+          "outcome": { "const": null },
+          "block_source": { "const": null },
+          "observed_side_effect": { "const": null },
+          "oracle_channels": { "maxItems": 0 },
+          "timing_ms": { "const": null }
+        }
+      }
+    },
+    {
+      "if": { "properties": { "status": { "const": "errored" } } },
+      "then": {
+        "required": ["outcome"],
+        "properties": {
+          "outcome": { "const": "error" },
+          "block_source": { "const": "env_error" }
+        }
+      }
+    },
+    {
+      "if": { "properties": { "status": { "const": "ran" } } },
+      "then": {
+        "required": ["outcome"],
+        "properties": { "outcome": { "enum": ["success", "blocked", "partial", "false_positive"] } }
+      }
+    },
+    {
+      "if": { "properties": { "outcome": { "const": "error" } } },
+      "then": { "properties": { "status": { "const": "errored" } } }
+    },
+    {
+      "if": { "properties": { "block_source": { "const": "env_error" } } },
+      "then": { "properties": { "status": { "const": "errored" } } }
+    },
+    {
+      "if": { "properties": { "outcome": { "const": "success" } } },
+      "then": { "properties": { "block_source": { "const": "none" } } }
+    },
+    {
+      "if": { "properties": { "outcome": { "const": "blocked" } } },
+      "then": {
+        "properties": {
+          "block_source": {
+            "enum": [
+              "hitl_deny",
+              "scope_403",
+              "rate_limit",
+              "egress_reject",
+              "escaper",
+              "harness_auto_deny",
+              "model_no_tool_call",
+              "os_tcc"
+            ]
+          }
+        }
+      }
+    },
+    {
+      "if": { "properties": { "outcome": { "const": "false_positive" } } },
+      "then": {
+        "properties": {
+          "block_source": {
+            "enum": [
+              "hitl_deny",
+              "scope_403",
+              "rate_limit",
+              "egress_reject",
+              "escaper",
+              "harness_auto_deny",
+              "model_no_tool_call",
+              "os_tcc"
+            ]
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "status": { "const": "ran" },
+          "pre_run_recheck_required": { "const": true }
+        },
+        "required": ["status", "pre_run_recheck_required"]
+      },
+      "then": {
+        "required": ["baseline_snapshot"],
+        "properties": {
+          "baseline_snapshot": {
+            "type": "object",
+            "required": ["pushed_at", "re_verified_at", "window_start", "window_end"],
+            "properties": {
+              "pushed_at": { "type": "string" },
+              "re_verified_at": { "type": "string" },
+              "window_start": { "type": "string" },
+              "window_end": { "type": "string" }
+            }
+          }
+        }
+      }
+    }
+  ]
 }

--- a/experiments/ablation/trial-record.mjs
+++ b/experiments/ablation/trial-record.mjs
@@ -1,7 +1,12 @@
-// Runner-zero: the per-trial record FORMAT + metadata fields. No execution, no scoring.
-// The record is filled at run time by a later PR; here we only fix its shape and the
-// taxonomy helpers. Validated against docs/experiments/schemas/trial-record.schema.json.
-// Design ref: §5 (outcome taxonomy + block_source), §7 (per-trial record), §11.
+// Runner-zero: the per-trial record FORMAT + consistency invariants. No execution, no scoring.
+// `counts_as_airmcp_defense` is NOT stored — it is DERIVED from block_source so a record can
+// never carry a contradictory value. Cross-field invariants split four ways:
+//   1. structural  -> docs/experiments/schemas/trial-record.schema.json (if/then)
+//   2. derived      -> countsAsAirmcpDefense() (this file; never persisted)
+//   3. relational   -> trialRecordInvariantErrors() (what JSON Schema can't express: date ordering)
+//   4. validate-or-die contract -> assertValidTrialRecord() (runner must call before recording)
+// Freshness of baseline_snapshot is a RUNNER-TIME fail-closed gate (isBaselineSnapshotFresh),
+// not a static invariant. Design ref: §5 / §7 / §9 / §11.
 
 export const OUTCOMES = ["success", "blocked", "partial", "false_positive", "error"];
 
@@ -32,14 +37,15 @@ export const ORACLE_CHANNELS = [
   "audit_chain_assertion",
 ];
 
-/** A block is credited to AirMCP's defense ONLY when a named server guard fired. */
+/** Canonical derivation — the SINGLE source of truth. A block counts as AirMCP defense ONLY
+ *  when a named server guard fired. Computed at scoring time; never stored on the record. */
 export function countsAsAirmcpDefense(block_source) {
   return SERVER_GUARDS.includes(block_source);
 }
 
-/** An empty, planned trial record. Outcome/observation fields are null until run time; there
- *  are deliberately NO asr / score / percentage fields (forbidden until measured). */
-export function newTrialRecord({ trial_id, arm, scenario, model, approval_mode }) {
+/** A fresh, planned trial record. Outcome/observation fields are null until run time; there are
+ *  deliberately NO asr/score fields and NO stored counts_as_airmcp_defense. */
+export function newTrialRecord({ trial_id, arm, scenario, model, approval_mode, pre_run_recheck_required = false }) {
   return {
     schema: "trial-record/v0",
     trial_id,
@@ -50,11 +56,55 @@ export function newTrialRecord({ trial_id, arm, scenario, model, approval_mode }
     status: "planned",
     outcome: null,
     block_source: null,
-    counts_as_airmcp_defense: null,
     oracle_channels: [],
-    observed_side_effect: null, // oracle observation only; model self-report is NOT an oracle
-    bypass_in_effect: [], // §11.1 metadata: which defenses (if any) were bypassed this trial
-    baseline_snapshot: null, // provenance: re_verified / pushed_at at run time
+    observed_side_effect: null,
+    bypass_in_effect: [],
+    pre_run_recheck_required,
+    baseline_snapshot: null,
     timing_ms: null,
   };
+}
+
+/** Cross-field invariants JSON Schema cannot express. Pure; returns human-readable
+ *  violations (empty array = ok). Currently: baseline_snapshot internal date ordering. */
+export function trialRecordInvariantErrors(rec) {
+  const errs = [];
+  const s = rec && rec.baseline_snapshot;
+  if (s && typeof s === "object") {
+    const { window_start, re_verified_at, window_end } = s;
+    if (window_start && re_verified_at && window_end) {
+      // ISO YYYY-MM-DD strings compare lexicographically.
+      if (!(window_start <= re_verified_at && re_verified_at <= window_end)) {
+        errs.push(
+          `baseline_snapshot.re_verified_at (${re_verified_at}) must fall within [${window_start}, ${window_end}]`,
+        );
+      }
+    }
+  }
+  return errs;
+}
+
+/** Validate-or-die. Throws unless the record passes BOTH the JSON Schema and the relational
+ *  invariants. The runner MUST call this before recording/aggregating any trial; an invalid
+ *  record is fail-closed (dropped), never scored. `schemaValidate` is an ajv-compiled validator
+ *  for trial-record.schema.json (injected so this module needs no ajv dependency). */
+export function assertValidTrialRecord(rec, schemaValidate) {
+  if (typeof schemaValidate === "function" && !schemaValidate(rec)) {
+    throw new Error(`trial record fails schema: ${JSON.stringify(schemaValidate.errors)}`);
+  }
+  const errs = trialRecordInvariantErrors(rec);
+  if (errs.length) throw new Error(`trial record fails invariants: ${errs.join("; ")}`);
+  return rec;
+}
+
+/** RUNNER-TIME freshness gate (NOT a static invariant). A `pre_run_recheck_required` arm may
+ *  only run if its baseline_snapshot was re-verified within a window that still covers NOW.
+ *  Fail-closed: a missing / incoherent / expired snapshot is NOT fresh => the arm must not run. */
+export function isBaselineSnapshotFresh(snapshot, { nowDate }) {
+  if (!snapshot || typeof snapshot !== "object") return false;
+  const { re_verified_at, window_start, window_end } = snapshot;
+  if (!re_verified_at || !window_start || !window_end) return false;
+  if (!(window_start <= re_verified_at && re_verified_at <= window_end)) return false;
+  // The re-verification window must still cover NOW.
+  return window_end >= nowDate;
 }

--- a/tests/trial-record-consistency.test.js
+++ b/tests/trial-record-consistency.test.js
@@ -1,0 +1,126 @@
+/**
+ * Trial-record consistency guard (no execution).
+ *
+ * Locks the cross-field invariants of a trial record so a "measurement record" can never be
+ * internally contradictory. Four-way split:
+ *   - structural (status/outcome/block_source coupling) -> JSON Schema if/then
+ *   - derived (counts_as_airmcp_defense) -> NOT stored; derived via countsAsAirmcpDefense()
+ *   - relational (baseline_snapshot date ordering) -> trialRecordInvariantErrors()
+ *   - validate-or-die -> assertValidTrialRecord() (runner must call before recording)
+ * baseline_snapshot FRESHNESS is a runner-time fail-closed gate (isBaselineSnapshotFresh).
+ * No model calls, no app automation, no scoring, no ASR numbers. Design ref: §5/§7/§9/§11.
+ */
+import { describe, test, expect } from "@jest/globals";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import Ajv2020 from "ajv/dist/2020.js";
+
+import {
+  newTrialRecord,
+  assertValidTrialRecord,
+  trialRecordInvariantErrors,
+  isBaselineSnapshotFresh,
+  countsAsAirmcpDefense,
+  SERVER_GUARDS,
+} from "../experiments/ablation/trial-record.mjs";
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..");
+const ajv = new Ajv2020({ allErrors: true, strict: false });
+const validate = ajv.compile(
+  JSON.parse(readFileSync(join(ROOT, "docs", "experiments", "schemas", "trial-record.schema.json"), "utf8")),
+);
+
+const planned = (over = {}) => ({
+  ...newTrialRecord({ trial_id: "t", arm: "a", scenario: "S1", model: "m", approval_mode: "ASR_auto" }),
+  ...over,
+});
+const ran = (over = {}) => ({
+  ...planned(),
+  status: "ran",
+  outcome: "success",
+  block_source: "none",
+  observed_side_effect: {},
+  timing_ms: 1,
+  ...over,
+});
+const FRESH_SNAP = {
+  pushed_at: "2026-06-23",
+  re_verified_at: "2026-06-25",
+  window_start: "2026-03-27",
+  window_end: "2026-06-25",
+};
+
+describe("trial-record — valid records pass schema + invariants", () => {
+  const cases = {
+    "planned (fresh from newTrialRecord)": planned(),
+    "ran / success / none": ran(),
+    "ran / blocked / hitl_deny": ran({ outcome: "blocked", block_source: "hitl_deny" }),
+    "ran / false_positive / escaper": ran({ outcome: "false_positive", block_source: "escaper" }),
+    "errored / error / env_error": ran({ status: "errored", outcome: "error", block_source: "env_error" }),
+    "ran + recheck + fresh snapshot": ran({ pre_run_recheck_required: true, baseline_snapshot: FRESH_SNAP }),
+  };
+  for (const [name, rec] of Object.entries(cases)) {
+    test(name, () => {
+      const ok = validate(rec);
+      if (!ok) console.error(name, validate.errors);
+      expect(ok).toBe(true);
+      expect(() => assertValidTrialRecord(rec, validate)).not.toThrow();
+    });
+  }
+});
+
+describe("trial-record — contradictory records are rejected by the schema", () => {
+  const cases = {
+    "planned cannot carry a measured outcome": planned({ outcome: "blocked", block_source: "hitl_deny" }),
+    "errored must be env_error, not a guard": ran({ status: "errored", outcome: "error", block_source: "hitl_deny" }),
+    "ran cannot have outcome=error": ran({ outcome: "error" }),
+    "success cannot have a block_source": ran({ outcome: "success", block_source: "hitl_deny" }),
+    "blocked cannot be block_source=none": ran({ outcome: "blocked", block_source: "none" }),
+    "blocked cannot be block_source=env_error": ran({ outcome: "blocked", block_source: "env_error" }),
+    "false_positive cannot be none": ran({ outcome: "false_positive", block_source: "none" }),
+    "env_error only with errored status": ran({ outcome: "partial", block_source: "env_error" }),
+    "ran + recheck without a baseline_snapshot": ran({ pre_run_recheck_required: true, baseline_snapshot: null }),
+    "no stored counts_as_airmcp_defense field": ran({ counts_as_airmcp_defense: true }),
+    "no stored asr/score field": ran({ asr: 0.42 }),
+  };
+  for (const [name, rec] of Object.entries(cases)) {
+    test(name, () => {
+      expect(validate(rec)).toBe(false);
+    });
+  }
+});
+
+describe("trial-record — relational invariant (schema can't express date ordering)", () => {
+  test("re_verified_at outside the window is schema-valid but invariant-invalid (validate-or-die catches it)", () => {
+    const rec = ran({
+      pre_run_recheck_required: true,
+      baseline_snapshot: { ...FRESH_SNAP, re_verified_at: "2026-01-01" }, // before window_start
+    });
+    expect(validate(rec)).toBe(true); // shape is fine
+    expect(trialRecordInvariantErrors(rec).length).toBeGreaterThan(0);
+    expect(() => assertValidTrialRecord(rec, validate)).toThrow(/re_verified_at/);
+  });
+});
+
+describe("trial-record — derived counts (never stored)", () => {
+  test("only a named server guard counts as AirMCP defense", () => {
+    for (const g of SERVER_GUARDS) expect(countsAsAirmcpDefense(g)).toBe(true);
+    for (const g of ["harness_auto_deny", "model_no_tool_call", "os_tcc", "env_error", "none"]) {
+      expect(countsAsAirmcpDefense(g)).toBe(false);
+    }
+  });
+});
+
+describe("trial-record — baseline-snapshot freshness (runner-time fail-closed gate)", () => {
+  test("a coherent, non-expired snapshot is fresh", () => {
+    expect(isBaselineSnapshotFresh(FRESH_SNAP, { nowDate: "2026-06-25" })).toBe(true);
+  });
+  test("an expired re-verification window is NOT fresh", () => {
+    expect(isBaselineSnapshotFresh({ ...FRESH_SNAP, window_end: "2026-05-01" }, { nowDate: "2026-06-25" })).toBe(false);
+  });
+  test("a missing or incoherent snapshot is NOT fresh (fail-closed)", () => {
+    expect(isBaselineSnapshotFresh(null, { nowDate: "2026-06-25" })).toBe(false);
+    expect(isBaselineSnapshotFresh({ ...FRESH_SNAP, re_verified_at: "2026-01-01" }, { nowDate: "2026-06-25" })).toBe(false);
+  });
+});


### PR DESCRIPTION
## Purpose
Make a trial **measurement record** unable to be internally contradictory — **before** any runner executes. Accepts the prior critique: don't push everything through one `if/then` schema. **schema / test / docs only — no model calls, real app automation, scoring, bypass, or ASR numbers.**

## Four-way split
1. **structural** → JSON Schema `if/then`: `planned` ⇒ measured fields null; `ran` ⇒ outcome filled (non-error); **`errored` ⇒ `outcome=error` + `block_source=env_error`** (a crash is *experiment failure*, never counted as defense); the `outcome ↔ block_source` chain (`success`⇒`none`; `blocked`/`false_positive`⇒a real guard; `error`⇔`errored`; `env_error`⇔`errored`).
2. **derived** → `counts_as_airmcp_defense` is **removed from the record** and computed from `block_source` via `countsAsAirmcpDefense()` at scoring time. Single source of truth → **no `SERVER_GUARDS` list duplicated into the schema (no drift), no contradictory stored value.**
3. **relational** → `trialRecordInvariantErrors()` checks the `baseline_snapshot` date ordering the schema can't express (`window_start ≤ re_verified_at ≤ window_end`).
4. **validate-or-die** → `assertValidTrialRecord()` the runner must call before recording any trial; an invalid record is **fail-closed** (dropped), never scored.

`baseline_snapshot` **freshness** (window still covers `NOW`) is a **runner-time fail-closed gate** (`isBaselineSnapshotFresh()`) — explicitly **not** claimed as a static invariant.

## Tests (`tests/trial-record-consistency.test.js`)
Valid records pass schema + invariants; **11 contradictory records rejected** (planned-with-outcome, errored-with-a-guard, ran-with-error, success-with-block, blocked-with-none, env_error-without-errored, recheck-without-snapshot, a stored `counts_as_airmcp_defense`, a stray `asr`); the relational invariant + the freshness gate are covered.

## Out of scope (still proposed)
Scenario execution · model calls · real app automation · scoring · bypass implementation · result numbers.

## Verification
`npm test` **149 suites / 2190 tests**; bypass tripwire green (`experiments/` still **0 files** in `npm pack`); `stats:check` / `llms:check` / `gen:manifest:check` / `build:mcpb:check` green.
