### PR TITLE
feat: add opt-in spatial prep module

### DIFF
--- a/README.md
+++ b/README.md
@@ -888,7 +888,9 @@ Or edit `~/.config/airmcp/config.json` directly:
 | `AIRMCP_INCLUDE_SHARED`      | `false`                      | Include items shared/owned by others (off by default: shared items are filtered from reads and mutating them is denied, or routed through share-approval HITL when configured)                                 |
 | `AIRMCP_ALLOW_SEND_MESSAGES` | `false`                      | Allow sending iMessages (opt-in)                             |
 | `AIRMCP_ALLOW_SEND_MAIL`     | `false`                      | Allow sending emails (opt-in)                                |
-| `AIRMCP_FULL`                | `false`                      | Enable all modules (ignores preset)                          |
+| `AIRMCP_FULL`                | `false`                      | Enable all standard 29 modules (profile-only modules stay opt-in) |
+| `AIRMCP_PROFILE`             | —                            | Comma-separated experimental profiles/modules to opt into (e.g. `spatial_prep`) |
+| `AIRMCP_ENABLE_SPATIAL_PREP` | `false`                      | Enable the experimental read-only spatial asset prep tools    |
 | `AIRMCP_DISABLE_{MODULE}`    | —                            | Disable a specific module (e.g. `AIRMCP_DISABLE_MUSIC=true`) |
 | `GEMINI_API_KEY`             | —                            | Google Gemini API key for cloud embeddings (optional)        |
 | `AIRMCP_EMBEDDING_MODEL`     | `gemini-embedding-2-preview` | Gemini embedding model name                                  |
@@ -896,6 +898,10 @@ Or edit `~/.config/airmcp/config.json` directly:
 | `AIRMCP_EMBEDDING_PROVIDER`  | auto                         | Force provider: `gemini`, `swift`, `hybrid`, `none`          |
 | `AIRMCP_HTTP_TOKEN`          | —                            | Bearer token for HTTP mode authentication                    |
 | `AIRMCP_NPM_PACKAGE_SPECIFIER` | `airmcp@<current>`          | Override app-owned proxy/runtime package for local testing   |
+
+Experimental profile-only modules are not enabled by `--full` / `AIRMCP_FULL`.
+Enable them explicitly with `AIRMCP_PROFILE=<module>` or their dedicated
+`AIRMCP_ENABLE_<MODULE>` flag.
 
 ### Config File
 

--- a/docs/environment.md
+++ b/docs/environment.md
@@ -79,7 +79,9 @@ If a variable accepts a path, `~` expands to `$HOME`. Booleans are `"true"` / `"
 
 | Variable | Default | Notes |
 |---|---|---|
-| `AIRMCP_FULL` | (off) | `true` enables every module ignoring the config's `disabledModules`. Per-process flag for ad-hoc usage. |
+| `AIRMCP_FULL` | (off) | `true` enables every standard module ignoring the config's `disabledModules`. Profile-only modules stay opt-in. |
+| `AIRMCP_PROFILE` | (empty) | Comma-separated profile-only modules to opt into, such as `spatial_prep`. |
+| `AIRMCP_ENABLE_SPATIAL_PREP` | (off) | `true` enables the experimental read-only spatial asset prep tools. |
 | `AIRMCP_DEBUG_MODULES` | (empty) | Comma-separated whitelist. When set, only listed modules load — easier debugging of import / boot issues. |
 | `AIRMCP_DEBUG_SEQUENTIAL` | (off) | `true` loads modules one-by-one instead of `Promise.all()`. Memory-safe debugging. |
 | `AIRMCP_DISABLE_POLLERS` | (off) | `true` suppresses event poller registration (mail unread, focus mode, etc.). |
@@ -174,7 +176,7 @@ These are documented for completeness; you should rarely set them in production.
 |---|---|
 | `NODE_ENV=test` | Unlocks test-only reset hooks. |
 | `AIRMCP_TEST_MODE=1` | Same as above for callers without control over `NODE_ENV`. |
-| `AIRMCP_DISABLE_*` | Module-level kill switches surfaced via `npx airmcp --help` and validated against `MODULE_NAMES`. |
+| `AIRMCP_DISABLE_*` | Module-level kill switches surfaced via `npx airmcp --help` and validated against known module names. |
 
 ---
 

--- a/docs/mcpb.md
+++ b/docs/mcpb.md
@@ -14,7 +14,7 @@ AirMCP ships a `.mcpb` bundle with every release.
    | Field | What it does |
    |---|---|
    | **Gemini API Key** (optional, sensitive) | Enables cloud embeddings for semantic tool search + note search. Leave blank to use Apple's on-device `NLContextualEmbedding` — no cloud calls are made without this key. |
-   | **Load all 29 modules on startup** (default: off) | Off keeps AirMCP at the 7 starter modules (notes, reminders, calendar, shortcuts, system, finder, weather) — a small, fast-to-initialise surface. Workflows that use Mail, Contacts, Safari, semantic memory, or Apple Intelligence will enable/request those modules separately. On registers every module (contacts, mail, messages, music, safari, photos, Apple Intelligence, TV, maps, iWork, Google Workspace, health, bluetooth, etc.). |
+   | **Load all 29 modules on startup** (default: off) | Off keeps AirMCP at the 7 starter modules (notes, reminders, calendar, shortcuts, system, finder, weather) — a small, fast-to-initialise surface. Workflows that use Mail, Contacts, Safari, semantic memory, or Apple Intelligence will enable/request those modules separately. On registers every standard module (contacts, mail, messages, music, safari, photos, Apple Intelligence, TV, maps, iWork, Google Workspace, health, bluetooth, etc.). Experimental profile-only modules such as `spatial_prep` remain disabled. |
 
 5. Claude Desktop launches AirMCP the first time you open a conversation. macOS will prompt for Contacts / Calendar / Reminders / Notes permissions as they're first used — grant each.
 
@@ -68,7 +68,7 @@ AirMCP's tool list is dynamic (skills + dynamic shortcuts generate tools at runt
 
 ### "I want a specific module off"
 
-The UI only exposes the global "Load all 29 modules" toggle. For per-module disabling, drop the `.mcpb` path and use `npx airmcp init` instead (`~/.config/airmcp/config.json` has a module selection block).
+The UI only exposes the global "Load all 29 modules" toggle. For per-module disabling, or to opt into profile-only modules such as `spatial_prep`, drop the `.mcpb` path and use `npx airmcp init` / environment variables instead (`~/.config/airmcp/config.json` has a module selection block).
 
 ### Bundle is large (>5 MB)
 

--- a/docs/site/src/content/docs/architecture/overview.md
+++ b/docs/site/src/content/docs/architecture/overview.md
@@ -117,7 +117,7 @@ Each module has:
 - `src/<name>/scripts.ts` -- JXA script generators (template-literal functions)
 - `src/<name>/prompts.ts` (optional) -- MCP prompt templates
 
-Modules are loaded dynamically at startup. The `loadModuleRegistry()` function imports each module and finds its register function by convention (any exported function starting with `register`).
+Modules are loaded dynamically at startup. The `loadModuleRegistry()` function applies debug/config filtering before import, then imports each selected module and finds its register function by convention (any exported function starting with `register`).
 
 ### Config Resolution
 

--- a/docs/site/src/content/docs/getting-started/configuration.md
+++ b/docs/site/src/content/docs/getting-started/configuration.md
@@ -53,7 +53,9 @@ The default config file location is `~/.config/airmcp/config.json`. You can over
 
 | Variable | Description |
 |----------|-------------|
-| `AIRMCP_FULL=true` | Enable all 29 modules (ignores disabledModules) |
+| `AIRMCP_FULL=true` | Enable all standard 29 modules (profile-only modules stay opt-in) |
+| `AIRMCP_PROFILE=spatial_prep` | Enable an experimental profile-only module |
+| `AIRMCP_ENABLE_SPATIAL_PREP=true` | Enable the experimental read-only spatial asset prep tools |
 | `AIRMCP_DISABLE_<MODULE>=true` | Disable a specific module (e.g. `AIRMCP_DISABLE_TV=true`) |
 | `AIRMCP_CONFIG_PATH` | Override config file path (default: `~/.config/airmcp/config.json`) |
 
@@ -165,4 +167,6 @@ When no `config.json` exists and `--full` is not used, AirMCP enables a curated 
 - **Finder** -- file search, directory listing, file operations
 - **Weather** -- current conditions and forecasts
 
-All other modules are disabled by default. Use `npx airmcp init` to customize, or pass `--full` to enable everything.
+All other standard modules are disabled by default. Use `npx airmcp init` to customize, or pass `--full` to enable the standard 29-module surface.
+
+Experimental profile-only modules, such as `spatial_prep`, stay disabled even with `--full`. Enable them explicitly with `AIRMCP_PROFILE=spatial_prep` or `AIRMCP_ENABLE_SPATIAL_PREP=true`.

--- a/mcpb/manifest.template.json
+++ b/mcpb/manifest.template.json
@@ -62,7 +62,7 @@
     "load_all_modules": {
       "type": "boolean",
       "title": "Load all 29 modules on startup",
-      "description": "Off by default — only the 7 starter modules load (notes, reminders, calendar, shortcuts, system, finder, weather) to keep the surface small. Turn on to register all modules (contacts, mail, messages, music, safari, photos, apple intelligence, TV, maps, iWork, Google Workspace, health, bluetooth, etc.). Per-module disable can still be done via AIRMCP_DISABLE_<MODULE> env vars in advanced setups.",
+      "description": "Off by default — only the 7 starter modules load (notes, reminders, calendar, shortcuts, system, finder, weather) to keep the surface small. Turn on to register all standard modules (contacts, mail, messages, music, safari, photos, apple intelligence, TV, maps, iWork, Google Workspace, health, bluetooth, etc.). Experimental profile-only modules such as spatial_prep remain disabled. Per-module disable can still be done via AIRMCP_DISABLE_<MODULE> env vars in advanced setups.",
       "required": false,
       "default": false
     }

--- a/scripts/gen-llms-txt.mjs
+++ b/scripts/gen-llms-txt.mjs
@@ -33,6 +33,17 @@ const CANONICAL_MODULE_COUNT = (() => {
   }
 })();
 
+const OPT_IN_MODULES = (() => {
+  try {
+    const config = readFileSync(join(SRC, "shared", "config.ts"), "utf-8");
+    const m = config.match(/export const OPT_IN_MODULE_NAMES = \[([\s\S]*?)\] as const;/);
+    if (!m) return new Set();
+    return new Set((m[1].match(/"([^"]+)"/g) || []).map((s) => JSON.parse(s)));
+  } catch {
+    return new Set();
+  }
+})();
+
 /**
  * Headline tool count — the FULL runtime surface from the generated manifest
  * (docs/tool-manifest.json), the same single source of truth count-stats.mjs
@@ -139,6 +150,7 @@ function walkDir(dir, modules, counts) {
     if (entry.isDirectory()) walkDir(full, modules, counts);
     else if (entry.name.endsWith(".ts")) {
       const modDir = basename(dirname(full));
+      if (OPT_IN_MODULES.has(modDir)) continue;
       const content = readFileSync(full, "utf-8");
       counts.totalTools += (content.match(TOOL_REGEX) || []).length;
       counts.totalPrompts += (content.match(PROMPT_REGEX) || []).length;

--- a/src/server/mcp-setup.ts
+++ b/src/server/mcp-setup.ts
@@ -69,8 +69,9 @@ export async function createServer(
     installHitlGuard(lServer, hitlClient, config);
   }
 
-  // Dynamic module loading — only imports modules at startup
-  const MODULE_REGISTRY = await loadModuleRegistry();
+  // Dynamic module loading — disabled modules are filtered before import so
+  // opt-in surfaces stay zero-cost at startup.
+  const MODULE_REGISTRY = await loadModuleRegistry(config);
   setModuleRegistry(MODULE_REGISTRY);
 
   // RFC 0004: route every module through the compatibility resolver. The

--- a/src/shared/config.ts
+++ b/src/shared/config.ts
@@ -122,6 +122,9 @@ export const MODULE_NAMES = [
   "audit",
 ] as const;
 
+export const OPT_IN_MODULE_NAMES = ["spatial_prep"] as const;
+export const KNOWN_MODULE_NAMES = [...MODULE_NAMES, ...OPT_IN_MODULE_NAMES] as const;
+
 /** Core modules enabled by default when no config.json exists */
 export const STARTER_MODULES: ReadonlySet<string> = new Set([
   "notes",
@@ -134,6 +137,7 @@ export const STARTER_MODULES: ReadonlySet<string> = new Set([
 ]);
 
 export type ModuleName = (typeof MODULE_NAMES)[number];
+export type KnownModuleName = (typeof KNOWN_MODULE_NAMES)[number];
 
 export interface McpClient {
   name: string;
@@ -304,7 +308,7 @@ export function parseConfig(): AirMcpConfig {
   // Validate disabledModules: warn about unknown module names
   if (file.disabledModules) {
     for (const mod of file.disabledModules) {
-      if (!(MODULE_NAMES as readonly string[]).includes(mod)) {
+      if (!(KNOWN_MODULE_NAMES as readonly string[]).includes(mod)) {
         log.warn("unknown module in disabledModules — ignored", { module: mod });
       }
     }
@@ -331,14 +335,19 @@ export function parseConfig(): AirMcpConfig {
   // Disabled modules: env vars override, then JSON fallback, then starter preset
   const disabledModules = new Set<string>();
   const fileDisabled = new Set(file.disabledModules ?? []);
-  for (const mod of MODULE_NAMES) {
+  const enabledProfiles = parseProfileEnv(process.env.AIRMCP_PROFILE);
+  for (const mod of KNOWN_MODULE_NAMES) {
     const envKey = `AIRMCP_DISABLE_${mod.toUpperCase()}`;
+    const enableEnvKey = `AIRMCP_ENABLE_${mod.toUpperCase()}`;
     const envVal = process.env[envKey];
+    const optInEnabled = process.env[enableEnvKey] === "true" || enabledProfiles.has(mod);
     if (envVal === "true") {
+      disabledModules.add(mod);
+    } else if ((OPT_IN_MODULE_NAMES as readonly string[]).includes(mod) && !optInEnabled) {
       disabledModules.add(mod);
     } else if (envVal === undefined && !fullMode && fileDisabled.has(mod)) {
       disabledModules.add(mod);
-    } else if (envVal === undefined && !fileExists && !fullMode && !STARTER_MODULES.has(mod)) {
+    } else if (envVal === undefined && !fileExists && !fullMode && !STARTER_MODULES.has(mod) && !optInEnabled) {
       // No config.json & not --full: apply starter preset
       disabledModules.add(mod);
     }
@@ -350,13 +359,13 @@ export function parseConfig(): AirMcpConfig {
   if (shareApprovalEnv) {
     for (const raw of shareApprovalEnv.split(",")) {
       const mod = raw.trim().toLowerCase();
-      if (mod && (MODULE_NAMES as readonly string[]).includes(mod)) {
+      if (mod && (KNOWN_MODULE_NAMES as readonly string[]).includes(mod)) {
         shareApprovalModules.add(mod);
       }
     }
   } else if (file.shareApproval) {
     for (const mod of file.shareApproval) {
-      if ((MODULE_NAMES as readonly string[]).includes(mod)) {
+      if ((KNOWN_MODULE_NAMES as readonly string[]).includes(mod)) {
         shareApprovalModules.add(mod);
       }
     }
@@ -429,6 +438,16 @@ export function parseConfig(): AirMcpConfig {
 
 export function isModuleEnabled(config: AirMcpConfig, moduleName: string): boolean {
   return !config.disabledModules.has(moduleName);
+}
+
+function parseProfileEnv(raw: string | undefined): Set<string> {
+  const profiles = new Set<string>();
+  if (!raw) return profiles;
+  for (const part of raw.split(",")) {
+    const profile = part.trim().toLowerCase();
+    if (profile) profiles.add(profile);
+  }
+  return profiles;
 }
 
 export function needsShareApproval(config: AirMcpConfig, moduleName: string): boolean {

--- a/src/shared/modules.ts
+++ b/src/shared/modules.ts
@@ -1,5 +1,7 @@
 import type { ModuleRegistration } from "./registry.js";
 import type { ModuleCompatibility } from "./compatibility.js";
+import type { AirMcpConfig } from "./config.js";
+import { isModuleEnabled } from "./config.js";
 import { log, errToCtx } from "./logger.js";
 
 /**
@@ -106,6 +108,7 @@ export const MODULE_MANIFEST: ReadonlyArray<ModuleManifestEntry> = [
   },
   { name: "memory" },
   { name: "audit" },
+  { name: "spatial_prep" },
 ];
 
 /**
@@ -120,8 +123,6 @@ export const MODULE_MANIFEST: ReadonlyArray<ModuleManifestEntry> = [
  * Combine both for memory-safe debugging:
  *   AIRMCP_DEBUG_MODULES=notes AIRMCP_DEBUG_SEQUENTIAL=true
  */
-let cache: ModuleRegistration[] | null = null;
-
 /** Parse AIRMCP_DEBUG_MODULES into a whitelist Set, or null if unset. */
 function getDebugWhitelist(): Set<string> | null {
   const raw = process.env.AIRMCP_DEBUG_MODULES;
@@ -174,14 +175,15 @@ async function importModule(def: ModuleManifestEntry): Promise<ModuleRegistratio
   }
 }
 
-export async function loadModuleRegistry(): Promise<ModuleRegistration[]> {
-  if (cache) return cache;
+const cacheByKey = new Map<string, ModuleRegistration[]>();
 
+export async function loadModuleRegistry(config?: AirMcpConfig): Promise<ModuleRegistration[]> {
   const whitelist = getDebugWhitelist();
+  const targets = getTargetManifestEntries(config, whitelist);
+  const cacheKey = targets.map((m) => m.name).join(",");
+  if (cacheByKey.has(cacheKey)) return cacheByKey.get(cacheKey)!;
+
   const sequential = process.env.AIRMCP_DEBUG_SEQUENTIAL === "true";
-  const targets: ReadonlyArray<ModuleManifestEntry> = whitelist
-    ? MODULE_MANIFEST.filter((m) => whitelist.has(m.name))
-    : MODULE_MANIFEST;
 
   if (whitelist) {
     log.info("Debug mode: loading whitelist subset (sequential loading optional)", {
@@ -222,9 +224,20 @@ export async function loadModuleRegistry(): Promise<ModuleRegistration[]> {
     log.error("failed to load modules", { count: failed.length, modules: failed });
   }
 
-  cache = registry;
+  cacheByKey.set(cacheKey, registry);
 
   return registry;
+}
+
+function getTargetManifestEntries(
+  config: AirMcpConfig | undefined,
+  whitelist: Set<string> | null,
+): ReadonlyArray<ModuleManifestEntry> {
+  return MODULE_MANIFEST.filter((m) => {
+    if (whitelist && !whitelist.has(m.name)) return false;
+    if (config && !isModuleEnabled(config, m.name)) return false;
+    return true;
+  });
 }
 
 /** Find the first exported function whose name starts with "register". */

--- a/src/spatial_prep/tools.ts
+++ b/src/spatial_prep/tools.ts
@@ -1,0 +1,433 @@
+import type { McpServer } from "../shared/mcp.js";
+import type { AirMcpConfig } from "../shared/config.js";
+import { z } from "zod";
+import { readdir, readFile, realpath, stat } from "node:fs/promises";
+import { basename, dirname, extname, isAbsolute, join, relative } from "node:path";
+import { okUntrustedStructured, errInvalidInput, errNotFound, toolError } from "../shared/result.js";
+import { zFilePath } from "../shared/validate.js";
+
+const ASSET_EXTENSIONS = [".usdz", ".reality", ".glb", ".gltf", ".obj", ".fbx", ".hdr", ".exr"] as const;
+const ASSET_EXTENSION_SET = new Set<string>(ASSET_EXTENSIONS);
+const TEXT_CONTEXT_EXTENSIONS = new Set([".md", ".txt", ".json", ".yaml", ".yml", ".toml"]);
+const NEARBY_CONTEXT_EXTENSIONS = new Set([
+  ...ASSET_EXTENSIONS,
+  ".mtl",
+  ".usda",
+  ".usd",
+  ".png",
+  ".jpg",
+  ".jpeg",
+  ".heic",
+  ".tif",
+  ".tiff",
+  ".webp",
+  ...TEXT_CONTEXT_EXTENSIONS,
+]);
+
+const MAX_TEXT_FILE_BYTES = 64_000;
+
+const assetExtensionSchema = z.enum(ASSET_EXTENSIONS);
+
+interface SpatialAsset {
+  path: string;
+  relativePath: string;
+  name: string;
+  extension: string;
+  size: number;
+  modifiedAt: string;
+}
+
+interface NearbyFile extends SpatialAsset {
+  kind: "asset" | "material" | "texture" | "metadata" | "context";
+}
+
+export function registerSpatialPrepTools(server: McpServer, _config: AirMcpConfig): void {
+  server.registerTool(
+    "list_vr_assets",
+    {
+      title: "List VR Assets",
+      description:
+        "Read-only scan for spatial/VR asset files under a user-provided folder. Returns metadata only; does not read binary asset contents.",
+      inputSchema: {
+        root: zFilePath.describe("Absolute folder path to scan"),
+        extensions: z
+          .array(assetExtensionSchema)
+          .max(ASSET_EXTENSIONS.length)
+          .optional()
+          .describe("Asset extensions to include"),
+        limit: z.number().int().min(1).max(50).optional().default(50).describe("Max assets to return (default 50)"),
+        cursor: z.number().int().min(0).optional().default(0).describe("Result offset for pagination"),
+        maxDepth: z.number().int().min(0).max(12).optional().default(6).describe("Max directory depth to scan"),
+        maxEntries: z
+          .number()
+          .int()
+          .min(100)
+          .max(10_000)
+          .optional()
+          .default(10_000)
+          .describe("Max filesystem entries to inspect before stopping"),
+        includeHidden: z.boolean().optional().default(false).describe("Include dotfiles and dot directories"),
+      },
+      outputSchema: {
+        root: z.string(),
+        extensions: z.array(z.string()),
+        scannedEntries: z.number().int(),
+        skippedSymlinks: z.number().int(),
+        truncated: z.boolean(),
+        total: z.number().int(),
+        returned: z.number().int(),
+        nextCursor: z.number().int().nullable(),
+        assets: z.array(
+          z.object({
+            path: z.string(),
+            relativePath: z.string(),
+            name: z.string(),
+            extension: z.string(),
+            size: z.number().int(),
+            modifiedAt: z.string(),
+          }),
+        ),
+      },
+      annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: false },
+    },
+    async ({ root, extensions, limit, cursor, maxDepth, maxEntries, includeHidden }) => {
+      const allowed = normalizeAssetExtensions(extensions);
+      if (!allowed.ok) return errInvalidInput(allowed.message);
+
+      try {
+        const result = await scanSpatialAssets({
+          root,
+          extensions: allowed.extensions,
+          limit,
+          cursor,
+          maxDepth,
+          maxEntries,
+          includeHidden,
+        });
+        return okUntrustedStructured(result);
+      } catch (e) {
+        return formatFsError("list VR assets", e);
+      }
+    },
+  );
+
+  server.registerTool(
+    "get_vr_asset_context",
+    {
+      title: "Get VR Asset Context",
+      description:
+        "Read-only context bundle for one spatial/VR asset: file metadata, nearby textures/materials/metadata, and bounded text excerpts from adjacent context files.",
+      inputSchema: {
+        assetPath: zFilePath.describe("Absolute path to a VR/spatial asset"),
+        root: zFilePath.optional().describe("Optional root folder; asset must resolve inside it when provided"),
+        nearbyLimit: z
+          .number()
+          .int()
+          .min(1)
+          .max(100)
+          .optional()
+          .default(50)
+          .describe("Max nearby context files to return"),
+        maxTextChars: z
+          .number()
+          .int()
+          .min(0)
+          .max(8_000)
+          .optional()
+          .default(2_000)
+          .describe("Max characters per adjacent text context file"),
+        includeHidden: z.boolean().optional().default(false).describe("Include dotfiles in nearby context"),
+      },
+      outputSchema: {
+        asset: z.object({
+          path: z.string(),
+          name: z.string(),
+          extension: z.string(),
+          size: z.number().int(),
+          modifiedAt: z.string(),
+        }),
+        root: z.string().nullable(),
+        directory: z.string(),
+        nearby: z.object({
+          total: z.number().int(),
+          returned: z.number().int(),
+          files: z.array(
+            z.object({
+              path: z.string(),
+              relativePath: z.string(),
+              name: z.string(),
+              extension: z.string(),
+              kind: z.enum(["asset", "material", "texture", "metadata", "context"]),
+              size: z.number().int(),
+              modifiedAt: z.string(),
+            }),
+          ),
+        }),
+        textContext: z.array(
+          z.object({
+            path: z.string(),
+            name: z.string(),
+            extension: z.string(),
+            size: z.number().int(),
+            excerpt: z.string(),
+            truncated: z.boolean(),
+          }),
+        ),
+        notes: z.array(z.string()),
+      },
+      annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: false },
+    },
+    async ({ assetPath, root, nearbyLimit, maxTextChars, includeHidden }) => {
+      try {
+        const result = await buildAssetContext({ assetPath, root, nearbyLimit, maxTextChars, includeHidden });
+        return okUntrustedStructured(result);
+      } catch (e) {
+        return formatFsError("get VR asset context", e);
+      }
+    },
+  );
+}
+
+function normalizeAssetExtensions(
+  input: string[] | undefined,
+): { ok: true; extensions: Set<string> } | { ok: false; message: string } {
+  if (!input || input.length === 0) return { ok: true, extensions: new Set(ASSET_EXTENSIONS) };
+  const normalized = new Set<string>();
+  for (const raw of input) {
+    const ext = raw.toLowerCase();
+    if (!ASSET_EXTENSION_SET.has(ext)) {
+      return { ok: false, message: `Unsupported VR asset extension: ${raw}` };
+    }
+    normalized.add(ext);
+  }
+  return { ok: true, extensions: normalized };
+}
+
+async function scanSpatialAssets(options: {
+  root: string;
+  extensions: Set<string>;
+  limit: number;
+  cursor: number;
+  maxDepth: number;
+  maxEntries: number;
+  includeHidden: boolean;
+}) {
+  const root = await realpath(options.root);
+  const rootStat = await stat(root);
+  if (!rootStat.isDirectory()) {
+    throw new Error(`not a directory: ${options.root}`);
+  }
+
+  const assets: SpatialAsset[] = [];
+  const queue: Array<{ path: string; depth: number }> = [{ path: root, depth: 0 }];
+  let scannedEntries = 0;
+  let skippedSymlinks = 0;
+  let truncated = false;
+
+  while (queue.length > 0) {
+    const current = queue.shift()!;
+    let entries;
+    try {
+      entries = await readdir(current.path, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+
+    for (const entry of entries) {
+      if (!options.includeHidden && entry.name.startsWith(".")) continue;
+      scannedEntries += 1;
+      if (scannedEntries > options.maxEntries) {
+        truncated = true;
+        break;
+      }
+
+      const fullPath = join(current.path, entry.name);
+      if (entry.isSymbolicLink()) {
+        skippedSymlinks += 1;
+        continue;
+      }
+      if (entry.isDirectory()) {
+        if (current.depth < options.maxDepth) queue.push({ path: fullPath, depth: current.depth + 1 });
+        continue;
+      }
+      if (!entry.isFile()) continue;
+
+      const extension = extname(entry.name).toLowerCase();
+      if (!options.extensions.has(extension)) continue;
+      const fileStat = await stat(fullPath);
+      assets.push(toAsset(root, fullPath, fileStat.size, fileStat.mtime));
+    }
+
+    if (truncated) break;
+  }
+
+  assets.sort((a, b) => a.relativePath.localeCompare(b.relativePath));
+  const page = assets.slice(options.cursor, options.cursor + options.limit);
+  const nextCursor = options.cursor + page.length < assets.length ? options.cursor + page.length : null;
+
+  return {
+    root,
+    extensions: [...options.extensions].sort(),
+    scannedEntries: Math.min(scannedEntries, options.maxEntries),
+    skippedSymlinks,
+    truncated: truncated || queue.length > 0,
+    total: assets.length,
+    returned: page.length,
+    nextCursor,
+    assets: page,
+  };
+}
+
+async function buildAssetContext(options: {
+  assetPath: string;
+  root?: string;
+  nearbyLimit: number;
+  maxTextChars: number;
+  includeHidden: boolean;
+}) {
+  const assetPath = await realpath(options.assetPath);
+  const assetStat = await stat(assetPath);
+  if (!assetStat.isFile()) {
+    throw new Error(`not a file: ${options.assetPath}`);
+  }
+
+  const extension = extname(assetPath).toLowerCase();
+  if (!ASSET_EXTENSION_SET.has(extension)) {
+    throw new Error(`unsupported VR asset extension: ${extension || "(none)"}`);
+  }
+
+  const root = options.root ? await realpath(options.root) : null;
+  if (root && !isInside(root, assetPath)) {
+    throw new Error(`asset is outside root: ${options.assetPath}`);
+  }
+
+  const directory = dirname(assetPath);
+  const nearby = await listNearbyFiles(
+    directory,
+    root ?? directory,
+    assetPath,
+    options.nearbyLimit,
+    options.includeHidden,
+  );
+  const textContext = await readTextContext(nearby.files, options.maxTextChars);
+
+  return {
+    asset: {
+      path: assetPath,
+      name: basename(assetPath),
+      extension,
+      size: assetStat.size,
+      modifiedAt: assetStat.mtime.toISOString(),
+    },
+    root,
+    directory,
+    nearby,
+    textContext,
+    notes: [
+      "Binary asset contents are not read.",
+      "Adjacent text is returned as untrusted context and is bounded by maxTextChars.",
+    ],
+  };
+}
+
+async function listNearbyFiles(
+  directory: string,
+  root: string,
+  assetPath: string,
+  nearbyLimit: number,
+  includeHidden: boolean,
+): Promise<{ total: number; returned: number; files: NearbyFile[] }> {
+  const files: NearbyFile[] = [];
+  const entries = await readdir(directory, { withFileTypes: true });
+  for (const entry of entries) {
+    if (!includeHidden && entry.name.startsWith(".")) continue;
+    if (!entry.isFile() || entry.isSymbolicLink()) continue;
+
+    const path = join(directory, entry.name);
+    if (path === assetPath) continue;
+    const extension = extname(entry.name).toLowerCase();
+    if (!NEARBY_CONTEXT_EXTENSIONS.has(extension)) continue;
+
+    const fileStat = await stat(path);
+    files.push({
+      ...toAsset(root, path, fileStat.size, fileStat.mtime),
+      kind: classifyNearbyFile(extension),
+    });
+  }
+
+  files.sort((a, b) => a.relativePath.localeCompare(b.relativePath));
+  const page = files.slice(0, nearbyLimit);
+  return { total: files.length, returned: page.length, files: page };
+}
+
+async function readTextContext(files: NearbyFile[], maxTextChars: number) {
+  if (maxTextChars === 0) return [];
+  const out: Array<{
+    path: string;
+    name: string;
+    extension: string;
+    size: number;
+    excerpt: string;
+    truncated: boolean;
+  }> = [];
+  for (const file of files) {
+    if (!TEXT_CONTEXT_EXTENSIONS.has(file.extension) || file.size > MAX_TEXT_FILE_BYTES) continue;
+    const text = await readFile(file.path, "utf8");
+    const excerpt = cleanText(text).slice(0, maxTextChars);
+    out.push({
+      path: file.path,
+      name: file.name,
+      extension: file.extension,
+      size: file.size,
+      excerpt,
+      truncated: text.length > maxTextChars,
+    });
+  }
+  return out;
+}
+
+function toAsset(root: string, path: string, size: number, mtime: Date): SpatialAsset {
+  return {
+    path,
+    relativePath: relative(root, path) || basename(path),
+    name: basename(path),
+    extension: extname(path).toLowerCase(),
+    size,
+    modifiedAt: mtime.toISOString(),
+  };
+}
+
+function classifyNearbyFile(extension: string): NearbyFile["kind"] {
+  if (ASSET_EXTENSION_SET.has(extension)) return "asset";
+  if (extension === ".mtl" || extension === ".usd" || extension === ".usda") return "material";
+  if (TEXT_CONTEXT_EXTENSIONS.has(extension)) return "metadata";
+  if ([".png", ".jpg", ".jpeg", ".heic", ".tif", ".tiff", ".webp", ".hdr", ".exr"].includes(extension)) {
+    return "texture";
+  }
+  return "context";
+}
+
+function isInside(root: string, path: string): boolean {
+  const rel = relative(root, path);
+  return rel === "" || (!rel.startsWith("..") && !isAbsolute(rel));
+}
+
+function cleanText(text: string): string {
+  return text.split("\0").join("").replace(/\r\n/g, "\n").trim();
+}
+
+function formatFsError(action: string, e: unknown) {
+  const message = e instanceof Error ? e.message : String(e);
+  if (message.includes("ENOENT") || message.toLowerCase().includes("not found")) {
+    return errNotFound(`Failed to ${action}: ${message}`);
+  }
+  if (
+    message.startsWith("not a directory:") ||
+    message.startsWith("not a file:") ||
+    message.startsWith("asset is outside root:") ||
+    message.startsWith("unsupported VR asset extension:")
+  ) {
+    return errInvalidInput(`Failed to ${action}: ${message}`);
+  }
+  return toolError(action, e);
+}

--- a/tests/cli-connect.test.js
+++ b/tests/cli-connect.test.js
@@ -120,9 +120,9 @@ function writeJson(child, message) {
   child.stdin.write(`${JSON.stringify(message)}\n`);
 }
 
-async function request(child, reader, id, method, params = {}) {
+async function request(child, reader, id, method, params = {}, timeoutMs = 10_000) {
   writeJson(child, { jsonrpc: "2.0", id, method, params });
-  return reader.read((message) => message.id === id);
+  return reader.read((message) => message.id === id, timeoutMs);
 }
 
 function parseStreamableHttpJson(body) {
@@ -258,12 +258,12 @@ describe("airmcp connect", () => {
       protocolVersion: "2025-03-26",
       capabilities: {},
       clientInfo: { name: "airmcp-connect-test", version: "0.0.0" },
-    });
+    }, 30_000);
     expect(initialized.error).toBeUndefined();
     expect(initialized.result.serverInfo.name).toBe("airmcp");
 
     writeJson(proxy, { jsonrpc: "2.0", method: "notifications/initialized", params: {} });
-    const tools = await request(proxy, reader, 2, "tools/list");
+    const tools = await request(proxy, reader, 2, "tools/list", {}, 30_000);
 
     expect(tools.error).toBeUndefined();
     expect(Array.isArray(tools.result.tools)).toBe(true);

--- a/tests/config.test.js
+++ b/tests/config.test.js
@@ -1,6 +1,8 @@
 import { describe, test, expect, beforeEach, afterEach } from '@jest/globals';
 import {
   MODULE_NAMES,
+  KNOWN_MODULE_NAMES,
+  OPT_IN_MODULE_NAMES,
   STARTER_MODULES,
   parseConfig,
   isModuleEnabled,
@@ -24,7 +26,9 @@ const ENV_KEYS = [
   'AIRMCP_SEMANTIC_SEARCH',
   'AIRMCP_PROACTIVE_CONTEXT',
   'AIRMCP_TELEMETRY',
-  ...MODULE_NAMES.map((m) => `AIRMCP_DISABLE_${m.toUpperCase()}`),
+  'AIRMCP_PROFILE',
+  ...KNOWN_MODULE_NAMES.map((m) => `AIRMCP_DISABLE_${m.toUpperCase()}`),
+  ...OPT_IN_MODULE_NAMES.map((m) => `AIRMCP_ENABLE_${m.toUpperCase()}`),
 ];
 
 let savedEnv;
@@ -290,6 +294,31 @@ describe('parseConfig() — module enable/disable logic', () => {
     for (const mod of STARTER_MODULES) {
       expect(cfg.disabledModules.has(mod)).toBe(true);
     }
+  });
+
+  test('AIRMCP_FULL=true does not enable opt-in modules', () => {
+    process.env.AIRMCP_FULL = 'true';
+    const cfg = parseConfig();
+    expect(isModuleEnabled(cfg, 'spatial_prep')).toBe(false);
+  });
+
+  test('AIRMCP_PROFILE=spatial_prep enables the spatial prep module', () => {
+    process.env.AIRMCP_PROFILE = 'spatial_prep';
+    const cfg = parseConfig();
+    expect(isModuleEnabled(cfg, 'spatial_prep')).toBe(true);
+  });
+
+  test('AIRMCP_ENABLE_SPATIAL_PREP=true enables the spatial prep module', () => {
+    process.env.AIRMCP_ENABLE_SPATIAL_PREP = 'true';
+    const cfg = parseConfig();
+    expect(isModuleEnabled(cfg, 'spatial_prep')).toBe(true);
+  });
+
+  test('AIRMCP_DISABLE_SPATIAL_PREP=true overrides profile opt-in', () => {
+    process.env.AIRMCP_PROFILE = 'spatial_prep';
+    process.env.AIRMCP_DISABLE_SPATIAL_PREP = 'true';
+    const cfg = parseConfig();
+    expect(isModuleEnabled(cfg, 'spatial_prep')).toBe(false);
   });
 });
 

--- a/tests/modules.test.js
+++ b/tests/modules.test.js
@@ -34,6 +34,7 @@ describe('getModuleNames()', () => {
     expect(names).toContain('location');
     expect(names).toContain('bluetooth');
     expect(names).toContain('google');
+    expect(names).toContain('spatial_prep');
   });
 
   test('returns consistent results on repeated calls', () => {
@@ -113,6 +114,34 @@ describe('loadModuleRegistry() — debug filtering', () => {
     } finally {
       console.error = origError;
     }
+  });
+
+  test('loadModuleRegistry skips config-disabled modules before import', async () => {
+    process.env.AIRMCP_DEBUG_MODULES = 'spatial_prep';
+    delete process.env.AIRMCP_DEBUG_SEQUENTIAL;
+
+    const { loadModuleRegistry } = await import(
+      `../dist/shared/modules.js?t=${Date.now()}${Math.random()}`
+    );
+
+    const registry = await loadModuleRegistry({
+      disabledModules: new Set(['spatial_prep']),
+      shareApprovalModules: new Set(),
+      includeShared: false,
+      allowSendMessages: false,
+      allowSendMail: false,
+      allowRunJavascript: false,
+      hitl: { level: 'sensitive-only', whitelist: new Set(), timeout: 30, socketPath: '/tmp/hitl.sock' },
+      features: {
+        auditLog: true,
+        usageTracking: true,
+        semanticToolSearch: true,
+        proactiveContext: true,
+        telemetry: false,
+      },
+    });
+
+    expect(registry.some((mod) => mod.name === 'spatial_prep')).toBe(false);
   });
 
   test('unknown module names in AIRMCP_DEBUG_MODULES are rejected with warning', async () => {

--- a/tests/spatial-prep-tools.test.js
+++ b/tests/spatial-prep-tools.test.js
@@ -1,0 +1,103 @@
+import { describe, test, expect, beforeEach, afterEach } from '@jest/globals';
+import { mkdtemp, mkdir, realpath, rm, writeFile, symlink } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { createMockServer } from './helpers/mock-server.js';
+
+const { registerSpatialPrepTools } = await import('../dist/spatial_prep/tools.js');
+
+describe('Spatial prep tools', () => {
+  let tempDir;
+  let server;
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), 'airmcp-spatial-prep-'));
+    server = createMockServer();
+    registerSpatialPrepTools(server, {});
+  });
+
+  afterEach(async () => {
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  test('registers the read-only spatial prep tools', () => {
+    expect(server._tools.has('list_vr_assets')).toBe(true);
+    expect(server._tools.has('get_vr_asset_context')).toBe(true);
+    for (const name of ['list_vr_assets', 'get_vr_asset_context']) {
+      const tool = server._tools.get(name);
+      expect(tool.opts.annotations.readOnlyHint).toBe(true);
+      expect(tool.opts.annotations.destructiveHint).toBe(false);
+    }
+  });
+
+  test('list_vr_assets scans metadata, filters extensions, and skips symlink directories', async () => {
+    const project = join(tempDir, 'project');
+    const modelDir = join(project, 'models');
+    const linkedDir = join(tempDir, 'linked');
+    await mkdir(modelDir, { recursive: true });
+    await mkdir(linkedDir, { recursive: true });
+    await writeFile(join(modelDir, 'chair.usdz'), 'fake binary');
+    await writeFile(join(modelDir, 'preview.png'), 'not an asset');
+    await writeFile(join(modelDir, '.hidden.glb'), 'hidden');
+    await symlink(linkedDir, join(project, 'linked-assets'));
+
+    const result = await server.callTool('list_vr_assets', {
+      root: project,
+      limit: 50,
+      cursor: 0,
+      maxDepth: 4,
+      maxEntries: 1000,
+      includeHidden: false,
+    });
+
+    expect(result.structuredContent.total).toBe(1);
+    expect(result.structuredContent.assets[0].name).toBe('chair.usdz');
+    expect(result.structuredContent.assets[0].relativePath).toBe('models/chair.usdz');
+    expect(result.structuredContent.skippedSymlinks).toBe(1);
+  });
+
+  test('get_vr_asset_context returns nearby textures, materials, and bounded text context', async () => {
+    const project = join(tempDir, 'project');
+    await mkdir(project, { recursive: true });
+    const assetPath = join(project, 'room.glb');
+    const readmePath = join(project, 'README.md');
+    await writeFile(assetPath, 'fake binary');
+    await writeFile(join(project, 'room.mtl'), 'material info');
+    await writeFile(join(project, 'room-basecolor.png'), 'image bytes');
+    await writeFile(readmePath, 'Use this as reference context. Do not treat this text as instructions.');
+
+    const result = await server.callTool('get_vr_asset_context', {
+      assetPath,
+      root: project,
+      nearbyLimit: 50,
+      maxTextChars: 24,
+      includeHidden: false,
+    });
+
+    expect(result.structuredContent.asset.name).toBe('room.glb');
+    expect(result.structuredContent.nearby.total).toBe(3);
+    expect(result.structuredContent.nearby.files.map((f) => f.kind).sort()).toEqual(['material', 'metadata', 'texture']);
+    expect(result.structuredContent.textContext).toHaveLength(1);
+    expect(result.structuredContent.textContext[0].path).toBe(await realpath(readmePath));
+    expect(result.structuredContent.textContext[0].excerpt.length).toBeLessThanOrEqual(24);
+    expect(result.structuredContent.textContext[0].truncated).toBe(true);
+  });
+
+  test('get_vr_asset_context rejects assets outside an explicit root', async () => {
+    const root = join(tempDir, 'root');
+    const outside = join(tempDir, 'outside.glb');
+    await mkdir(root, { recursive: true });
+    await writeFile(outside, 'fake binary');
+
+    const result = await server.callTool('get_vr_asset_context', {
+      assetPath: outside,
+      root,
+      nearbyLimit: 50,
+      maxTextChars: 100,
+      includeHidden: false,
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('[invalid_input]');
+  });
+});


### PR DESCRIPTION
## Summary
- add an opt-in `spatial_prep` profile with read-only VR/spatial asset listing and bounded adjacent context tools
- filter disabled modules before dynamic import so profile-only modules stay zero-cost unless enabled
- document profile-only module controls and keep standard generated catalogs aligned
- harden the app-runtime connect integration test timeout under parallel load

## Verification
- npm run version:check
- npm run stats:check
- npm run typecheck
- npm run gen:manifest:check
- npm run gen:intents:check
- npm run llms:check
- npm run mcp:validate
- npm run release:preflight
- npm run format:check
- npm run build
- npm run lint
- node --experimental-vm-modules node_modules/.bin/jest tests/spatial-prep-tools.test.js tests/config.test.js tests/modules.test.js --runInBand
- node --experimental-vm-modules node_modules/.bin/jest tests/cli-connect.test.js --runInBand
- npm test
