### PR TITLE
fix(experiments): close trial-record schema vacuous-if-match (base-required + partial domain)

### DIFF
--- a/docs/experiments/schemas/trial-record.schema.json
+++ b/docs/experiments/schemas/trial-record.schema.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "trial-record.schema.json",
   "title": "Per-trial record (consistency-guarded format)",
-  "description": "One ablation trial record. STRUCTURAL cross-field invariants are enforced here by `allOf` if/then. `counts_as_airmcp_defense` is NOT a field — it is DERIVED from block_source via countsAsAirmcpDefense() at scoring time, so a stored value can never contradict the record. `additionalProperties:false` forbids any asr/score field AND a stored counts field. Invariants the schema cannot express (date ordering inside baseline_snapshot) live in trialRecordInvariantErrors(); the runner must call assertValidTrialRecord() (validate-or-die) before recording any trial. baseline_snapshot FRESHNESS (window still covers NOW) is a RUNNER-TIME fail-closed gate (isBaselineSnapshotFresh), NOT enforced statically here. Design ref: §5 / §7 / §9 / §11.",
+  "description": "One ablation trial record. EVERY format field is base-`required` (nullable where applicable) so a field can never be absent — this both rejects malformed records and removes the JSON-Schema vacuous-`if`-match class (an `if`/`then` can't silently pass on a missing field). Each `if` additionally carries `required` for the field it tests. `counts_as_airmcp_defense` is NOT a field — it is DERIVED from block_source via countsAsAirmcpDefense() at scoring time, so a stored value can never contradict the record. `additionalProperties:false` forbids any asr/score field AND a stored counts field. Invariants the schema cannot express (date ordering inside baseline_snapshot) live in trialRecordInvariantErrors(); the runner must call assertValidTrialRecord() (validate-or-die) before recording any trial. baseline_snapshot FRESHNESS (window still covers NOW) is a RUNNER-TIME fail-closed gate (isBaselineSnapshotFresh), NOT enforced statically. Design ref: §5 / §7 / §9 / §11.",
   "type": "object",
   "additionalProperties": false,
   "required": [
@@ -13,7 +13,14 @@
     "model",
     "approval_mode",
     "status",
-    "pre_run_recheck_required"
+    "outcome",
+    "block_source",
+    "oracle_channels",
+    "observed_side_effect",
+    "bypass_in_effect",
+    "pre_run_recheck_required",
+    "baseline_snapshot",
+    "timing_ms"
   ],
   "properties": {
     "schema": { "const": "trial-record/v0" },
@@ -76,7 +83,7 @@
   },
   "allOf": [
     {
-      "if": { "properties": { "status": { "const": "planned" } } },
+      "if": { "required": ["status"], "properties": { "status": { "const": "planned" } } },
       "then": {
         "properties": {
           "outcome": { "const": null },
@@ -88,9 +95,9 @@
       }
     },
     {
-      "if": { "properties": { "status": { "const": "errored" } } },
+      "if": { "required": ["status"], "properties": { "status": { "const": "errored" } } },
       "then": {
-        "required": ["outcome"],
+        "required": ["outcome", "block_source"],
         "properties": {
           "outcome": { "const": "error" },
           "block_source": { "const": "env_error" }
@@ -98,27 +105,28 @@
       }
     },
     {
-      "if": { "properties": { "status": { "const": "ran" } } },
+      "if": { "required": ["status"], "properties": { "status": { "const": "ran" } } },
       "then": {
         "required": ["outcome"],
         "properties": { "outcome": { "enum": ["success", "blocked", "partial", "false_positive"] } }
       }
     },
     {
-      "if": { "properties": { "outcome": { "const": "error" } } },
-      "then": { "properties": { "status": { "const": "errored" } } }
+      "if": { "required": ["outcome"], "properties": { "outcome": { "const": "error" } } },
+      "then": { "required": ["status"], "properties": { "status": { "const": "errored" } } }
     },
     {
-      "if": { "properties": { "block_source": { "const": "env_error" } } },
-      "then": { "properties": { "status": { "const": "errored" } } }
+      "if": { "required": ["block_source"], "properties": { "block_source": { "const": "env_error" } } },
+      "then": { "required": ["status"], "properties": { "status": { "const": "errored" } } }
     },
     {
-      "if": { "properties": { "outcome": { "const": "success" } } },
-      "then": { "properties": { "block_source": { "const": "none" } } }
+      "if": { "required": ["outcome"], "properties": { "outcome": { "const": "success" } } },
+      "then": { "required": ["block_source"], "properties": { "block_source": { "const": "none" } } }
     },
     {
-      "if": { "properties": { "outcome": { "const": "blocked" } } },
+      "if": { "required": ["outcome"], "properties": { "outcome": { "const": "blocked" } } },
       "then": {
+        "required": ["block_source"],
         "properties": {
           "block_source": {
             "enum": [
@@ -136,8 +144,30 @@
       }
     },
     {
-      "if": { "properties": { "outcome": { "const": "false_positive" } } },
+      "if": { "required": ["outcome"], "properties": { "outcome": { "const": "false_positive" } } },
       "then": {
+        "required": ["block_source"],
+        "properties": {
+          "block_source": {
+            "enum": [
+              "hitl_deny",
+              "scope_403",
+              "rate_limit",
+              "egress_reject",
+              "escaper",
+              "harness_auto_deny",
+              "model_no_tool_call",
+              "os_tcc"
+            ]
+          }
+        }
+      }
+    },
+    {
+      "if": { "required": ["outcome"], "properties": { "outcome": { "const": "partial" } } },
+      "then": {
+        "required": ["block_source"],
+        "description": "Ratified: a partial trial means part of the objective was achieved and part was stopped, so a real guard fired — block_source must be one of the eight guard sources (never none / env_error / null).",
         "properties": {
           "block_source": {
             "enum": [
@@ -156,11 +186,11 @@
     },
     {
       "if": {
+        "required": ["status", "pre_run_recheck_required"],
         "properties": {
           "status": { "const": "ran" },
           "pre_run_recheck_required": { "const": true }
-        },
-        "required": ["status", "pre_run_recheck_required"]
+        }
       },
       "then": {
         "required": ["baseline_snapshot"],

--- a/tests/trial-record-consistency.test.js
+++ b/tests/trial-record-consistency.test.js
@@ -57,6 +57,7 @@ describe("trial-record — valid records pass schema + invariants", () => {
     "ran / success / none": ran(),
     "ran / blocked / hitl_deny": ran({ outcome: "blocked", block_source: "hitl_deny" }),
     "ran / false_positive / escaper": ran({ outcome: "false_positive", block_source: "escaper" }),
+    "ran / partial / rate_limit": ran({ outcome: "partial", block_source: "rate_limit" }),
     "errored / error / env_error": ran({ status: "errored", outcome: "error", block_source: "env_error" }),
     "ran + recheck + fresh snapshot": ran({ pre_run_recheck_required: true, baseline_snapshot: FRESH_SNAP }),
   };
@@ -83,12 +84,44 @@ describe("trial-record — contradictory records are rejected by the schema", ()
     "ran + recheck without a baseline_snapshot": ran({ pre_run_recheck_required: true, baseline_snapshot: null }),
     "no stored counts_as_airmcp_defense field": ran({ counts_as_airmcp_defense: true }),
     "no stored asr/score field": ran({ asr: 0.42 }),
+    "errored with block_source null (must be env_error)": ran({ status: "errored", outcome: "error", block_source: null }),
+    "partial cannot be block_source=none": ran({ outcome: "partial", block_source: "none" }),
+    "partial cannot be block_source=env_error": ran({ outcome: "partial", block_source: "env_error" }),
   };
   for (const [name, rec] of Object.entries(cases)) {
     test(name, () => {
       expect(validate(rec)).toBe(false);
     });
   }
+});
+
+describe("trial-record — missing format fields are rejected (no vacuous if-match)", () => {
+  const drop = (rec, key) => {
+    const r = { ...rec };
+    delete r[key];
+    return r;
+  };
+  // Every format field is base-required, so a missing field is malformed AND can't trigger a
+  // vacuous if/then match (the P1 the prior schema had).
+  for (const key of [
+    "status",
+    "outcome",
+    "block_source",
+    "oracle_channels",
+    "observed_side_effect",
+    "timing_ms",
+    "pre_run_recheck_required",
+    "baseline_snapshot",
+  ]) {
+    test(`missing "${key}" is rejected`, () => {
+      expect(validate(drop(ran(), key))).toBe(false);
+    });
+  }
+
+  test("errored with block_source MISSING is rejected (the P1 vacuous-match case)", () => {
+    const rec = drop(ran({ status: "errored", outcome: "error", block_source: "env_error" }), "block_source");
+    expect(validate(rec)).toBe(false);
+  });
 });
 
 describe("trial-record — relational invariant (schema can't express date ordering)", () => {


### PR DESCRIPTION
## Purpose
Close the **P1** from review: JSON Schema `if: { properties: ... }` without `required` matches **vacuously** when the tested field is absent, so e.g. `{status:errored, outcome:error}` with `block_source` **missing** passed the schema. **schema/test only — no model calls, app automation, scoring, bypass, or ASR numbers.**

## Root cause + fix
Format fields were not base-`required`, so absence was possible. Fix is systemic + the reviewer's prescription:
- **Every format field is now base-`required`** (nullable where applicable): `outcome`, `block_source`, `oracle_channels`, `observed_side_effect`, `bypass_in_effect`, `baseline_snapshot`, `timing_ms`. Absence is now malformed AND the vacuous-`if` class is gone (the field is always present).
- **`required` added to every `if`** that tests `status`/`outcome`/`block_source`, and `block_source` added to the `then` `required` for `errored`/`success`/`blocked`/`false_positive`/`partial`.
- **`partial` block_source domain ratified + tested**: a partial trial means a real guard stopped the rest → `block_source` must be one of the eight guard sources (never `none`/`env_error`/`null`).
- counts stays **derived only** — `counts_as_airmcp_defense` is not re-added.

## Negative fixtures added
missing `outcome`/`block_source`/`oracle_channels`/etc.; the exact **errored-missing-block_source** P1 case; `errored`-with-`null`-block_source; `partial`-with-`none`; `partial`-with-`env_error`.

## Verification
`trial-record-consistency` + `ablation-plumbing` **45/45**; the P1 record is now **rejected**; `stats:check`/`llms:check`/`gen:manifest:check`/`build:mcpb:check` green.

⚠️ **Unrelated flake (not this diff):** `tests/cli-connect.test.js` is a parallel-load timing flake (3/3 green in isolation, raced under the full suite). Spun off a deflake task. If CI flakes on it, re-run the job.

## Before actual runner (noted, not in this PR)
It is now **2026-06-26**, so the 2026-06-25 §11.7 window has moved (`isBaselineSnapshotFresh` would now return false for that snapshot). **§11.7 must be re-stamped + baseline snapshots refreshed before any runner execution.**
