### PR TITLE
ci(release): attach mcpb from npm publish workflow

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -60,6 +60,9 @@ jobs:
             exit 1
           fi
 
+      - name: Build .mcpb Desktop Extension
+        run: npm run build:mcpb
+
       - name: Publish with provenance
         run: npm publish --provenance --access public
         env:
@@ -71,3 +74,5 @@ jobs:
           tag_name: v${{ steps.pkg.outputs.version }}
           name: v${{ steps.pkg.outputs.version }}
           generate_release_notes: true
+          files: build/mcpb/airmcp-${{ steps.pkg.outputs.version }}.mcpb
+          fail_on_unmatched_files: true

--- a/.github/workflows/release-app.yml
+++ b/.github/workflows/release-app.yml
@@ -141,33 +141,19 @@ jobs:
           ditto -c -k --keepParent AirMCP.app "AirMCP-${VERSION}.zip"
           ls -la "AirMCP-${VERSION}.zip"
 
-      # Also produce the .mcpb Desktop Extension bundle so the GitHub
-      # Release carries both artifacts. The .mcpb doesn't itself need
-      # notarization (it's a JS bundle, not a Mach-O executable), but
-      # shipping it from the same tagged build keeps the versions in
-      # lockstep with the signed .app.
-      - name: Build .mcpb bundle
-        run: npm run build:mcpb
-
-      # SLSA build provenance for the notarized .app archive + the .mcpb
-      # bundle. Lets downstream consumers verify the artifacts came from
-      # this repo + this workflow run (cosign / `gh attestation verify`).
-      # The cd.yml pipeline already gets provenance for free via npm's
-      # trusted publishing; this closes the same gap for the distributable
-      # binaries that ship outside npm.
+      # SLSA build provenance for the notarized .app archive. The `.mcpb`
+      # Desktop Extension is built and attached by cd.yml alongside the npm
+      # publish, because it needs no Apple signing secrets and should not be
+      # blocked on notarization.
       - name: Generate artifact attestation
         uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
         with:
-          subject-path: |
-            AirMCP-${{ steps.version.outputs.version }}.zip
-            build/mcpb/airmcp-${{ steps.version.outputs.version }}.mcpb
+          subject-path: AirMCP-${{ steps.version.outputs.version }}.zip
 
       - name: Attach artifacts to Release
         uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v2
         with:
           tag_name: v${{ steps.version.outputs.version }}
-          files: |
-            AirMCP-${{ steps.version.outputs.version }}.zip
-            build/mcpb/airmcp-${{ steps.version.outputs.version }}.mcpb
+          files: AirMCP-${{ steps.version.outputs.version }}.zip
           fail_on_unmatched_files: true
           generate_release_notes: true

--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -93,12 +93,13 @@ Breaking을 포함한 minor/patch는 **금지**. 직전 메이저에 묶어 둘 
 - [ ] `ci.yml` 전 단계 green
 - [ ] CodeQL·Scorecard 경고 신규 없음
 
-### 3.3 npm publish
+### 3.3 npm publish + .mcpb → GitHub Release
 - [ ] CD workflow(`cd.yml`) 자동 트리거 확인, 또는 수동 `npm publish --provenance`
 - [ ] `npm view airmcp@X.Y.Z` 로 반영 검증
 - [ ] `npx -y airmcp@X.Y.Z --version` 스모크
+- [ ] Release에 `airmcp-X.Y.Z.mcpb`가 첨부되어 있는지 확인 (Claude Desktop 원클릭 설치용)
 
-### 3.4 Signed .app + .mcpb → GitHub Release
+### 3.4 Signed .app → GitHub Release
 - [ ] `release-app.yml` 워크플로가 태그 푸시로 자동 실행됐는지 확인 (Actions 탭)
 - [ ] 실패 시 **Missing required secrets** 에러면 아래 6개를 Settings → Secrets and variables → Actions에 등록:
   - `APPLE_DEVELOPER_ID` — Developer ID Application certificate 공통명 (예: `Developer ID Application: Jane Doe (A1B2C3D4E5)`)
@@ -107,9 +108,9 @@ Breaking을 포함한 minor/patch는 **금지**. 직전 메이저에 묶어 둘 
   - `APPLE_TEAM_ID` — 10자리 팀 ID
   - `APPLE_CERT_P12_BASE64` — `.p12` 인증서 + 개인키를 base64 인코딩 (`base64 -i cert.p12 | pbcopy`)
   - `APPLE_CERT_P12_PASSWORD` — `.p12` import 암호
-- [ ] 성공 시 Release에 두 산출물 첨부되어 있어야 함:
+- [ ] 성공 시 Release에 signed app 산출물이 첨부되어 있어야 함:
   - `AirMCP-X.Y.Z.zip` (Developer ID 서명 + 공증 + staple 완료)
-  - `airmcp-X.Y.Z.mcpb` (Claude Desktop 원클릭 설치용)
+- [ ] `.mcpb`는 3.3의 CD workflow가 같은 Release에 이미 첨부했는지 확인
 - [ ] 공증 실패 시 Actions 로그의 `notarytool log` 출력에서 거부 사유 확인 (hardened runtime / timestamp / 빠진 entitlement 등)
 - [ ] 신호용 검증: `codesign -dv --verbose=4 AirMCP.app` 에서 `Authority=Developer ID Application: …` 확인
 - [ ] Gatekeeper 검증: `spctl -a -vvv AirMCP.app` → `accepted, source=Notarized Developer ID`


### PR DESCRIPTION
## Summary
- build the `.mcpb` Desktop Extension in `cd.yml` before publishing
- attach `build/mcpb/airmcp-${version}.mcpb` to the GitHub Release created by the npm publish workflow
- keep `release-app.yml` focused on the signed/notarized `.app` artifact so `.mcpb` is not blocked on Apple signing secrets or double-uploaded
- update the release checklist to reflect the new artifact ownership split

## Evidence
Current public surface as of 2026-06-26:
- npm latest is still `2.12.0` while repo/package is `2.12.1`
- latest GitHub Release has no assets
- README points users to Release `.mcpb`, so the publish workflow must produce that asset directly

## Verification
- `ruby -e 'require "yaml"; ARGV.each { |p| YAML.load_file(p); puts "ok #{p}" }' .github/workflows/cd.yml .github/workflows/release-app.yml`
- `npm run build && npm run build:mcpb && npm run build:mcpb:check && npm test -- tests/mcpb-manifest.test.js tests/experiment-bypass-tripwire.test.js --runInBand && npm run version:check`
- `npm run typecheck && npm run stats:check && npm run gen:manifest:check && npm run llms:check && npm test -- --runInBand`
- `npm pack --dry-run --json`
- `npm run mcp:validate`

## Notes
- Runtime code unchanged.
- npm tarball remains `dist`-only; the `.mcpb` is a GitHub Release asset, not an npm package file.
