### PR TITLE
build: dedupe add-on shared runtime

### DIFF
--- a/docs/rfc/0015-modular-install-and-task-harness.md
+++ b/docs/rfc/0015-modular-install-and-task-harness.md
@@ -39,7 +39,7 @@ The second shipped slice is the module-pack contract:
 The third shipped slice is physical package staging:
 
 - `scripts/build-addon-packages.mjs` stages tarball-ready package directories under `build/addons`,
-- each staged package includes only its pack modules plus the shared runtime files those modules import,
+- each staged package includes only its pack modules; shared runtime imports are rewritten to the peer root `airmcp` package instead of copied into every add-on,
 - `AIRMCP_ADDON_PACKAGE_MODE=prefer-installed` tries an installed add-on package before bundled fallback,
 - `AIRMCP_ADDON_PACKAGE_MODE=external-only` turns missing add-ons into module-load failures outside `core`,
 - `npm run addons:check` is wired into CI and `release:preflight`.

--- a/package.json
+++ b/package.json
@@ -58,6 +58,11 @@
   "bin": {
     "airmcp": "dist/index.js"
   },
+  "exports": {
+    ".": "./dist/index.js",
+    "./package.json": "./package.json",
+    "./dist/*": "./dist/*"
+  },
   "files": [
     "dist"
   ],

--- a/scripts/build-addon-packages.mjs
+++ b/scripts/build-addon-packages.mjs
@@ -8,7 +8,17 @@
  * to publish as separate npm packages.
  */
 
-import { cpSync, existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import {
+  cpSync,
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 
@@ -43,6 +53,60 @@ function copyRequiredDir(from, to, label) {
   cpSync(from, to, { recursive: true });
 }
 
+function rewriteSharedRuntimeImports(file) {
+  const before = readFileSync(file, "utf8");
+  const after = before
+    .replaceAll('from "../shared/', 'from "airmcp/dist/shared/')
+    .replaceAll("from '../shared/", "from 'airmcp/dist/shared/")
+    .replaceAll('import("../shared/', 'import("airmcp/dist/shared/')
+    .replaceAll("import('../shared/", "import('airmcp/dist/shared/");
+  if (after !== before) writeFileSync(file, after);
+}
+
+function rewriteSharedRuntimeImportsInDir(dir) {
+  for (const entry of readdirSync(dir)) {
+    const path = join(dir, entry);
+    const stat = lstatSync(path);
+    if (stat.isDirectory()) {
+      rewriteSharedRuntimeImportsInDir(path);
+    } else if (entry.endsWith(".js")) {
+      rewriteSharedRuntimeImports(path);
+    }
+  }
+}
+
+function assertNoBundledSharedRuntime(packageRoot, pack) {
+  const sharedDir = join(packageRoot, "dist", "shared");
+  if (existsSync(sharedDir)) fail(`${pack.name} add-on must not bundle dist/shared`);
+}
+
+function assertNoRelativeSharedImports(packageRoot, pack) {
+  const offenders = [];
+  function scan(dir) {
+    for (const entry of readdirSync(dir)) {
+      const path = join(dir, entry);
+      const stat = lstatSync(path);
+      if (stat.isDirectory()) {
+        scan(path);
+      } else if (entry.endsWith(".js") && readFileSync(path, "utf8").includes("../shared/")) {
+        offenders.push(path.replace(`${packageRoot}/`, ""));
+      }
+    }
+  }
+  scan(join(packageRoot, "dist"));
+  if (offenders.length) {
+    fail(`${pack.name} add-on still has relative shared imports: ${offenders.join(", ")}`);
+  }
+}
+
+function installRootPackageSymlinkForVerification(packageRoot) {
+  const nodeModules = join(packageRoot, "node_modules");
+  const link = join(nodeModules, "airmcp");
+  mkdirSync(nodeModules, { recursive: true });
+  rmSync(link, { recursive: true, force: true });
+  symlinkSync(ROOT, link, "dir");
+}
+
 function makePackageJson(rootPkg, pack) {
   if (pack.packageName.includes("pack-") || pack.packageName.includes("-pack")) {
     fail(`${pack.name} package name must not contain pack-* wording: ${pack.packageName}`);
@@ -68,6 +132,7 @@ function makePackageJson(rootPkg, pack) {
     airmcp: {
       modulePack: pack.name,
       modules: pack.modules,
+      sharedRuntime: "peer-root",
     },
     exports: {
       ".": "./dist/index.js",
@@ -90,6 +155,9 @@ function writeAddonIndex(packageDir, pack) {
 }
 
 async function verifyAddonEntrypoints(packageRoot, pack) {
+  installRootPackageSymlinkForVerification(packageRoot);
+  assertNoBundledSharedRuntime(packageRoot, pack);
+  assertNoRelativeSharedImports(packageRoot, pack);
   for (const moduleName of pack.modules) {
     const file = join(packageRoot, "dist", moduleName, "tools.js");
     try {
@@ -113,10 +181,14 @@ async function main() {
   for (const pack of addonPacks) {
     const packageRoot = join(BUILD_DIR, packageDirName(pack.packageName), "package");
     mkdirSync(join(packageRoot, "dist"), { recursive: true });
-    copyRequiredDir(join(ROOT, "dist", "shared"), join(packageRoot, "dist", "shared"), "shared runtime");
 
     for (const moduleName of pack.modules) {
-      copyRequiredDir(join(ROOT, "dist", moduleName), join(packageRoot, "dist", moduleName), `${pack.name}/${moduleName}`);
+      copyRequiredDir(
+        join(ROOT, "dist", moduleName),
+        join(packageRoot, "dist", moduleName),
+        `${pack.name}/${moduleName}`,
+      );
+      rewriteSharedRuntimeImportsInDir(join(packageRoot, "dist", moduleName));
     }
 
     writeAddonIndex(packageRoot, pack);
@@ -129,10 +201,14 @@ async function main() {
       packageName: pack.packageName,
       modules: pack.modules,
       packageDir: packageRoot.replace(`${ROOT}/`, ""),
+      sharedRuntime: "peer-root",
     });
   }
 
-  writeFileSync(join(BUILD_DIR, "manifest.json"), JSON.stringify({ version: rootPkg.version, packages: manifest }, null, 2) + "\n");
+  writeFileSync(
+    join(BUILD_DIR, "manifest.json"),
+    JSON.stringify({ version: rootPkg.version, packages: manifest }, null, 2) + "\n",
+  );
   console.log(`ok: staged ${manifest.length} add-on packages in ${BUILD_DIR}`);
   if (CHECK) console.log("ok: add-on package boundary check passed");
 }

--- a/tests/addon-packages.test.js
+++ b/tests/addon-packages.test.js
@@ -22,7 +22,13 @@ describe("add-on package staging", () => {
     expect(packageJson.name).toBe("@heznpc/airmcp-productivity");
     expect(packageJson.name).not.toContain("pack-");
     expect(packageJson.airmcp.modules).toEqual(["pages", "numbers", "keynote"]);
+    expect(packageJson.airmcp.sharedRuntime).toBe("peer-root");
+    expect(productivity.sharedRuntime).toBe("peer-root");
     expect(existsSync(join(packageRoot, "dist", "pages", "tools.js"))).toBe(true);
-    expect(existsSync(join(packageRoot, "dist", "shared", "mcp.js"))).toBe(true);
+    expect(existsSync(join(packageRoot, "dist", "shared", "mcp.js"))).toBe(false);
+
+    const pagesTools = readFileSync(join(packageRoot, "dist", "pages", "tools.js"), "utf8");
+    expect(pagesTools).toContain('from "airmcp/dist/shared/');
+    expect(pagesTools).not.toContain("../shared/");
   });
 });


### PR DESCRIPTION
## Summary
- stop copying `dist/shared` into every staged add-on package
- rewrite add-on module imports from `../shared/*` to the peer root package (`airmcp/dist/shared/*`)
- expose root package `./dist/*` subpaths so installed add-ons can resolve the shared runtime
- update the add-on staging test and RFC wording for the peer-root shared runtime contract

## Local evidence
- productivity add-on packed size: ~59KB before earlier staging, now 5.5KB
- `npm run addons:measure-split`: productivity scenario now `size-win-startup-neutral`, packed saved ~51.6KB, installed package dirs saved ~234.3KB, same 116 exposed/registered tools
- `npm run addons:measure-split -- --all --output build/addons/split-measurement-all.json`: all packs no longer grow by ~1.91MB; remaining overhead is ~57.8KB installed package dirs

## Validation
- npm run build && npm run addons:check
- npm run addons:verify-install
- npm run addons:verify-install -- --all
- npm run addons:measure-split
- npm run addons:measure-split -- --all --output build/addons/split-measurement-all.json
- node --check scripts/build-addon-packages.mjs && node --check scripts/measure-addon-split.mjs
- npm run typecheck
- npm run version:check
- npm run stats:check
- npm run release:preflight
- npm run addons:measure-split -- --no-build --require-size-win
- npm run lint
- npm test -- --runTestsByPath tests/addon-packages.test.js
- npm test