### PR TITLE
ci(release): add dry preflight artifacts

### DIFF
--- a/.github/workflows/release-preflight.yml
+++ b/.github/workflows/release-preflight.yml
@@ -1,0 +1,41 @@
+name: Release Preflight
+
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: release-preflight
+  cancel-in-progress: false
+
+jobs:
+  ci:
+    uses: ./.github/workflows/ci.yml
+
+  artifacts:
+    needs: ci
+    runs-on: macos-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: 22
+          cache: "npm"
+
+      - name: Select Xcode
+        run: sudo xcode-select -s /Applications/Xcode.app/Contents/Developer
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build dry release artifacts
+        run: npm run release:preflight -- --app
+
+      - name: Upload dry release artifacts
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: airmcp-release-preflight
+          path: build/release-preflight/*
+          if-no-files-found: error

--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -31,13 +31,21 @@ Breaking을 포함한 minor/patch는 **금지**. 직전 메이저에 묶어 둘 
 - [ ] `npm run lint`
 - [ ] `npm run typecheck`
 - [ ] `npm run build`
-- [ ] `npm test` — 커버리지 게이트(현재 46/40/42/46) 통과 확인
-- [ ] macOS 환경이라면 `npm run swift-build` · `npm run swift-test`
+- [ ] `npm test`
+- [ ] `npm run smoke`
+- [ ] `npm run mcp:validate`
+- [ ] `npm run verify:package`
+- [ ] macOS 환경이라면 `npm run swift-build` · `cd swift && swift test` · `cd ios && swift test`
 - [ ] `npx airmcp doctor` 자체 실행이 성공 (CI 환경 외)
 
 ### 1.3 공개 계약 체크
-- [ ] `npm run count-stats` — 툴/모듈/리소스 수와 `server.json`·`glama.json`·README·docs/site·i18n이 일치
-- [ ] `npm run check-i18n` — 9 로케일 키 동기화 통과
+- [ ] `npm run stats:check` — 툴/모듈/리소스 수와 `server.json`·`glama.json`·README·docs/site·i18n이 일치
+- [ ] `npm run gen:manifest:check` — runtime tool schema와 `docs/tool-manifest.json` 일치
+- [ ] `npm run gen:intents:check` — generated AppIntents drift 없음
+- [ ] `npm run build:mcpb:check` — `.mcpb` manifest v0.3 substitution 일치
+- [ ] `npm run llms:check` — public LLM summary drift 없음
+- [ ] `npm run version:check` — package/app/plugin/config version pin 일치
+- [ ] `npm run i18n:check` — 9 로케일 키 동기화 통과
 - [ ] `outputSchema` 추가·변경이 있다면 Zod `.safeParse` 테스트가 성공 응답과 에러 응답 모두에 대해 도는지 확인
 
 ### 1.4 취약점
@@ -52,13 +60,13 @@ Breaking을 포함한 minor/patch는 **금지**. 직전 메이저에 묶어 둘 
 ### 2.1 CHANGELOG.md
 - [ ] `## [Unreleased]`에 기록된 항목을 새 버전 섹션으로 이동 (없으면 직접 작성)
 - [ ] 분류: `Added` / `Changed` / `Fixed` / `Security` / `Deprecated` / `Removed` / `Breaking Changes`
-- [ ] 테스트 변화가 크면 "Testing (N → M tests, coverage X → Y%)" 섹션 추가 (v2.7.2 포맷)
+- [ ] 테스트 변화가 크면 contract / artifact gate 변화와 총 테스트 수를 기록
 - [ ] Breaking 항목은 **마이그레이션 가이드** 포함 ("envvar/flag가 이렇게 바뀜")
 - [ ] 이슈·PR 번호(#NN) 참조
 
 ### 2.2 TODO.md (가장 자주 잊히는 곳)
 - [ ] CHANGELOG delta와 대조하여 **완료된 항목 체크오프**
-  - 테스트 커버리지 구체 수치(%) 갱신
+  - 새로 닫힌 contract / artifact gate 반영
   - "완료" 섹션 맨 위에 새 버전 한 줄 요약 추가
 - [ ] 새 버전에서 생긴 후속 작업 P0/P1/P2에 삽입
 - [ ] 헤더의 "X.Y.Z 기준 (YYYY-MM-DD 동기화)" 라인 갱신
@@ -84,22 +92,29 @@ Breaking을 포함한 minor/patch는 **금지**. 직전 메이저에 묶어 둘 
 
 ## 3. 릴리스 실행
 
-### 3.1 커밋
+### 3.1 Dry release preflight (publish 금지)
+- [ ] `npm run release:preflight` 로 npm tarball dry-run + packaged server boot + `.mcpb` 구조 검증
+- [ ] app 산출물까지 확인할 때는 `npm run release:preflight -- --app`
+- [ ] GitHub Actions **Release Preflight** workflow green 확인
+- [ ] workflow artifact에 `airmcp-X.Y.Z.mcpb`와 `AirMCP-X.Y.Z-adhoc.zip`이 생성되는지 확인
+- [ ] 이 단계는 태그·npm publish·GitHub Release를 만들지 않는다. 실패 시 publish 단계로 넘어가지 않는다.
+
+### 3.2 커밋
 - [ ] `chore(release): vX.Y.Z` 커밋에 위 모든 파일 동시 포함
 - [ ] `git tag vX.Y.Z` (서명 권장: `git tag -s`)
 - [ ] `git push origin main --tags`
 
-### 3.2 CI 통과 확인
+### 3.3 CI 통과 확인
 - [ ] `ci.yml` 전 단계 green
 - [ ] CodeQL·Scorecard 경고 신규 없음
 
-### 3.3 npm publish + .mcpb → GitHub Release
+### 3.4 npm publish + .mcpb → GitHub Release
 - [ ] CD workflow(`cd.yml`) 자동 트리거 확인, 또는 수동 `npm publish --provenance`
 - [ ] `npm view airmcp@X.Y.Z` 로 반영 검증
 - [ ] `npx -y airmcp@X.Y.Z --version` 스모크
 - [ ] Release에 `airmcp-X.Y.Z.mcpb`가 첨부되어 있는지 확인 (Claude Desktop 원클릭 설치용)
 
-### 3.4 Signed .app → GitHub Release
+### 3.5 Signed .app → GitHub Release
 - [ ] `release-app.yml` 워크플로가 태그 푸시로 자동 실행됐는지 확인 (Actions 탭)
 - [ ] 실패 시 **Missing required secrets** 에러면 아래 6개를 Settings → Secrets and variables → Actions에 등록:
   - `APPLE_DEVELOPER_ID` — Developer ID Application certificate 공통명 (예: `Developer ID Application: Jane Doe (A1B2C3D4E5)`)
@@ -117,7 +132,7 @@ Breaking을 포함한 minor/patch는 **금지**. 직전 메이저에 묶어 둘 
 - [ ] 배포 artifact 검증: `APP_BUNDLE_PATH=/path/to/AirMCP.app npm run app:verify:signed`
   - 기존 번들을 다시 빌드하지 않고 Developer ID 서명, Gatekeeper, staple, app-owned runtime, 토큰 인증, AppIntents 런타임 로그를 한 번에 확인
 
-### 3.5 GitHub Release notes
+### 3.6 GitHub Release notes
 - [ ] Release notes는 CHANGELOG 섹션 복사 (요약 강조, 이미지/GIF는 README 링크)
 - [ ] Breaking이 있으면 Release 제목에 `[BREAKING]` 프리픽스
 - [ ] `latest` 태그 갱신 확인
@@ -175,7 +190,10 @@ Breaking을 포함한 minor/patch는 **금지**. 직전 메이저에 묶어 둘 
 npm run lint && npm run typecheck && npm run build && npm test
 
 # 통계·i18n
-npm run count-stats && npm run check-i18n
+npm run stats:check && npm run i18n:check
+
+# dry release artifact
+npm run release:preflight
 
 # 취약점
 npm audit --audit-level=moderate

--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
     "premcp:validate": "npm run build",
     "mcp:validate": "node scripts/mcp-validate.mjs",
     "verify:package": "node scripts/verify-published-package.mjs",
+    "release:preflight": "node scripts/release-preflight.mjs",
     "build:mcpb": "node scripts/build-mcpb.mjs",
     "build:mcpb:check": "node scripts/build-mcpb.mjs --check",
     "gen:manifest": "node scripts/dump-tool-manifest.mjs",

--- a/scripts/release-preflight.mjs
+++ b/scripts/release-preflight.mjs
@@ -1,0 +1,160 @@
+#!/usr/bin/env node
+/**
+ * Dry release preflight.
+ *
+ * Builds and inspects the artifacts a user would install before any publish
+ * step is allowed to run. This is intentionally local/CI-only: it never creates
+ * a tag, never calls npm publish, and never mutates a GitHub Release.
+ */
+
+import { copyFileSync, existsSync, mkdirSync, readFileSync, rmSync, statSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const ROOT = dirname(fileURLToPath(new URL("../package.json", import.meta.url)));
+const OUT_DIR = join(ROOT, "build", "release-preflight");
+const args = new Set(process.argv.slice(2));
+const INCLUDE_APP = args.has("--app");
+const pkg = JSON.parse(readFileSync(join(ROOT, "package.json"), "utf8"));
+const version = pkg.version;
+
+function run(cmd, cmdArgs, options = {}) {
+  const result = spawnSync(cmd, cmdArgs, {
+    cwd: ROOT,
+    env: process.env,
+    encoding: "utf8",
+    stdio: options.capture ? "pipe" : "inherit",
+    maxBuffer: 64 * 1024 * 1024,
+    ...options,
+  });
+  if (result.status !== 0) {
+    const rendered = [cmd, ...cmdArgs].join(" ");
+    console.error(`release-preflight: command failed (${result.status}): ${rendered}`);
+    if (result.stdout) console.error(result.stdout);
+    if (result.stderr) console.error(result.stderr);
+    process.exit(result.status ?? 1);
+  }
+  return result.stdout ?? "";
+}
+
+function fail(message) {
+  console.error(`release-preflight: ${message}`);
+  process.exit(1);
+}
+
+function assertFile(path, label) {
+  if (!existsSync(path)) fail(`${label} missing: ${path}`);
+  const size = statSync(path).size;
+  if (size <= 0) fail(`${label} is empty: ${path}`);
+  return size;
+}
+
+function listZip(path) {
+  const output = run("unzip", ["-Z1", path], { capture: true });
+  return output
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean);
+}
+
+function readZipJson(path, entry) {
+  const output = run("unzip", ["-p", path, entry], { capture: true });
+  try {
+    return JSON.parse(output);
+  } catch (error) {
+    fail(`${entry} in ${path} is not valid JSON: ${error.message}`);
+  }
+}
+
+function verifyNpmDryRun() {
+  const output = run("npm", ["pack", "--dry-run", "--json"], { capture: true });
+  let pack;
+  try {
+    [pack] = JSON.parse(output);
+  } catch (error) {
+    fail(`npm pack --dry-run --json did not return parseable JSON: ${error.message}`);
+  }
+  if (!pack || pack.version !== version) {
+    fail(`npm dry-run version mismatch: expected ${version}, got ${pack?.version ?? "none"}`);
+  }
+  const filePaths = (pack.files ?? []).map((file) => file.path);
+  const forbidden = filePaths.filter(
+    (path) =>
+      path.startsWith("build/") ||
+      path.startsWith("experiments/") ||
+      path.endsWith(".mcpb") ||
+      path.endsWith(".env") ||
+      path === ".npmrc",
+  );
+  if (forbidden.length) {
+    fail(`npm dry-run includes non-shipped or sensitive paths: ${forbidden.join(", ")}`);
+  }
+  if (!filePaths.includes("dist/index.js")) {
+    fail("npm dry-run is missing dist/index.js");
+  }
+  console.log(`ok: npm dry-run: ${pack.filename}, ${filePaths.length} files, dist-only publish surface`);
+}
+
+function verifyMcpb(path) {
+  const size = assertFile(path, ".mcpb");
+  const entries = listZip(path);
+  const required = ["manifest.json", "icon.png", "server/package.json", "server/dist/index.js"];
+  const missing = required.filter((entry) => !entries.includes(entry));
+  if (missing.length) fail(`.mcpb is missing required entries: ${missing.join(", ")}`);
+  if (!entries.some((entry) => entry.startsWith("server/node_modules/"))) {
+    fail(".mcpb is missing bundled production dependencies under server/node_modules/");
+  }
+  const forbidden = entries.filter(
+    (entry) =>
+      entry.startsWith("src/") ||
+      entry.startsWith("experiments/") ||
+      entry.includes("/experiments/") ||
+      entry.endsWith(".env") ||
+      entry === ".npmrc" ||
+      entry.endsWith("/.npmrc"),
+  );
+  if (forbidden.length) fail(`.mcpb includes forbidden paths: ${forbidden.join(", ")}`);
+
+  const manifest = readZipJson(path, "manifest.json");
+  if (manifest.version !== version) {
+    fail(`.mcpb manifest version mismatch: expected ${version}, got ${manifest.version}`);
+  }
+  if (manifest.manifest_version !== "0.3") {
+    fail(`.mcpb manifest_version mismatch: expected 0.3, got ${manifest.manifest_version}`);
+  }
+  console.log(`ok: .mcpb: ${path} (${(size / 1024 / 1024).toFixed(2)} MB), manifest v${manifest.version}`);
+}
+
+function buildAppArchive() {
+  run("bash", ["scripts/bundle-app.sh", "bundle"], {
+    env: { ...process.env, AIRMCP_SKIP_WIDGET: "1" },
+  });
+  const appPath = join(ROOT, "AirMCP.app");
+  assertFile(join(appPath, "Contents", "MacOS", "AirMCP"), "AirMCP.app executable");
+  const zipPath = join(OUT_DIR, `AirMCP-${version}-adhoc.zip`);
+  run("ditto", ["-c", "-k", "--norsrc", "--keepParent", appPath, zipPath]);
+  const size = assertFile(zipPath, "ad-hoc app archive");
+  console.log(`ok: ad-hoc app archive: ${zipPath} (${(size / 1024 / 1024).toFixed(2)} MB)`);
+}
+
+rmSync(OUT_DIR, { recursive: true, force: true });
+mkdirSync(OUT_DIR, { recursive: true });
+
+console.log(`release-preflight: AirMCP v${version}`);
+run("npm", ["run", "build"]);
+run("npm", ["run", "verify:package"]);
+verifyNpmDryRun();
+run("npm", ["run", "build:mcpb"]);
+
+const mcpbPath = join(ROOT, "build", "mcpb", `airmcp-${version}.mcpb`);
+verifyMcpb(mcpbPath);
+copyFileSync(mcpbPath, join(OUT_DIR, `airmcp-${version}.mcpb`));
+
+if (INCLUDE_APP) {
+  buildAppArchive();
+} else {
+  console.log("release-preflight: skipping app bundle archive (pass --app to include it)");
+}
+
+console.log(`ok: release preflight artifacts ready in ${OUT_DIR}`);


### PR DESCRIPTION
## Summary
- add `npm run release:preflight` to build and inspect installable artifacts without publishing
- add a manual `Release Preflight` workflow that runs full CI, then uploads dry `.mcpb` and ad-hoc app zip artifacts
- update the release checklist so dry artifact validation is required before tag/npm/GitHub Release steps
- remove stale coverage-count wording and old script names from the release checklist

## Why
Publishing should not be the first time AirMCP proves the installable surface exists. This separates completion from distribution:
- no tag creation
- no `npm publish`
- no GitHub Release mutation
- packaged npm tarball boot is checked
- `.mcpb` structure and manifest version are checked
- optional app bundle archive is produced as a dry artifact

## Verification
- `node --check scripts/release-preflight.mjs`
- `ruby -e 'require "yaml"; ARGV.each { |p| YAML.load_file(p); puts "ok #{p}" }' .github/workflows/release-preflight.yml .github/workflows/cd.yml .github/workflows/ci.yml`
- `npm run release:preflight`
- `npm run release:preflight -- --app`
- `npm test`
- `npm run typecheck && npm run build:mcpb:check && npm run version:check && npm run stats:check`

## Notes
- Runtime code unchanged.
- Publish remains blocked until the project owner explicitly chooses to run CD with valid npm credentials.
