### PR TITLE
test: harden add-on provenance gates

### DIFF
--- a/docs/rfc/0015-modular-install-and-task-harness.md
+++ b/docs/rfc/0015-modular-install-and-task-harness.md
@@ -59,10 +59,10 @@ Keep the npm package as the reliable universal fallback while add-on packages pr
 ## Acceptance gates before publishing physical module-pack packages
 
 - `profiles:check` reports startup/list timings for starter/progressive vs full/full, multiple restricted-pack profiles, strict task-session behavior, and discovery golden queries.
-- `npm run harness:check` proves `compatible`, `strict`, `app-runtime`, and `agent` adapter policy over the real MCP stdio wire.
+- `npm run harness:check` proves `compatible`, `strict`, `app-runtime`, and `agent` adapter policy over the real MCP stdio wire, including the app-owned runtime inference path.
 - `npm run tokens:check` keeps the eager tool-description budget bounded as modules grow.
 - `npm run addons:check` stages every non-core package and fails on missing module/shared files or `pack-*` naming drift.
-- `npm run addons:verify-install` packs the root package plus at least one staged add-on, installs both into a clean project, and boots with `AIRMCP_ADDON_PACKAGE_MODE=external-only`.
+- `npm run addons:verify-install` packs the root package plus at least one staged add-on, first proves a root-only install cannot silently use bundled fallback in `AIRMCP_ADDON_PACKAGE_MODE=external-only`, then installs the add-on artifact and proves the selected pack registers over MCP stdio.
 - `npm pack --dry-run --json` shows package size regressions per release.
 - `list_module_packs` and `profile_status.modulesMissingPacks` remain stable public truth surfaces.
 - At least one real user/workflow needs a smaller install, not only a smaller context window.
@@ -75,8 +75,8 @@ This matrix is the decision surface after an add-on modular-distribution kill-te
 Validation evidence must include:
 
 - `npm run release:preflight` or the equivalent explicit sequence: `build`, `tokens:check`, `profiles:check`, `harness:check`, `addons:check`, `addons:verify-install`, `verify:package`, `npm pack --dry-run --json`, and `build:mcpb`.
-- Add-on package install smoke test in `AIRMCP_ADDON_PACKAGE_MODE=external-only` for at least one non-core pack and one restricted-pack profile.
-- Wire test coverage for `compatible`, `strict`, `app-runtime`, and `agent` harness adapter policies.
+- Add-on package install smoke test in `AIRMCP_ADDON_PACKAGE_MODE=external-only` for at least one non-core pack and one restricted-pack profile, with both root-only negative provenance and installed-add-on positive registration checks.
+- Wire test coverage for explicit `compatible`, `strict`, `app-runtime`, and `agent` harness adapter policies plus app-owned runtime inference.
 - Size and startup/list timing measurements for universal bundled install vs add-on install. Thresholds are owner-ratified release gates, not inferred by the implementation session.
 
 | Validation result       | Decision                                                                                                            | Immediate action                                                                                                                                                                                            | Follow-up goal                                                                                                             | Public status                                                                 |

--- a/scripts/verify-addon-install.mjs
+++ b/scripts/verify-addon-install.mjs
@@ -6,9 +6,10 @@
  * This gate goes one step closer to a user install:
  *   1. build the root package and staged add-ons,
  *   2. npm-pack the root package plus selected add-on packages,
- *   3. install those tarballs into a clean throwaway project,
- *   4. boot the installed root package with AIRMCP_ADDON_PACKAGE_MODE=external-only,
- *   5. prove selected pack modules register over the real MCP stdio wire.
+ *   3. install only the root tarball and prove external-only refuses bundled fallback,
+ *   4. install root plus add-ons into a clean throwaway project,
+ *   5. boot the installed root package with AIRMCP_ADDON_PACKAGE_MODE=external-only,
+ *   6. prove selected pack modules register over the real MCP stdio wire.
  *
  * The default intentionally checks one coherent workflow pack (`productivity`).
  * Use `--all` when you want a broader artifact smoke without changing the
@@ -20,11 +21,12 @@ import { createInterface } from "node:readline";
 import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 import { cleanBootEnv } from "./lib/clean-boot-env.mjs";
 
 const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const TIMEOUT_MS = Number(process.env.ADDON_INSTALL_VERIFY_TIMEOUT_MS ?? 45_000);
+const COMPATIBILITY_OPTIONAL_MODULES = new Set(["health", "intelligence"]);
 
 const PACK_ASSERTIONS = {
   productivity: {
@@ -36,6 +38,8 @@ const PACK_ASSERTIONS = {
     validationTool: "numbers_set_cell",
   },
 };
+
+let profileModulesByName = null;
 
 function fail(message) {
   console.error(`[addons:verify-install] FAIL — ${message}`);
@@ -115,6 +119,57 @@ function parseStructuredResult(callResp) {
 
 function firstText(callResp) {
   return callResp.result?.content?.find?.((c) => c.type === "text")?.text ?? "";
+}
+
+async function getProfileModuleSet(profile) {
+  if (!profileModulesByName) {
+    const profilesUrl = pathToFileURL(join(ROOT, "dist", "shared", "profiles.js")).href;
+    const { PROFILE_MODULES } = await import(profilesUrl);
+    profileModulesByName = PROFILE_MODULES;
+  }
+  return new Set(profileModulesByName[profile] ?? profileModulesByName.full ?? []);
+}
+
+async function getExpectedPackModules(packNames, packManifest, profile) {
+  const profileModules = await getProfileModuleSet(profile);
+  return [
+    ...new Set(
+      packNames.flatMap((packName) => {
+        const pack = packManifest.find((candidate) => candidate.name === packName);
+        return (pack?.modules ?? []).filter((moduleName) => profileModules.has(moduleName));
+      }),
+    ),
+  ];
+}
+
+function getPackPackageName(packManifest, packName) {
+  return packManifest.find((candidate) => candidate.name === packName)?.packageName ?? null;
+}
+
+function getAddonLoadFailureLines(stderr) {
+  return stderr
+    .split(/\r?\n/)
+    .filter(
+      (line) =>
+        line.includes("required add-on package module failed to load") ||
+        line.includes("Cannot find package '@heznpc/airmcp-"),
+    );
+}
+
+function hasAddonLoadFailureForModule(stderr, moduleName) {
+  return getAddonLoadFailureLines(stderr).some(
+    (line) =>
+      line.includes(`"module":"${moduleName}"`) ||
+      line.includes(`"module": "${moduleName}"`) ||
+      line.includes(`/${moduleName}/tools.js`) ||
+      line.includes(`/${moduleName}/prompts.js`),
+  );
+}
+
+function throwWithStderr(message, stderr) {
+  const failures = getAddonLoadFailureLines(stderr);
+  const suffix = failures.length ? `\n--- add-on load failures ---\n${failures.slice(-20).join("\n")}` : "";
+  throw new Error(`${message}${suffix}`);
 }
 
 function startMcp(entry, cwd, env) {
@@ -253,16 +308,20 @@ async function verifyInstalledRuntime({ work, entry, packNames, packManifest }) 
       if (!activePacks.has(packName)) throw new Error(`active packs missing ${packName}: ${JSON.stringify(packs)}`);
     }
 
-    const requiredModules = [
-      ...new Set(
-        packNames.flatMap((packName) => {
-          const pack = packManifest.find((candidate) => candidate.name === packName);
-          return pack?.modules ?? [];
-        }),
-      ),
-    ];
+    const stderr = client.stderr();
+    const hardLoadFailures = getAddonLoadFailureLines(stderr);
+    if (hardLoadFailures.length) {
+      throwWithStderr("installed add-on mode emitted required package load failures", stderr);
+    }
+
+    const requiredModules = await getExpectedPackModules(packNames, packManifest, profile);
+    const compatibilitySkipped = [];
     for (const moduleName of requiredModules) {
       if (!status.modulesEnabled?.includes?.(moduleName)) {
+        if (COMPATIBILITY_OPTIONAL_MODULES.has(moduleName) && !hasAddonLoadFailureForModule(stderr, moduleName)) {
+          compatibilitySkipped.push(moduleName);
+          continue;
+        }
         throw new Error(`module ${moduleName} was not enabled from installed add-on: ${JSON.stringify(status)}`);
       }
     }
@@ -317,6 +376,96 @@ async function verifyInstalledRuntime({ work, entry, packNames, packManifest }) 
       }
     }
 
+    return {
+      tools: tools.length,
+      registered: status.toolsRegistered,
+      modulesEnabled: status.modulesEnabled,
+      compatibilitySkipped,
+    };
+  } catch (error) {
+    const stderr = client.stderr();
+    if (/required add-on package module failed to load|Cannot find package '@heznpc\/airmcp-/.test(stderr)) {
+      throw new Error(
+        `${error instanceof Error ? error.message : String(error)}\n--- stderr ---\n${stderr.slice(-4000)}`,
+      );
+    }
+    throw error;
+  } finally {
+    clearTimeout(watchdog);
+    await client.stop();
+  }
+}
+
+async function verifyBundledFallbackRefused({ work, entry, packNames, packManifest }) {
+  const primaryPack = packNames[0] ?? "productivity";
+  const assertion = PACK_ASSERTIONS[primaryPack] ?? {};
+  const profile = assertion.profile ?? "full";
+  const env = {
+    ...cleanBootEnv(),
+    AIRMCP_PROFILE: profile,
+    AIRMCP_TOOL_EXPOSURE: "profile",
+    AIRMCP_MODULE_PACKS: ["core", ...packNames].join(","),
+    AIRMCP_ADDON_PACKAGE_MODE: "external-only",
+    AIRMCP_FAKE_OS_VERSION: "0",
+    AIRMCP_SEMANTIC_SEARCH: "false",
+    AIRMCP_AUDIT_LOG: "false",
+    AIRMCP_USAGE_TRACKING: "false",
+    AIRMCP_PROACTIVE_CONTEXT: "false",
+  };
+
+  const client = startMcp(entry, work, env);
+  const watchdog = setTimeout(() => {
+    client.stop().finally(() => fail(`root-only fallback verification timed out after ${TIMEOUT_MS}ms`));
+  }, TIMEOUT_MS);
+
+  try {
+    const initResp = await client.request(
+      "initialize",
+      {
+        protocolVersion: "2025-06-18",
+        capabilities: {},
+        clientInfo: { name: "airmcp-addon-negative-verify", version: "0.0.0" },
+      },
+      1,
+    );
+    if (!initResp.result) throw new Error(`initialize failed: ${JSON.stringify(initResp)}`);
+    client.notify("notifications/initialized");
+
+    const listResp = await client.request("tools/list", {}, 2);
+    const tools = listResp.result?.tools;
+    if (!Array.isArray(tools) || tools.length < 10) {
+      throw new Error(`tools/list malformed or too small: ${JSON.stringify(listResp)}`);
+    }
+
+    const statusResp = await client.request("tools/call", { name: "profile_status", arguments: {} }, 3);
+    expectNoWireError(statusResp, "profile_status");
+    const status = parseStructuredResult(statusResp);
+    if (!status) throw new Error(`profile_status was not parseable: ${JSON.stringify(statusResp)}`);
+
+    const stderr = client.stderr();
+    const expectedModules = await getExpectedPackModules(packNames, packManifest, profile);
+    const leakedModules = expectedModules.filter((moduleName) => status.modulesEnabled?.includes?.(moduleName));
+    if (leakedModules.length) {
+      throwWithStderr(
+        `root-only install loaded selected add-on module(s) despite external-only mode: ${leakedModules.join(", ")}`,
+        stderr,
+      );
+    }
+
+    const expectedPackages = [];
+    for (const packName of packNames) {
+      const modules = await getExpectedPackModules([packName], packManifest, profile);
+      const packageName = getPackPackageName(packManifest, packName);
+      if (modules.length && packageName) expectedPackages.push(packageName);
+    }
+    const missingFailurePackages = expectedPackages.filter((packageName) => !stderr.includes(packageName));
+    if (missingFailurePackages.length) {
+      throwWithStderr(
+        `root-only install did not prove missing package failure(s): ${missingFailurePackages.join(", ")}`,
+        stderr,
+      );
+    }
+
     return { tools: tools.length, registered: status.toolsRegistered, modulesEnabled: status.modulesEnabled };
   } catch (error) {
     const stderr = client.stderr();
@@ -334,10 +483,11 @@ async function verifyInstalledRuntime({ work, entry, packNames, packManifest }) 
 
 const { all, packs } = parsePackArgs();
 let work = null;
+let rootOnlyWork = null;
 const tarballs = [];
 
 try {
-  console.log("[1/5] build root dist and stage add-on packages");
+  console.log("[1/6] build root dist and stage add-on packages");
   sh("npm", ["run", "build"], { cwd: ROOT });
   sh(process.execPath, ["scripts/build-addon-packages.mjs", "--check"], { cwd: ROOT });
 
@@ -347,7 +497,7 @@ try {
   const missing = selectedPacks.filter((packName) => !stagedManifest.packages.some((pack) => pack.name === packName));
   if (missing.length) fail(`unknown staged add-on pack(s): ${missing.join(", ")}`);
 
-  console.log(`[2/5] npm pack root and add-on artifacts (${selectedPacks.join(", ")})`);
+  console.log(`[2/6] npm pack root and add-on artifacts (${selectedPacks.join(", ")})`);
   const rootPack = npmPack(ROOT);
   tarballs.push(rootPack.tgz);
   const addonPacks = selectedPacks.map((packName) => {
@@ -358,8 +508,21 @@ try {
     return { ...artifact, packName, packageName: pack.packageName };
   });
 
+  rootOnlyWork = mkdtempSync(join(tmpdir(), "airmcp-addon-root-only-"));
+  console.log(`[3/6] prove root-only install refuses bundled fallback ${rootOnlyWork}`);
+  sh("npm", ["init", "-y"], { cwd: rootOnlyWork });
+  sh("npm", ["install", "--no-audit", "--no-fund", "--no-save", rootPack.tgz], { cwd: rootOnlyWork });
+  const rootOnlyEntry = join(rootOnlyWork, "node_modules", "airmcp", "dist", "index.js");
+  if (!existsSync(rootOnlyEntry)) fail(`installed root-only package is missing ${rootOnlyEntry}`);
+  await verifyBundledFallbackRefused({
+    work: rootOnlyWork,
+    entry: rootOnlyEntry,
+    packNames: selectedPacks,
+    packManifest: stagedManifest.packages,
+  });
+
   work = mkdtempSync(join(tmpdir(), "airmcp-addon-install-"));
-  console.log(`[3/5] install tarballs into clean project ${work}`);
+  console.log(`[4/6] install tarballs into clean project ${work}`);
   sh("npm", ["init", "-y"], { cwd: work });
   sh("npm", ["install", "--no-audit", "--no-fund", "--no-save", rootPack.tgz, ...addonPacks.map((pack) => pack.tgz)], {
     cwd: work,
@@ -368,7 +531,7 @@ try {
   const entry = join(work, "node_modules", "airmcp", "dist", "index.js");
   if (!existsSync(entry)) fail(`installed root package is missing ${entry}`);
 
-  console.log("[4/5] boot installed root with AIRMCP_ADDON_PACKAGE_MODE=external-only");
+  console.log("[5/6] boot installed root with AIRMCP_ADDON_PACKAGE_MODE=external-only");
   const result = await verifyInstalledRuntime({
     work,
     entry,
@@ -376,7 +539,7 @@ try {
     packManifest: stagedManifest.packages,
   });
 
-  console.log("[5/5] artifact summary");
+  console.log("[6/6] artifact summary");
   const rows = [
     { name: "airmcp", filename: rootPack.filename, packed: rootPack.packageSize, unpacked: rootPack.unpackedSize },
     ...addonPacks.map((pack) => ({
@@ -392,9 +555,13 @@ try {
   console.log(
     `ok: installed add-on pack(s) ${selectedPacks.join(", ")} registered ${result.registered} tools; tools/list exposed ${result.tools}`,
   );
+  if (result.compatibilitySkipped.length) {
+    console.log(`ok: compatibility-gated module(s) skipped on this host: ${result.compatibilitySkipped.join(", ")}`);
+  }
 } catch (error) {
   fail(error instanceof Error ? error.message : String(error));
 } finally {
   for (const tgz of tarballs) rmSync(tgz, { force: true });
   if (work) rmSync(work, { recursive: true, force: true });
+  if (rootOnlyWork) rmSync(rootOnlyWork, { recursive: true, force: true });
 }

--- a/scripts/verify-harness-adapters.mjs
+++ b/scripts/verify-harness-adapters.mjs
@@ -22,10 +22,17 @@ const ENTRY = join(ROOT, "dist", "index.js");
 const TIMEOUT_MS = Number(process.env.HARNESS_VERIFY_TIMEOUT_MS ?? 30_000);
 
 const CASES = [
-  { adapter: "compatible", hiddenRunRequiresSession: false },
-  { adapter: "strict", hiddenRunRequiresSession: true },
-  { adapter: "app-runtime", hiddenRunRequiresSession: true },
-  { adapter: "agent", hiddenRunRequiresSession: true },
+  { name: "compatible", adapter: "compatible", expectedAdapter: "compatible", hiddenRunRequiresSession: false },
+  { name: "strict", adapter: "strict", expectedAdapter: "strict", hiddenRunRequiresSession: true },
+  { name: "app-runtime", adapter: "app-runtime", expectedAdapter: "app-runtime", hiddenRunRequiresSession: true },
+  {
+    name: "app-runtime-inferred",
+    adapter: null,
+    expectedAdapter: "app-runtime",
+    hiddenRunRequiresSession: true,
+    env: { AIRMCP_APP_OWNED_RUNTIME: "true" },
+  },
+  { name: "agent", adapter: "agent", expectedAdapter: "agent", hiddenRunRequiresSession: true },
 ];
 
 if (!existsSync(ENTRY)) {
@@ -49,19 +56,20 @@ function firstText(callResp) {
   return callResp.result?.content?.find?.((c) => c.type === "text")?.text ?? "";
 }
 
-function startMcp(adapter) {
+function startMcp(testCase) {
   const env = {
     ...cleanBootEnv(),
     AIRMCP_PROFILE: "starter",
     AIRMCP_TOOL_EXPOSURE: "progressive",
     AIRMCP_REQUIRE_TOOL_SESSION: "false",
-    AIRMCP_HARNESS_ADAPTER: adapter,
     AIRMCP_FAKE_OS_VERSION: "0",
     AIRMCP_SEMANTIC_SEARCH: "false",
     AIRMCP_AUDIT_LOG: "false",
     AIRMCP_USAGE_TRACKING: "false",
     AIRMCP_PROACTIVE_CONTEXT: "false",
+    ...(testCase.env ?? {}),
   };
+  if (testCase.adapter) env.AIRMCP_HARNESS_ADAPTER = testCase.adapter;
   const proc = spawn("node", [ENTRY], { cwd: ROOT, env, stdio: ["pipe", "pipe", "pipe"] });
   const rl = createInterface({ input: proc.stdout });
   const pending = new Map();
@@ -142,10 +150,10 @@ function expectNoWireError(resp, label) {
 }
 
 async function verifyCase(testCase) {
-  const client = startMcp(testCase.adapter);
+  const client = startMcp(testCase);
   const watchdog = setTimeout(() => {
     client.stop().finally(() => {
-      console.error(`[harness-adapters] FAIL ${testCase.adapter}: timeout after ${TIMEOUT_MS}ms`);
+      console.error(`[harness-adapters] FAIL ${testCase.name}: timeout after ${TIMEOUT_MS}ms`);
       process.exit(1);
     });
   }, TIMEOUT_MS);
@@ -172,8 +180,8 @@ async function verifyCase(testCase) {
     const statusResp = await client.request("tools/call", { name: "profile_status", arguments: {} }, 3);
     expectNoWireError(statusResp, "profile_status");
     const status = parseStructuredResult(statusResp);
-    if (status?.harnessAdapter !== testCase.adapter) {
-      throw new Error(`profile_status.harnessAdapter=${status?.harnessAdapter}, expected ${testCase.adapter}`);
+    if (status?.harnessAdapter !== testCase.expectedAdapter) {
+      throw new Error(`profile_status.harnessAdapter=${status?.harnessAdapter}, expected ${testCase.expectedAdapter}`);
     }
 
     const discoverResp = await client.request(
@@ -219,7 +227,7 @@ async function verifyCase(testCase) {
 
     const sessionResp = await client.request(
       "tools/call",
-      { name: "start_tool_session", arguments: { tools: ["create_note"], label: testCase.adapter, ttlSeconds: 60 } },
+      { name: "start_tool_session", arguments: { tools: ["create_note"], label: testCase.name, ttlSeconds: 60 } },
       7,
     );
     expectNoWireError(sessionResp, "start_tool_session");
@@ -283,12 +291,12 @@ for (const testCase of CASES) {
   try {
     const result = await verifyCase(testCase);
     console.error(
-      `[harness-adapters] OK ${testCase.adapter}: ${result.tools} exposed / ${result.registered} registered / hiddenRequiresSession=${testCase.hiddenRunRequiresSession}`,
+      `[harness-adapters] OK ${testCase.name}: ${result.tools} exposed / ${result.registered} registered / adapter=${testCase.expectedAdapter} / hiddenRequiresSession=${testCase.hiddenRunRequiresSession}`,
     );
   } catch (error) {
     failed = true;
     console.error(
-      `[harness-adapters] FAIL ${testCase.adapter}: ${error instanceof Error ? error.message : String(error)}`,
+      `[harness-adapters] FAIL ${testCase.name}: ${error instanceof Error ? error.message : String(error)}`,
     );
   }
 }


### PR DESCRIPTION
## Summary
- add root-only negative provenance check to addons:verify-install so external-only cannot silently pass through bundled fallback
- make all-pack add-on smoke profile-aware and tolerate host capability skips only when import provenance is clean
- cover app-owned runtime adapter inference in harness:check

## Validation
- npm run build && npm run harness:check
- npm run addons:verify-install
- npm run addons:verify-install -- --all
- npm run typecheck
- npm run lint
- npm run release:preflight
- npm run version:check
- npm run stats:check
- npm test