### PR TITLE
feat: add on-demand module add-ons

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,8 +116,8 @@ jobs:
         run: npm run addons:check
 
       - name: Verify installed add-on package smoke
-        timeout-minutes: 5
-        run: npm run addons:verify-install
+        timeout-minutes: 10
+        run: npm run addons:verify-install -- --all
 
       # Forcing function on the SHIPPED artifact (RFC 0014 root-cause). The
       # step above boots the repo's dist/; this packs the real tarball,

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 **Part of:** Human-Controlled AI Systems · Research Program 1 (anchor — Apple-side agent governance).
 
-**Requires**: macOS for the server. The recommended desktop path is the AirMCP menubar app: it owns the loopback HTTP runtime, while Claude/Codex/Cursor attach to it as clients. The direct CLI server (`npx -y airmcp`) still works for development and boots the **starter** profile with progressive `tools/list` exposure: a small front door (`profile_status`, `list_profiles`, `list_module_packs`, `discover_tools`, `describe_tool`, `run_tool`, and core starter tools) instead of every loaded tool. Use `AIRMCP_PROFILE=communications-safe|productivity|full` to choose a module profile, `AIRMCP_TOOL_EXPOSURE=profile|full` to widen `tools/list`, `npx airmcp modules enable productivity` or `AIRMCP_MODULE_PACKS=core,productivity` to activate only selected DLC-like packs, or `--full` / `AIRMCP_FULL=true` to enable all 29 modules / 294 tools. New app/CLI-created configs require task sessions for hidden `run_tool` dispatch; no-config direct stdio keeps the compatible path unless `AIRMCP_REQUIRE_TOOL_SESSION=true` is set. Most tools are pure JXA and work on macOS 14+ with no extra setup. **Swift-backed tools** — HealthKit, on-device semantic search, recurring events/reminders, photo import/delete/classify, Vision, Speech, Location, Bluetooth, and Apple Intelligence previews — need the **optional Swift bridge** — build it from a source checkout with `npm run swift-build` (it ships in **none** of the distribution channels — the npm tarball, the `.mcpb` bundle, or the menubar `.app` — so build it from source as above); without it those tools return a clear "Swift bridge not found" error and everything else keeps working. FoundationModels-backed Apple Intelligence and `AskAirMCPIntent` additionally require macOS 26+ on Apple Silicon and an opt-in Swift build with `AIRMCP_ENABLE_FOUNDATION_MODELS`.
+**Requires**: macOS for the server. The recommended desktop path is the AirMCP menubar app: it owns the loopback HTTP runtime, while Claude/Codex/Cursor attach to it as clients. The direct CLI server (`npx -y airmcp`) still works for development and boots the **starter** profile with progressive `tools/list` exposure: a small front door (`profile_status`, `list_profiles`, `list_module_packs`, `discover_tools`, `describe_tool`, `run_tool`, and core starter tools) instead of every loaded tool. Use `AIRMCP_PROFILE=communications-safe|productivity|full` to choose a module profile, `AIRMCP_TOOL_EXPOSURE=profile|full` to widen `tools/list`, `npx airmcp modules enable productivity` or `AIRMCP_MODULE_PACKS=core,productivity` to activate only selected DLC-like packs, or `--full` / `AIRMCP_FULL=true` to request all 29 modules / 294 tools when the matching add-ons are installed. New app/CLI-created configs require task sessions for hidden `run_tool` dispatch; no-config direct stdio keeps the compatible path unless `AIRMCP_REQUIRE_TOOL_SESSION=true` is set. Most tools are pure JXA and work on macOS 14+ with no extra setup. **Swift-backed tools** — HealthKit, on-device semantic search, recurring events/reminders, photo import/delete/classify, Vision, Speech, Location, Bluetooth, and Apple Intelligence previews — need the **optional Swift bridge** — build it from a source checkout with `npm run swift-build` (it ships in **none** of the distribution channels — the npm tarball, the `.mcpb` bundle, or the menubar `.app` — so build it from source as above); without it those tools return a clear "Swift bridge not found" error and everything else keeps working. FoundationModels-backed Apple Intelligence and `AskAirMCPIntent` additionally require macOS 26+ on Apple Silicon and an opt-in Swift build with `AIRMCP_ENABLE_FOUNDATION_MODELS`.
 
 > Available in multiple languages at the [project landing page](https://heznpc.github.io/AirMCP/).
 
@@ -93,10 +93,12 @@ Checks Node.js version, config files, MCP client setup, macOS permissions, and m
 ```bash
 npx airmcp modules
 npx airmcp modules enable productivity,communications
+npx airmcp modules enable productivity --install
+npx airmcp modules uninstall media
 npx airmcp modules doctor
 ```
 
-This edits the runtime `modulePacks` activation set. `npm run addons:build` stages tarball-ready physical add-on packages from `dist`, `npm run addons:verify-install` proves installed add-ons are load-bearing in `external-only` mode, and `npm run addons:measure-split` records the slim-root size/startup delta before any add-on publish decision. Add-on package names intentionally omit `pack-*` naming, for example `@heznpc/airmcp-productivity`.
+This edits the runtime `modulePacks` activation set. `--install` installs the matching companion npm add-on into `~/.airmcp/addons` (override with `AIRMCP_ADDON_INSTALL_PREFIX`) and then activates the pack; `uninstall` disables the pack and removes that companion package. The npm and MCPB release artifacts ship as a slim root, while `npm run addons:build` stages tarball-ready physical add-on packages from `dist`, `npm run addons:verify-install` proves installed add-ons are load-bearing in `external-only` mode, and `npm run addons:measure-split` records the slim-root size/startup delta against the universal local build. Add-on package names intentionally omit `pack-*` naming, for example `@heznpc/airmcp-productivity`.
 
 ### Workflow Catalog
 
@@ -875,7 +877,7 @@ By default, new installations start with 7 starter modules (Notes, Reminders, Ca
 # Re-run the setup wizard to change modules
 npx airmcp init
 
-# Or enable all modules at once
+# Or request every installed module at once
 npx airmcp --full
 ```
 
@@ -896,7 +898,7 @@ Or edit `~/.config/airmcp/config.json` directly:
 | `npx airmcp modules`   | Inspect or edit module add-ons    |
 | `npx airmcp`           | Start MCP server (stdio, default) |
 | `npx airmcp --version` | Print version and exit            |
-| `npx airmcp --full`    | Start with all 29 modules enabled |
+| `npx airmcp --full`    | Request every installed module |
 | `npx airmcp --http`    | Start as HTTP server (port 3847)  |
 | `npx airmcp connect`   | Proxy stdio clients to AirMCP.app |
 | `npx airmcp connect-clients` | Repair installed client configs for AirMCP.app |
@@ -915,6 +917,7 @@ Or edit `~/.config/airmcp/config.json` directly:
 | `AIRMCP_TOOL_EXPOSURE`       | profile-dependent            | `progressive` exposes a small front door, `profile` exposes the selected profile, `full` exposes every loaded tool |
 | `AIRMCP_MODULE_PACKS`        | all packs                    | Activate selected module add-ons, e.g. `core,productivity` |
 | `AIRMCP_ADDON_PACKAGE_MODE`  | `prefer-installed`           | Module import mode: `prefer-installed`, `bundled`, or `external-only` |
+| `AIRMCP_ADDON_INSTALL_PREFIX` | `~/.airmcp/addons`          | Override where `airmcp modules --install` places companion add-on packages |
 | `AIRMCP_HARNESS_ADAPTER`     | inferred                     | Task harness adapter: `compatible`, `strict`, `app-runtime`, or `agent` |
 | `AIRMCP_REQUIRE_TOOL_SESSION` | config-dependent            | Require task sessions before hidden `run_tool` dispatch |
 | `AIRMCP_ENABLE_SPATIAL_PREP` | `false`                      | Enable the experimental read-only spatial asset prep tools    |

--- a/app/Sources/AirMCPApp/AddonManager.swift
+++ b/app/Sources/AirMCPApp/AddonManager.swift
@@ -1,0 +1,106 @@
+import Foundation
+
+@MainActor
+@Observable
+final class AddonManager {
+    enum State: Equatable {
+        case idle
+        case running(String)
+        case done(String)
+        case failed(String)
+    }
+
+    private enum CommandResult: Sendable {
+        case success(String)
+        case failure(String)
+    }
+
+    var state: State = .idle
+
+    var isRunning: Bool {
+        if case .running = state { return true }
+        return false
+    }
+
+    var statusLabel: String? {
+        switch state {
+        case .idle:
+            return nil
+        case .running(let pack):
+            return L("addons.installing", pack)
+        case .done(let message):
+            return message
+        case .failed(let message):
+            return L("addons.failed", message)
+        }
+    }
+
+    func install(pack: String, configManager: ConfigManager) {
+        run(action: "enable", pack: pack, flag: "--install", configManager: configManager)
+    }
+
+    func uninstall(pack: String, configManager: ConfigManager) {
+        run(action: "uninstall", pack: pack, flag: nil, configManager: configManager)
+    }
+
+    func reset() {
+        state = .idle
+    }
+
+    private func run(action: String, pack: String, flag: String?, configManager: ConfigManager) {
+        guard !isRunning else { return }
+        state = .running(pack)
+
+        var args = ["modules", action, pack]
+        if let flag {
+            args.append(flag)
+        }
+
+        Task {
+            let result = await Self.runAirMcp(args)
+            switch result {
+            case .success:
+                configManager.load()
+                state = .done(L("addons.doneRestart"))
+            case .failure(let message):
+                state = .failed(message)
+            }
+        }
+    }
+
+    private nonisolated static func runAirMcp(_ args: [String]) async -> CommandResult {
+        await withCheckedContinuation { continuation in
+            DispatchQueue.global().async {
+                guard let npxPath = NodeEnvironment.findExecutable(named: "npx") else {
+                    continuation.resume(returning: .failure("Node.js not found. Install Node.js first."))
+                    return
+                }
+
+                let process = Process()
+                process.executableURL = URL(fileURLWithPath: npxPath)
+                process.arguments = ["-y", AirMcpConstants.npmPackageSpecifier] + args
+                process.environment = NodeEnvironment.buildEnv()
+
+                let stdout = Pipe()
+                let stderr = Pipe()
+                process.standardOutput = stdout
+                process.standardError = stderr
+
+                do {
+                    try process.run()
+                    process.waitUntilExit()
+                    let out = String(data: stdout.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
+                    let err = String(data: stderr.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
+                    if process.terminationStatus == 0 {
+                        continuation.resume(returning: .success(out))
+                    } else {
+                        let message = err.trimmingCharacters(in: .whitespacesAndNewlines)
+                        continuation.resume(returning: .failure(message.isEmpty ? out : message))
+                    }
+                } catch {
+                    continuation.resume(returning: .failure(error.localizedDescription))
+                }
+            }
+        }
+    }
+}

--- a/app/Sources/AirMCPApp/AirMCPApp.swift
+++ b/app/Sources/AirMCPApp/AirMCPApp.swift
@@ -12,6 +12,7 @@ struct AirMCPApp: App {
     @State private var hitlManager = HitlManager()
     @State private var logManager = LogManager()
     @State private var updateManager = UpdateManager()
+    @State private var addonManager = AddonManager()
     @State private var hitlInitialized = false
     @State private var appInitialized = false
 
@@ -65,7 +66,8 @@ struct AirMCPApp: App {
                 setupManager: setupManager,
                 hitlManager: hitlManager,
                 logManager: logManager,
-                updateManager: updateManager
+                updateManager: updateManager,
+                addonManager: addonManager
             )
             .onAppear {
                 initializeRuntimeIfNeeded()

--- a/app/Sources/AirMCPApp/ConfigManager.swift
+++ b/app/Sources/AirMCPApp/ConfigManager.swift
@@ -11,6 +11,19 @@ enum HitlLevel: String, Codable, Sendable, CaseIterable {
 @MainActor
 @Observable
 final class ConfigManager {
+    private static let allModulePacks = [
+        "core",
+        "communications",
+        "productivity",
+        "browser",
+        "media",
+        "visual",
+        "location",
+        "device",
+        "intelligence",
+        "google-workspace",
+        "spatial",
+    ]
 
     struct HitlConfig: Codable, Sendable {
         var level: HitlLevel
@@ -150,6 +163,35 @@ final class ConfigManager {
             config.disabledModules = newValue
             save()
         }
+    }
+
+    var modulePacks: [String] {
+        get { config.modulePacks ?? Self.allModulePacks }
+        set {
+            var seen = Set<String>()
+            var next = newValue.filter { pack in
+                guard Self.allModulePacks.contains(pack), !seen.contains(pack) else { return false }
+                seen.insert(pack)
+                return true
+            }
+            if !next.contains("core") {
+                next.insert("core", at: 0)
+            }
+            config.modulePacks = next
+            save()
+        }
+    }
+
+    func setModulePack(_ pack: String, enabled: Bool) {
+        var packs = modulePacks
+        if enabled {
+            if !packs.contains(pack) {
+                packs.append(pack)
+            }
+        } else if pack != "core" {
+            packs.removeAll { $0 == pack }
+        }
+        modulePacks = packs
     }
 
     var shareApprovalModules: [String] {

--- a/app/Sources/AirMCPApp/Resources/en.lproj/Localizable.strings
+++ b/app/Sources/AirMCPApp/Resources/en.lproj/Localizable.strings
@@ -8,6 +8,7 @@
 
 /* Menu - Sections */
 "menu.modules" = "Modules";
+"addons.menu" = "Module Add-ons";
 "menu.workflows" = "Workflows";
 "menu.settings" = "Settings";
 "menu.viewLogs" = "View Logs (%d)";
@@ -165,7 +166,40 @@
 "module.memory.desc" = "Durable facts, entities, episodes — ai_agent's recall";
 "module.audit" = "Audit";
 "module.audit.desc" = "Query the on-device log of every tool call";
+"module.spatial_prep" = "Spatial Prep";
+"module.spatial_prep.desc" = "Read-only VR/spatial asset context";
 "module.requiresMacOS" = "requires macOS %d+";
+
+/* Module Add-ons */
+"addons.active" = "Active";
+"addons.install" = "Install and Activate";
+"addons.uninstall" = "Uninstall";
+"addons.copyInstallCommand" = "Copy Install Command";
+"addons.installing" = "Installing %@...";
+"addons.doneRestart" = "Add-on updated. Restart server to apply.";
+"addons.failed" = "Add-on failed: %@";
+"addon.core" = "Core Workspace";
+"addon.core.desc" = "Starter workspace tools and audit visibility.";
+"addon.communications" = "Communications";
+"addon.communications.desc" = "Contacts, Mail, and Messages.";
+"addon.productivity" = "Productivity";
+"addon.productivity.desc" = "Pages, Numbers, and Keynote.";
+"addon.browser" = "Browser";
+"addon.browser.desc" = "Safari tabs, bookmarks, and page capture.";
+"addon.media" = "Media";
+"addon.media.desc" = "Music, TV, Podcasts, and Speech.";
+"addon.visual" = "Visual";
+"addon.visual.desc" = "Photos, Screen, and UI Automation.";
+"addon.location" = "Location";
+"addon.location.desc" = "Maps and current location.";
+"addon.device" = "Device";
+"addon.device.desc" = "Bluetooth and HealthKit-oriented device tools.";
+"addon.intelligence" = "Intelligence";
+"addon.intelligence.desc" = "Apple Intelligence and context memory.";
+"addon.google" = "Google Workspace";
+"addon.google.desc" = "Google Workspace integration.";
+"addon.spatial" = "Spatial";
+"addon.spatial.desc" = "VR/spatial asset and project context preparation.";
 
 /* Onboarding */
 "onboarding.back" = "Back";

--- a/app/Sources/AirMCPApp/Resources/ko.lproj/Localizable.strings
+++ b/app/Sources/AirMCPApp/Resources/ko.lproj/Localizable.strings
@@ -8,6 +8,7 @@
 
 /* Menu - Sections */
 "menu.modules" = "모듈";
+"addons.menu" = "모듈 애드온";
 "menu.workflows" = "워크플로우";
 "menu.settings" = "설정";
 "menu.viewLogs" = "로그 보기 (%d)";
@@ -165,7 +166,40 @@
 "module.memory.desc" = "사실·엔티티·에피소드를 저장해 ai_agent가 기억하도록";
 "module.audit" = "감사 로그";
 "module.audit.desc" = "AirMCP가 실행한 모든 툴 호출을 조회";
+"module.spatial_prep" = "Spatial 준비";
+"module.spatial_prep.desc" = "VR/spatial asset 맥락을 읽기 전용으로 준비";
 "module.requiresMacOS" = "macOS %d 이상 필요";
+
+/* Module Add-ons */
+"addons.active" = "활성화";
+"addons.install" = "설치 및 활성화";
+"addons.uninstall" = "제거";
+"addons.copyInstallCommand" = "설치 명령 복사";
+"addons.installing" = "%@ 설치 중...";
+"addons.doneRestart" = "애드온이 업데이트되었습니다. 서버를 재시작하면 반영됩니다.";
+"addons.failed" = "애드온 실패: %@";
+"addon.core" = "Core Workspace";
+"addon.core.desc" = "starter workspace 도구와 감사 로그.";
+"addon.communications" = "Communications";
+"addon.communications.desc" = "연락처, 메일, 메시지.";
+"addon.productivity" = "Productivity";
+"addon.productivity.desc" = "Pages, Numbers, Keynote.";
+"addon.browser" = "Browser";
+"addon.browser.desc" = "Safari 탭, 북마크, 페이지 캡처.";
+"addon.media" = "Media";
+"addon.media.desc" = "음악, TV, 팟캐스트, 음성.";
+"addon.visual" = "Visual";
+"addon.visual.desc" = "사진, 화면, UI 자동화.";
+"addon.location" = "Location";
+"addon.location.desc" = "지도와 현재 위치.";
+"addon.device" = "Device";
+"addon.device.desc" = "Bluetooth와 HealthKit 계열 기기 도구.";
+"addon.intelligence" = "Intelligence";
+"addon.intelligence.desc" = "Apple Intelligence와 맥락 기억.";
+"addon.google" = "Google Workspace";
+"addon.google.desc" = "Google Workspace 연동.";
+"addon.spatial" = "Spatial";
+"addon.spatial.desc" = "VR/spatial asset과 프로젝트 맥락 준비.";
 
 /* Onboarding */
 "onboarding.back" = "이전";

--- a/app/Sources/AirMCPApp/Views/MenuContent.swift
+++ b/app/Sources/AirMCPApp/Views/MenuContent.swift
@@ -41,6 +41,19 @@ private struct ModuleInfo: Identifiable {
     private static let currentMacOSVersion = ProcessInfo.processInfo.operatingSystemVersion.majorVersion
 }
 
+private struct ModulePackInfo: Identifiable {
+    let id: String
+    let titleKey: String
+    let descKey: String
+    let packageName: String
+    let icon: String
+    let required: Bool
+
+    var localizedTitle: String { L(titleKey) }
+    var localizedDescription: String { L(descKey) }
+    var installCommand: String { "npx airmcp modules enable \(id) --install" }
+}
+
 private struct WorkflowInfo: Identifiable {
     let id: String
     let titleKey: String
@@ -89,6 +102,100 @@ private let allModules: [ModuleInfo] = [
     ModuleInfo(id: "google", icon: "globe", toolCount: 16),
     ModuleInfo(id: "speech", icon: "waveform", toolCount: 3),
     ModuleInfo(id: "health", icon: "heart", toolCount: 5),
+    ModuleInfo(id: "memory", icon: "brain.head.profile", toolCount: 4),
+    ModuleInfo(id: "audit", icon: "doc.text.magnifyingglass", toolCount: 2),
+    ModuleInfo(id: "spatial_prep", icon: "visionpro", toolCount: 2),
+]
+
+private let allModulePacks: [ModulePackInfo] = [
+    ModulePackInfo(
+        id: "core",
+        titleKey: "addon.core",
+        descKey: "addon.core.desc",
+        packageName: "airmcp",
+        icon: "square.stack.3d.up",
+        required: true
+    ),
+    ModulePackInfo(
+        id: "communications",
+        titleKey: "addon.communications",
+        descKey: "addon.communications.desc",
+        packageName: "@heznpc/airmcp-communications",
+        icon: "bubble.left.and.bubble.right",
+        required: false
+    ),
+    ModulePackInfo(
+        id: "productivity",
+        titleKey: "addon.productivity",
+        descKey: "addon.productivity.desc",
+        packageName: "@heznpc/airmcp-productivity",
+        icon: "doc.on.doc",
+        required: false
+    ),
+    ModulePackInfo(
+        id: "browser",
+        titleKey: "addon.browser",
+        descKey: "addon.browser.desc",
+        packageName: "@heznpc/airmcp-browser",
+        icon: "safari",
+        required: false
+    ),
+    ModulePackInfo(
+        id: "media",
+        titleKey: "addon.media",
+        descKey: "addon.media.desc",
+        packageName: "@heznpc/airmcp-media",
+        icon: "play.rectangle",
+        required: false
+    ),
+    ModulePackInfo(
+        id: "visual",
+        titleKey: "addon.visual",
+        descKey: "addon.visual.desc",
+        packageName: "@heznpc/airmcp-visual",
+        icon: "photo.on.rectangle",
+        required: false
+    ),
+    ModulePackInfo(
+        id: "location",
+        titleKey: "addon.location",
+        descKey: "addon.location.desc",
+        packageName: "@heznpc/airmcp-location",
+        icon: "map",
+        required: false
+    ),
+    ModulePackInfo(
+        id: "device",
+        titleKey: "addon.device",
+        descKey: "addon.device.desc",
+        packageName: "@heznpc/airmcp-device",
+        icon: "dot.radiowaves.left.and.right",
+        required: false
+    ),
+    ModulePackInfo(
+        id: "intelligence",
+        titleKey: "addon.intelligence",
+        descKey: "addon.intelligence.desc",
+        packageName: "@heznpc/airmcp-intelligence",
+        icon: "brain",
+        required: false
+    ),
+    ModulePackInfo(
+        id: "google-workspace",
+        titleKey: "addon.google",
+        descKey: "addon.google.desc",
+        packageName: "@heznpc/airmcp-google",
+        icon: "globe",
+        required: false
+    ),
+    ModulePackInfo(
+        id: "spatial",
+        titleKey: "addon.spatial",
+        descKey: "addon.spatial.desc",
+        packageName: "@heznpc/airmcp-spatial",
+        icon: "visionpro",
+        required: false
+    ),
 ]
 
 private let featuredWorkflows: [WorkflowInfo] = [
@@ -242,6 +349,7 @@ struct MenuContent: View {
     let hitlManager: HitlManager
     let logManager: LogManager
     let updateManager: UpdateManager
+    let addonManager: AddonManager
 
     var body: some View {
         // ── 1. Server Status ────────────────────────────────
@@ -477,9 +585,99 @@ struct MenuContent: View {
     @ViewBuilder
     private var modulesSection: some View {
         Menu(L("menu.modules")) {
+            addOnsMenu
+            Divider()
             ForEach(allModules) { module in
                 moduleToggle(for: module)
             }
+        }
+    }
+
+    @ViewBuilder
+    private var addOnsMenu: some View {
+        Menu(L("addons.menu")) {
+            if let status = addonManager.statusLabel {
+                Label(status, systemImage: addonStatusIcon)
+                    .foregroundStyle(addonStatusColor)
+                Divider()
+            }
+
+            ForEach(allModulePacks) { pack in
+                addOnMenu(for: pack)
+            }
+
+            Divider()
+
+            Text(L("settings.restartHint"))
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+    }
+
+    @ViewBuilder
+    private func addOnMenu(for pack: ModulePackInfo) -> some View {
+        let isActive = configManager.modulePacks.contains(pack.id)
+
+        Menu {
+            Text(pack.localizedDescription)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+
+            Text(pack.packageName)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+
+            Divider()
+
+            Toggle(L("addons.active"), isOn: Binding(
+                get: { isActive },
+                set: { enabled in
+                    configManager.setModulePack(pack.id, enabled: enabled)
+                }
+            ))
+            .disabled(pack.required)
+
+            if !pack.required {
+                Button(L("addons.install")) {
+                    addonManager.install(pack: pack.id, configManager: configManager)
+                }
+                .disabled(addonManager.isRunning)
+
+                Button(L("addons.uninstall")) {
+                    addonManager.uninstall(pack: pack.id, configManager: configManager)
+                }
+                .disabled(addonManager.isRunning)
+
+                Button(L("addons.copyInstallCommand")) {
+                    AirMcpConstants.copyToClipboard(pack.installCommand)
+                }
+            }
+        } label: {
+            Label(pack.localizedTitle, systemImage: isActive ? "checkmark.circle" : pack.icon)
+        }
+    }
+
+    private var addonStatusIcon: String {
+        switch addonManager.state {
+        case .idle:
+            "circle"
+        case .running:
+            "progress.indicator"
+        case .done:
+            "checkmark.circle.fill"
+        case .failed:
+            "exclamationmark.triangle"
+        }
+    }
+
+    private var addonStatusColor: Color {
+        switch addonManager.state {
+        case .done:
+            .green
+        case .failed:
+            .red
+        default:
+            .secondary
         }
     }
 

--- a/docs/environment.md
+++ b/docs/environment.md
@@ -14,6 +14,7 @@ If a variable accepts a path, `~` expands to `$HOME`. Booleans are `"true"` / `"
 | Bind HTTP server with OAuth 2.1 | `AIRMCP_ALLOW_NETWORK=with-oauth` + `AIRMCP_OAUTH_ISSUER=…` + `AIRMCP_OAUTH_AUDIENCE=…` |
 | Disable a flaky module without removing config | `AIRMCP_DEBUG_MODULES=notes,calendar` (whitelist) |
 | Use only selected module packs | `AIRMCP_MODULE_PACKS=core,productivity` |
+| Install and activate a module add-on | `npx airmcp modules enable productivity --install` |
 | Stage physical add-on package artifacts | `npm run addons:build` |
 | Send all 294 tools without compactDescription | `AIRMCP_COMPACT_TOOLS=false` + `AIRMCP_TOOL_EXPOSURE=full` |
 | Require sessions before hidden tools can run | `AIRMCP_REQUIRE_TOOL_SESSION=true` |
@@ -83,11 +84,12 @@ If a variable accepts a path, `~` expands to `$HOME`. Booleans are `"true"` / `"
 
 | Variable | Default | Notes |
 |---|---|---|
-| `AIRMCP_FULL` | (off) | `true` enables every standard module ignoring the config's `disabledModules`. Profile-only modules stay opt-in. |
+| `AIRMCP_FULL` | (off) | `true` requests every standard module ignoring the config's `disabledModules`. In slim-root release artifacts, non-core tools still require the matching add-on package; missing packages surface through `profile_status.missingPackInstallHints`. Profile-only modules stay opt-in. |
 | `AIRMCP_PROFILE` | `starter` | Runtime profile: `starter`, `communications-safe`, `productivity`, or `full`. May also include opt-in modules such as `spatial_prep`. |
 | `AIRMCP_TOOL_EXPOSURE` | profile-dependent | `progressive` exposes the front door, `profile` exposes the selected profile, `full` exposes every loaded tool. |
 | `AIRMCP_MODULE_PACKS` | all packs | Comma-separated DLC-like pack allow-list. `core` is always kept. Examples: `core-only`, `core,communications`, `core,productivity,spatial`, or `all`. Modules whose profile is enabled but pack is unavailable are reported through `profile_status.modulesMissingPacks`. |
 | `AIRMCP_ADDON_PACKAGE_MODE` | `prefer-installed` | Module import mode. `prefer-installed` tries installed physical add-on packages such as `@heznpc/airmcp-productivity` before bundled fallback; `bundled` skips external packages; `external-only` refuses missing add-ons outside `core`. |
+| `AIRMCP_ADDON_INSTALL_PREFIX` | `~/.airmcp/addons` | Override where `npx airmcp modules enable <pack> --install` installs companion add-on packages. The runtime resolver checks this user-level prefix after normal package resolution, so `npx` and AirMCP.app installs stay persistent instead of landing in a temporary npx cache. |
 | `AIRMCP_REQUIRE_TOOL_SESSION` | (off unless app/CLI config sets it) | `true` makes `run_tool` require a valid `sessionId` before dispatching hidden tools. Directly exposed tools remain callable without a session. New app/CLI-generated configs set `requireToolSession: true`; no-config direct stdio keeps the compatible default. |
 | `AIRMCP_HARNESS_ADAPTER` | inferred | Task harness policy: `compatible`, `strict`, `app-runtime`, or `agent`. App-owned HTTP runtime is inferred from `AIRMCP_APP_OWNED_RUNTIME`; config-driven strict sessions infer `strict`. |
 | `AIRMCP_TOOL_SESSION_MAX_TOOLS` | `64` | Maximum tools allowed in one task-scoped session. Capped at 64. |
@@ -208,7 +210,7 @@ It does not replace OS permissions, HITL approval, OAuth scopes, rate limits, or
 
 ## Module packs
 
-AirMCP module packs are the runtime contract for DLC-like installation. `npx airmcp modules` and `AIRMCP_MODULE_PACKS` let operators activate only selected packs today. `npm run addons:build` stages physical npm package directories under `build/addons`, and the runtime tries installed add-on packages first in `prefer-installed` mode before falling back to bundled modules. Add-on package names intentionally omit the word "pack": for example `@heznpc/airmcp-productivity`, `@heznpc/airmcp-communications`, and `@heznpc/airmcp-spatial`.
+AirMCP module packs are the runtime contract for DLC-like installation. `npx airmcp modules` and `AIRMCP_MODULE_PACKS` let operators activate only selected packs, while `npx airmcp modules enable productivity --install` installs the matching companion npm package and then activates it. npm and MCPB release artifacts ship as a slim root; non-core entrypoints live in the physical add-on packages staged by `npm run addons:build`. In local source builds, the runtime still tries installed add-on packages first in `prefer-installed` mode before falling back to the universal `dist` tree. Add-on package names intentionally omit the word "pack": for example `@heznpc/airmcp-productivity`, `@heznpc/airmcp-communications`, and `@heznpc/airmcp-spatial`.
 
 Built-in packs:
 
@@ -224,7 +226,7 @@ Built-in packs:
 - `google-workspace`: Google Workspace
 - `spatial`: experimental spatial prep
 
-Use `npx airmcp modules list` locally or `list_module_packs` over MCP to inspect the active pack set and add-on package names. Use `npx airmcp modules enable productivity,communications` to write a narrow `modulePacks` config. `profile_status` also reports `modulePacksConfigured`, `modulePacksAvailable`, and `modulesMissingPacks` so a client can tell whether a module is disabled by profile/config or unavailable because its pack is not active.
+Use `npx airmcp modules list` locally or `list_module_packs` over MCP to inspect the active pack set, package names, and install commands. Use `npx airmcp modules enable productivity,communications` to write a narrow `modulePacks` config, or add `--install` when the physical companion package should be installed on demand. `profile_status` also reports `modulePacksConfigured`, `modulePacksAvailable`, `modulesMissingPacks`, `modulesMissingAddonPackages`, and `missingPackInstallHints` so a client can prompt for the exact add-on install command when a requested profile is missing a pack or a slim-root runtime cannot find the package.
 
 ---
 

--- a/docs/rfc/0015-modular-install-and-task-harness.md
+++ b/docs/rfc/0015-modular-install-and-task-harness.md
@@ -1,6 +1,6 @@
 # RFC 0015 — Modular install and task-scoped harness
 
-Status: Add-on Staging Implemented
+Status: Slim Root Default Implemented
 
 ## Problem
 
@@ -30,29 +30,31 @@ The second shipped slice is the module-pack contract:
 - `src/shared/module-packs.ts` defines DLC-like packs (`core`, `communications`, `productivity`, `browser`, `media`, `visual`, `location`, `device`, `intelligence`, `google-workspace`, `spatial`),
 - each pack declares its add-on package name without a `pack-` prefix (`airmcp`, `@heznpc/airmcp-productivity`, `@heznpc/airmcp-spatial`, ...),
 - `AIRMCP_MODULE_PACKS` and `config.json -> modulePacks` can restrict the available pack set while preserving `core`,
-- `npx airmcp modules` lists, enables, disables, and doctors the active pack set,
+- `npx airmcp modules` lists, enables, disables, installs, uninstalls, and doctors the active pack set,
+- `npx airmcp modules enable <pack> --install` installs companion npm packages into the user-level add-on prefix before activating `modulePacks`,
 - module loading skips enabled-profile modules whose pack is unavailable before dynamic import,
 - `list_module_packs` reports the active pack set over MCP,
-- `profile_status` reports `modulePacksConfigured`, `modulePacksAvailable`, and `modulesMissingPacks`,
+- `profile_status` reports `modulePacksConfigured`, `modulePacksAvailable`, `modulesMissingPacks`, `modulesMissingAddonPackages`, and install hints,
 - `profiles:check` includes a real MCP wire case proving `productivity` remains available while `communications` modules become missing-pack modules when only `core,productivity` are active.
 
-The third shipped slice is physical package staging:
+The third shipped slice is physical package split:
 
 - `scripts/build-addon-packages.mjs` stages tarball-ready package directories under `build/addons`,
 - each staged package includes only its pack modules; shared runtime imports are rewritten to the peer root `airmcp` package instead of copied into every add-on,
-- `AIRMCP_ADDON_PACKAGE_MODE=prefer-installed` tries an installed add-on package before bundled fallback,
+- `AIRMCP_ADDON_PACKAGE_MODE=prefer-installed` tries an installed add-on package from normal package resolution and `AIRMCP_ADDON_INSTALL_PREFIX` before bundled fallback,
 - `AIRMCP_ADDON_PACKAGE_MODE=external-only` turns missing add-ons into module-load failures outside `core`,
+- `npm pack` / `npm publish` prepack builds a slim root artifact and postpack restores the universal local `dist`,
 - `npm run addons:check` is wired into CI and `release:preflight`.
 
-## Proposed install split
+## Implemented install split
 
-Keep the npm package as the reliable universal fallback while add-on packages prove install-size and startup wins. Split module packs in this order:
+Release artifacts now use a slim root by default while the source checkout keeps a universal local `dist` for development and measurement. Split module packs in this order:
 
 | Layer            | Package shape                                                                                                  | Why first                                                                                                                          |
 | ---------------- | -------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
 | Runtime core     | `airmcp`                                                                                                       | Owns config, transports, audit, HITL, OAuth, rate limits, profiles, and task sessions.                                             |
 | Optional bridges | source-built Swift bridge / future signed app component                                                        | Heavy native capability already differs from npm/MCPB distribution.                                                                |
-| Module add-ons   | staged `@heznpc/airmcp-productivity` / `@heznpc/airmcp-spatial` packages or signed app downloadable components | Runtime can already import installed add-ons first; publishing waits until package-size/startup evidence beats release complexity. |
+| Module add-ons   | staged `@heznpc/airmcp-productivity` / `@heznpc/airmcp-spatial` packages or signed app downloadable components | Runtime imports installed add-ons first; missing slim-root packages surface install hints instead of silently pretending the module exists. |
 
 `npx airmcp doctor` treats the Swift bridge as an optional bridge, not a module add-on package. That keeps the first physical split focused on the heaviest native binary/signing boundary before multiplying npm package surfaces.
 
@@ -62,29 +64,31 @@ Keep the npm package as the reliable universal fallback while add-on packages pr
 - `npm run harness:check` proves `compatible`, `strict`, `app-runtime`, and `agent` adapter policy over the real MCP stdio wire, including the app-owned runtime inference path.
 - `npm run tokens:check` keeps the eager tool-description budget bounded as modules grow.
 - `npm run addons:check` stages every non-core package and fails on missing module/shared files or `pack-*` naming drift.
-- `npm run addons:verify-install` packs the root package plus at least one staged add-on, first proves a root-only install cannot silently use bundled fallback in `AIRMCP_ADDON_PACKAGE_MODE=external-only`, then installs the add-on artifact and proves the selected pack registers over MCP stdio.
-- `npm run addons:measure-split` builds a temporary slim root artifact, installs it with selected add-ons, and records packed/unpacked/install-size plus startup/list timing deltas against the universal bundled package.
-- `npm pack --dry-run --json` shows package size regressions per release.
-- `list_module_packs` and `profile_status.modulesMissingPacks` remain stable public truth surfaces.
+- `npm run addons:verify-install -- --all` packs the slim root package plus every staged add-on, first proves a root-only install cannot silently use bundled fallback in `AIRMCP_ADDON_PACKAGE_MODE=external-only`, then installs the add-on artifacts and proves the selected packs register over MCP stdio.
+- `npm run addons:measure-split` packs the universal local build with lifecycle scripts disabled, compares it with slim-root plus selected add-ons, and records packed/unpacked/install-size plus startup/list timing deltas.
+- `npm pack --dry-run --json` must include `dist/.airmcp-slim-root.json` and must not include non-core module `tools.js` / `prompts.js` entrypoints.
+- `.mcpb` release artifacts must include the same slim-root marker and must not leak non-core module entrypoints.
+- `list_module_packs`, `profile_status.modulesMissingPacks`, `profile_status.modulesMissingAddonPackages`, and `profile_status.missingPackInstallHints` remain stable public truth surfaces.
 - At least one real user/workflow needs a smaller install, not only a smaller context window.
 - Pack boundaries have tests proving no profile loads a missing optional module by accident.
 
 ## Post-validation decision matrix
 
-This matrix is the decision surface after an add-on modular-distribution kill-test. It decides whether the staged package split graduates, stalls, or rolls back to runtime-only module packs. It does not change the current safety model: bundled fallback remains the default user-safe path until install evidence is clean across npm, MCPB, app runtime, and no-config stdio.
+This matrix is the decision surface after an add-on modular-distribution kill-test. It decides whether the slim-root/add-on split stays the default, stalls, or rolls back to runtime-only module packs. It does not change the safety model: `core` keeps the front door, and missing non-core packages surface install hints instead of widening permissions.
 
 Validation evidence must include:
 
-- `npm run release:preflight` or the equivalent explicit sequence: `build`, `tokens:check`, `profiles:check`, `harness:check`, `addons:check`, `addons:verify-install`, `addons:measure-split`, `verify:package`, `npm pack --dry-run --json`, and `build:mcpb`.
+- `npm run release:preflight` or the equivalent explicit sequence: `build`, `tokens:check`, `profiles:check`, `harness:check`, `addons:check`, `addons:verify-install -- --all`, `addons:measure-split -- --require-size-win`, `verify:package`, `npm pack --dry-run --json`, and `build:mcpb`.
 - Add-on package install smoke test in `AIRMCP_ADDON_PACKAGE_MODE=external-only` for at least one non-core pack and one restricted-pack profile, with both root-only negative provenance and installed-add-on positive registration checks.
 - Wire test coverage for explicit `compatible`, `strict`, `app-runtime`, and `agent` harness adapter policies plus app-owned runtime inference.
 - Size and startup/list timing measurements for universal bundled install vs slim-root add-on install. Thresholds are owner-ratified release gates, not inferred by the implementation session.
+- Shipped-artifact checks proving npm and MCPB artifacts are slim root artifacts, not merely measured temporary artifacts.
 
 | Validation result       | Decision                                                                                                            | Immediate action                                                                                                                                                                                            | Follow-up goal                                                                                                             | Public status                                                                 |
 | ----------------------- | ------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------- |
-| Validation passes       | Graduate add-ons to opt-in prerelease distribution, still with bundled fallback.                                    | Prepare npm prerelease/canary add-on package plan and document install path; keep `airmcp` universal package as the default.                                                                                | Add shipped-artifact CI coverage for installed add-ons before any stable publish or fallback removal.                      | "Add-on packages are opt-in prerelease; universal package remains supported." |
-| Size win is weak        | Do not publish physical add-ons yet. Runtime module packs remain useful; physical split stays staged.               | Record the measured size/startup deltas and keep `addons:check` in CI/release preflight.                                                                                                                    | Re-evaluate heavier boundaries first: Swift bridge/app component, shared dependency pruning, or pack granularity changes.  | "Staging validated technically, but release value is not proven."             |
-| Install fails           | Block add-on distribution. Keep bundled fallback and runtime pack activation only.                                  | Preserve failing artifact, install log, package manifest, and import mode; fix package layout, dependency, export, or peer-version issue before another kill-test.                                          | Add a regression test for the exact install failure if it is reproducible locally or in CI.                                | "No add-on package publish; use bundled `airmcp`."                            |
+| Validation passes       | Keep slim root as the default release shape.                                                                       | Publish root and add-on artifacts only when shipped-artifact checks pass; keep the install prompt path documented.                                                                                           | Expand clean-install coverage from the default productivity pack to every publish-target add-on.                           | "Slim root is the default; install add-ons on demand."                        |
+| Size win is weak        | Do not widen add-on publishing. Keep the slim gate, but re-check whether the split is worth the product complexity. | Record measured size/startup deltas and require owner ratification before adding more physical packages.                                                                                                     | Re-evaluate heavier boundaries first: Swift bridge/app component, shared dependency pruning, or pack granularity changes.  | "Slim root works technically, but value needs tighter evidence."              |
+| Install fails           | Block add-on distribution and block stable release.                                                                | Preserve failing artifact, install log, package manifest, and import mode; fix package layout, dependency, export, or peer-version issue before another release attempt.                                    | Add a regression test for the exact install failure if it is reproducible locally or in CI.                                | "No add-on package publish until install is fixed."                           |
 | Adapter wire tests fail | Block graduation of the task-harness contract for affected adapters; do not use add-on split to widen distribution. | Keep compatible/no-session stdio behavior available; fix `start_tool_session`, `discover_tools`, `describe_tool`, `run_tool`, `tool_session_status`, or `end_tool_session` wire behavior before publishing. | Add or tighten wire cases for the failing adapter policy, especially hidden-tool rejection and session allowlist behavior. | "Task harness remains staged for the failing adapter."                        |
 
 If multiple rows apply, choose the most conservative result in this order: install failure, adapter wire failure, weak size win, pass.
@@ -92,5 +96,4 @@ If multiple rows apply, choose the most conservative result in this order: insta
 ## Non-goals
 
 - Do not split safety primitives out of core.
-- Do not remove bundled fallback until installed add-ons have passed shipped-artifact checks across npm, MCPB, app runtime, and no-config stdio.
 - Do not use AppIntents/Shortcuts as the module-pack mechanism; they are user-facing automation surfaces, not runtime dependency management.

--- a/docs/site/src/content/docs/getting-started/configuration.md
+++ b/docs/site/src/content/docs/getting-started/configuration.md
@@ -66,6 +66,7 @@ The default config file location is `~/.config/airmcp/config.json`. You can over
 | `AIRMCP_TOOL_EXPOSURE=progressive` | Keep `tools/list` thin; use `profile` or `full` to expose more tools |
 | `AIRMCP_MODULE_PACKS=core,productivity` | Activate selected DLC-like module packs |
 | `AIRMCP_ADDON_PACKAGE_MODE=prefer-installed` | Try installed physical add-on packages before bundled fallback |
+| `AIRMCP_ADDON_INSTALL_PREFIX` | Override the default `~/.airmcp/addons` companion add-on install prefix |
 | `AIRMCP_REQUIRE_TOOL_SESSION=true` | Require task-scoped sessions before hidden `run_tool` dispatch |
 | `AIRMCP_HARNESS_ADAPTER=strict` | Select a task harness policy explicitly |
 | `AIRMCP_PROFILE=spatial_prep` | Enable an experimental profile-only module in addition to the selected profile |
@@ -135,7 +136,7 @@ npx airmcp                    # Start in stdio mode (default)
 npx airmcp --http             # Start as HTTP server
 npx airmcp --http --port 8080 # Custom port
 npx airmcp --http --bind-all  # Bind to 0.0.0.0 (all interfaces)
-npx airmcp --full             # Enable all modules
+npx airmcp --full             # Request every installed module
 npx airmcp connect            # Proxy stdio clients to AirMCP.app
 npx airmcp init               # Interactive setup wizard
 npx airmcp modules            # Inspect or edit module add-on activation

--- a/docs/site/src/content/docs/modules/overview.md
+++ b/docs/site/src/content/docs/modules/overview.md
@@ -5,7 +5,7 @@ description: All 25 AirMCP modules with tool counts and capabilities.
 
 AirMCP ships 29 modules that cover the Apple workspace. Each module registers a set of MCP tools that AI assistants can call. The full manifest contains 294 tools, while the default starter/progressive runtime exposes a smaller front door.
 
-Module packs are the DLC-like activation boundary above modules. `npx airmcp modules enable productivity` or `AIRMCP_MODULE_PACKS=core,productivity` keeps core workspace tools and iWork active while reporting unavailable profile modules through `profile_status.modulesMissingPacks`. `npm run addons:build` stages physical add-on packages, and runtime import can prefer installed add-ons before bundled fallback. Add-on names omit `pack-*` naming, for example `@heznpc/airmcp-productivity`.
+Module packs are the DLC-like activation boundary above modules. `npx airmcp modules enable productivity` or `AIRMCP_MODULE_PACKS=core,productivity` keeps core workspace tools and iWork active while reporting unavailable profile modules through `profile_status.modulesMissingPacks`. Add `--install` to install the matching companion npm add-on into the user-level add-on prefix before activating it. npm and MCPB releases ship as a slim root; non-core module entrypoints live in physical add-on packages staged by `npm run addons:build`. Add-on names omit `pack-*` naming, for example `@heznpc/airmcp-productivity`.
 
 ## Module Table
 

--- a/docs/tool-manifest.json
+++ b/docs/tool-manifest.json
@@ -6362,6 +6362,36 @@
                 },
                 "required": {
                   "type": "boolean"
+                },
+                "installSpec": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "installCommand": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "uninstallCommand": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
                 }
               },
               "required": [
@@ -6371,7 +6401,10 @@
                 "description",
                 "modules",
                 "available",
-                "required"
+                "required",
+                "installSpec",
+                "installCommand",
+                "uninstallCommand"
               ],
               "additionalProperties": false
             }
@@ -9443,6 +9476,46 @@
               "type": "string"
             }
           },
+          "modulesMissingAddonPackages": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "missingPackInstallHints": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "pack": {
+                  "type": "string"
+                },
+                "packageName": {
+                  "type": "string"
+                },
+                "installSpec": {
+                  "type": "string"
+                },
+                "modules": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "command": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "pack",
+                "packageName",
+                "installSpec",
+                "modules",
+                "command"
+              ],
+              "additionalProperties": false
+            }
+          },
           "requireToolSession": {
             "type": "boolean"
           },
@@ -9483,6 +9556,8 @@
           "modulePacksConfigured",
           "modulePacksAvailable",
           "modulesMissingPacks",
+          "modulesMissingAddonPackages",
+          "missingPackInstallHints",
           "requireToolSession",
           "harnessAdapter",
           "modulesEnabled",

--- a/package.json
+++ b/package.json
@@ -86,6 +86,8 @@
     "format": "prettier --write src/",
     "format:check": "prettier --check src/",
     "prepublishOnly": "npm run clean && npm run build",
+    "prepack": "npm run build && npm run addons:check && node scripts/slim-root-package.mjs --apply",
+    "postpack": "node scripts/slim-root-package.mjs --restore",
     "pretest": "npm run build",
     "start": "node dist/index.js",
     "test": "node --experimental-vm-modules node_modules/.bin/jest",

--- a/scripts/build-addon-packages.mjs
+++ b/scripts/build-addon-packages.mjs
@@ -3,9 +3,9 @@
  * Stage physical AirMCP add-on packages from the built dist tree.
  *
  * This is intentionally a build artifact, not checked-in package output:
- * runtime code can prefer installed add-on packages today, while the universal
- * `airmcp` package remains a compatibility fallback until the split is ready
- * to publish as separate npm packages.
+ * runtime code can prefer installed add-on packages today, while prepack turns
+ * the root `airmcp` artifact into a slim package that keeps non-core entrypoints
+ * in these companion packages.
  */
 
 import {

--- a/scripts/build-mcpb.mjs
+++ b/scripts/build-mcpb.mjs
@@ -107,7 +107,23 @@ if (!existsSync(join(ROOT, "dist", "index.js"))) {
   console.error(`[mcpb] dist/index.js not found — run \`npm run build\` first`);
   process.exit(1);
 }
-cpSync(join(ROOT, "dist"), join(serverDir, "dist"), { recursive: true });
+const slimApply = spawnSync(process.execPath, ["scripts/slim-root-package.mjs", "--apply"], { cwd: ROOT, stdio: "inherit" });
+if (slimApply.status !== 0) {
+  console.error(`[mcpb] slim root apply failed with status ${slimApply.status}`);
+  process.exit(1);
+}
+try {
+  cpSync(join(ROOT, "dist"), join(serverDir, "dist"), { recursive: true });
+} finally {
+  const slimRestore = spawnSync(process.execPath, ["scripts/slim-root-package.mjs", "--restore"], {
+    cwd: ROOT,
+    stdio: "inherit",
+  });
+  if (slimRestore.status !== 0) {
+    console.error(`[mcpb] slim root restore failed with status ${slimRestore.status}`);
+    process.exit(1);
+  }
+}
 
 // ── Install production deps into the bundle ──────────────────────────
 console.error("[mcpb] installing production dependencies into bundle…");

--- a/scripts/measure-addon-split.mjs
+++ b/scripts/measure-addon-split.mjs
@@ -125,8 +125,10 @@ function readJson(path) {
   return JSON.parse(readFileSync(path, "utf8"));
 }
 
-function npmPack(cwd) {
-  const output = sh("npm", ["pack", "--json"], { cwd });
+function npmPack(cwd, options = {}) {
+  const args = ["pack", "--json"];
+  if (options.ignoreScripts) args.push("--ignore-scripts");
+  const output = sh("npm", args, { cwd });
   let parsed;
   try {
     const arrayStart = output.indexOf("[");
@@ -564,12 +566,12 @@ try {
   const forbiddenModules = assertion.forbiddenModules ?? [];
 
   console.log(`[2/6] npm pack universal root and selected add-ons (${selectedPacks.join(", ")})`);
-  const universalRootPack = npmPack(ROOT);
+  const universalRootPack = npmPack(ROOT, { ignoreScripts: true });
   tarballs.push(universalRootPack.tgz);
   const addonPacks = selectedPacks.map((packName) => {
     const pack = stagedManifest.packages.find((candidate) => candidate.name === packName);
     const packageRoot = join(ROOT, pack.packageDir);
-    const artifact = npmPack(packageRoot);
+    const artifact = npmPack(packageRoot, { ignoreScripts: true });
     tarballs.push(artifact.tgz);
     return { ...artifact, packName, packageName: pack.packageName };
   });
@@ -577,7 +579,7 @@ try {
   console.log("[3/6] create temporary slim root package");
   const slim = makeSlimRootPackageSource(stagedManifest.packages);
   slimSourceDir = slim.sourceDir;
-  const slimRootPack = npmPack(slimSourceDir);
+  const slimRootPack = npmPack(slimSourceDir, { ignoreScripts: true });
   tarballs.push(slimRootPack.tgz);
 
   console.log("[4/6] install and boot universal bundled package");

--- a/scripts/release-preflight.mjs
+++ b/scripts/release-preflight.mjs
@@ -71,7 +71,10 @@ function verifyNpmDryRun() {
   const output = run("npm", ["pack", "--dry-run", "--json"], { capture: true });
   let pack;
   try {
-    [pack] = JSON.parse(output);
+    const arrayStart = output.indexOf("[");
+    const arrayEnd = output.lastIndexOf("]");
+    const jsonText = arrayStart >= 0 && arrayEnd > arrayStart ? output.slice(arrayStart, arrayEnd + 1) : output;
+    [pack] = JSON.parse(jsonText);
   } catch (error) {
     fail(`npm pack --dry-run --json did not return parseable JSON: ${error.message}`);
   }
@@ -93,13 +96,35 @@ function verifyNpmDryRun() {
   if (!filePaths.includes("dist/index.js")) {
     fail("npm dry-run is missing dist/index.js");
   }
-  console.log(`ok: npm dry-run: ${pack.filename}, ${filePaths.length} files, dist-only publish surface`);
+  if (!filePaths.includes("dist/.airmcp-slim-root.json")) {
+    fail("npm dry-run is missing dist/.airmcp-slim-root.json; root package is not the slim publish surface");
+  }
+  const stagedManifest = JSON.parse(readFileSync(join(ROOT, "build", "addons", "manifest.json"), "utf8"));
+  const leakedEntrypoints = [];
+  for (const addonPack of stagedManifest.packages ?? []) {
+    for (const moduleName of addonPack.modules ?? []) {
+      for (const fileName of ["tools.js", "prompts.js"]) {
+        const entry = `dist/${moduleName}/${fileName}`;
+        if (filePaths.includes(entry)) leakedEntrypoints.push(entry);
+      }
+    }
+  }
+  if (leakedEntrypoints.length) {
+    fail(`npm dry-run includes non-core module entrypoints that belong in add-ons: ${leakedEntrypoints.join(", ")}`);
+  }
+  console.log(`ok: npm dry-run: ${pack.filename}, ${filePaths.length} files, slim root publish surface`);
 }
 
 function verifyMcpb(path) {
   const size = assertFile(path, ".mcpb");
   const entries = listZip(path);
-  const required = ["manifest.json", "icon.png", "server/package.json", "server/dist/index.js"];
+  const required = [
+    "manifest.json",
+    "icon.png",
+    "server/package.json",
+    "server/dist/index.js",
+    "server/dist/.airmcp-slim-root.json",
+  ];
   const missing = required.filter((entry) => !entries.includes(entry));
   if (missing.length) fail(`.mcpb is missing required entries: ${missing.join(", ")}`);
   if (!entries.some((entry) => entry.startsWith("server/node_modules/"))) {
@@ -115,6 +140,19 @@ function verifyMcpb(path) {
       entry.endsWith("/.npmrc"),
   );
   if (forbidden.length) fail(`.mcpb includes forbidden paths: ${forbidden.join(", ")}`);
+  const stagedManifest = JSON.parse(readFileSync(join(ROOT, "build", "addons", "manifest.json"), "utf8"));
+  const leakedEntrypoints = [];
+  for (const addonPack of stagedManifest.packages ?? []) {
+    for (const moduleName of addonPack.modules ?? []) {
+      for (const fileName of ["tools.js", "prompts.js"]) {
+        const entry = `server/dist/${moduleName}/${fileName}`;
+        if (entries.includes(entry)) leakedEntrypoints.push(entry);
+      }
+    }
+  }
+  if (leakedEntrypoints.length) {
+    fail(`.mcpb includes non-core module entrypoints that belong in add-ons: ${leakedEntrypoints.join(", ")}`);
+  }
 
   const manifest = readZipJson(path, "manifest.json");
   if (manifest.version !== version) {
@@ -147,15 +185,14 @@ run("npm", ["run", "tokens:check"]);
 run("npm", ["run", "profiles:check"]);
 run("npm", ["run", "harness:check"]);
 run("npm", ["run", "addons:check"]);
-run("npm", ["run", "addons:verify-install"]);
-run("npm", ["run", "addons:measure-split", "--", "--no-build"]);
-run("npm", ["run", "verify:package"]);
-verifyNpmDryRun();
-run("npm", ["run", "build:mcpb"]);
-
+run("npm", ["run", "addons:verify-install", "--", "--all"]);
+run("npm", ["run", "addons:measure-split", "--", "--no-build", "--require-size-win"]);
 const splitMeasurementPath = join(ROOT, "build", "addons", "split-measurement.json");
 assertFile(splitMeasurementPath, "add-on split measurement");
 copyFileSync(splitMeasurementPath, join(OUT_DIR, "addon-split-measurement.json"));
+run("npm", ["run", "verify:package"]);
+verifyNpmDryRun();
+run("npm", ["run", "build:mcpb"]);
 
 const mcpbPath = join(ROOT, "build", "mcpb", `airmcp-${version}.mcpb`);
 verifyMcpb(mcpbPath);

--- a/scripts/slim-root-package.mjs
+++ b/scripts/slim-root-package.mjs
@@ -1,0 +1,89 @@
+#!/usr/bin/env node
+/**
+ * Apply or restore the slim-root npm package surface.
+ *
+ * `npm pack` / `npm publish` should ship the root package without non-core
+ * module entrypoints. The companion add-on packages carry those entrypoints.
+ * Local builds stay universal: prepack backs up dist, removes non-core
+ * tools/prompts, and postpack restores the universal dist tree.
+ */
+
+import { cpSync, existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const DIST = join(ROOT, "dist");
+const BACKUP_DIR = join(ROOT, "build", "slim-root-backup");
+const BACKUP_DIST = join(BACKUP_DIR, "dist");
+const MARKER = join(DIST, ".airmcp-slim-root.json");
+
+function fail(message) {
+  console.error(`slim-root-package: ${message}`);
+  process.exit(1);
+}
+
+function readJson(path) {
+  return JSON.parse(readFileSync(path, "utf8"));
+}
+
+function ensureBuilt() {
+  if (!existsSync(join(DIST, "index.js"))) fail("dist/index.js missing; run npm run build first");
+  if (!existsSync(join(DIST, "shared", "module-packs.js"))) {
+    fail("dist/shared/module-packs.js missing; run npm run build first");
+  }
+}
+
+function restore() {
+  if (!existsSync(BACKUP_DIST)) return;
+  rmSync(DIST, { recursive: true, force: true });
+  cpSync(BACKUP_DIST, DIST, { recursive: true });
+  rmSync(BACKUP_DIR, { recursive: true, force: true });
+  console.log("slim-root-package: restored universal dist");
+}
+
+async function applySlimRoot() {
+  ensureBuilt();
+  restore();
+  mkdirSync(BACKUP_DIR, { recursive: true });
+  cpSync(DIST, BACKUP_DIST, { recursive: true });
+
+  const rootPkg = readJson(join(ROOT, "package.json"));
+  const { MODULE_PACK_MANIFEST } = await import(pathToFileURL(join(DIST, "shared", "module-packs.js")).href);
+  const removed = [];
+  for (const pack of MODULE_PACK_MANIFEST) {
+    if (pack.name === "core") continue;
+    for (const moduleName of pack.modules) {
+      for (const fileName of ["tools.js", "prompts.js"]) {
+        const filePath = join(DIST, moduleName, fileName);
+        if (existsSync(filePath)) {
+          rmSync(filePath, { force: true });
+          removed.push(`dist/${moduleName}/${fileName}`);
+        }
+      }
+    }
+  }
+
+  writeFileSync(
+    MARKER,
+    JSON.stringify(
+      {
+        version: rootPkg.version,
+        slimRoot: true,
+        removedModuleEntrypoints: removed,
+      },
+      null,
+      2,
+    ) + "\n",
+  );
+  console.log(`slim-root-package: removed ${removed.length} non-core module entrypoints`);
+}
+
+const mode = process.argv[2];
+if (mode === "--apply") {
+  applySlimRoot().catch((error) => fail(error instanceof Error ? error.message : String(error)));
+} else if (mode === "--restore") {
+  restore();
+} else {
+  fail("usage: node scripts/slim-root-package.mjs --apply|--restore");
+}

--- a/scripts/verify-published-package.mjs
+++ b/scripts/verify-published-package.mjs
@@ -136,6 +136,11 @@ try {
     console.error(`✗ installed package is missing the entrypoint: ${entry}`);
     process.exit(1);
   }
+  const slimMarker = join(work, "node_modules", "airmcp", "dist", ".airmcp-slim-root.json");
+  if (!existsSync(slimMarker)) {
+    console.error("✗ installed package is missing dist/.airmcp-slim-root.json; npm artifact is not slim-root.");
+    process.exit(1);
+  }
 
   console.log("[3/3] boot the INSTALLED server under MCP Inspector …");
   // eslint-disable-next-line no-undef -- top-level await is fine in an ESM script

--- a/src/cli/help.ts
+++ b/src/cli/help.ts
@@ -20,7 +20,7 @@ export function runHelp(): void {
   );
   console.log(`    ${GREEN}$${RESET} npx airmcp ${BOLD}doctor${RESET}          ${DIM}Diagnose installation${RESET}`);
   console.log(
-    `    ${GREEN}$${RESET} npx airmcp ${BOLD}modules${RESET}         ${DIM}Inspect or edit module add-on activation${RESET}`,
+    `    ${GREEN}$${RESET} npx airmcp ${BOLD}modules${RESET}         ${DIM}Inspect, install, or edit module add-ons${RESET}`,
   );
   console.log(
     `    ${GREEN}$${RESET} npx airmcp ${BOLD}workflows${RESET}       ${DIM}Show high-value workflow examples${RESET}`,
@@ -39,7 +39,9 @@ export function runHelp(): void {
   );
   console.log(`    ${GREEN}$${RESET} npx airmcp                  ${DIM}Start MCP server (stdio)${RESET}`);
   console.log(`    ${GREEN}$${RESET} npx airmcp ${BOLD}--http${RESET}          ${DIM}Start as HTTP server${RESET}`);
-  console.log(`    ${GREEN}$${RESET} npx airmcp ${BOLD}--full${RESET}          ${DIM}Enable all modules${RESET}`);
+  console.log(
+    `    ${GREEN}$${RESET} npx airmcp ${BOLD}--full${RESET}          ${DIM}Request all installed modules${RESET}`,
+  );
   console.log(`    ${GREEN}$${RESET} npx airmcp ${BOLD}--version${RESET}       ${DIM}Print version and exit${RESET}`);
   console.log(
     `    ${GREEN}$${RESET} npx airmcp ${BOLD}--http --port${RESET} N  ${DIM}Custom port (default: 3847)${RESET}`,
@@ -52,7 +54,7 @@ export function runHelp(): void {
   console.log("");
   console.log(`    ${CYAN}init${RESET}       ${DIM}Choose language, select modules, configure MCP clients${RESET}`);
   console.log(`    ${CYAN}doctor${RESET}     ${DIM}Check Node.js, macOS, permissions, clients, modules${RESET}`);
-  console.log(`    ${CYAN}modules${RESET}    ${DIM}List, enable, disable, or doctor DLC-like module add-ons${RESET}`);
+  console.log(`    ${CYAN}modules${RESET}    ${DIM}List, install, enable, disable, or doctor module add-ons${RESET}`);
   console.log(`    ${CYAN}connect${RESET}    ${DIM}Bridge stdio clients into the app-owned local runtime${RESET}`);
   console.log(
     `    ${CYAN}connect-clients${RESET} ${DIM}Configure installed clients to use that app-owned runtime${RESET}`,
@@ -63,7 +65,7 @@ export function runHelp(): void {
   console.log("");
   console.log(`  ${BOLD}Environment Variables${RESET}`);
   console.log("");
-  console.log(`    ${WHITE}AIRMCP_FULL${RESET}=true              ${DIM}Enable all modules (ignores config)${RESET}`);
+  console.log(`    ${WHITE}AIRMCP_FULL${RESET}=true              ${DIM}Request all installed modules${RESET}`);
   console.log(
     `    ${WHITE}AIRMCP_PROFILE${RESET}=${DIM}starter|communications-safe|productivity|full${RESET} ${DIM}Choose module profile${RESET}`,
   );

--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -591,7 +591,9 @@ export async function runInit(): Promise<void> {
   );
   console.log(`    ${DIM}\u2022${RESET} Run ${BOLD}npx airmcp workflows${RESET} to see target workflows and prompts`);
   console.log(`    ${DIM}\u2022${RESET} Re-run ${BOLD}npx airmcp init${RESET} anytime to change modules`);
-  console.log(`    ${DIM}\u2022${RESET} Use ${BOLD}npx airmcp --full${RESET} to enable all modules temporarily`);
+  console.log(
+    `    ${DIM}\u2022${RESET} Use ${BOLD}npx airmcp --full${RESET} to request every installed module temporarily`,
+  );
   console.log("");
   console.log(`  ${DIM}${t("try_asking", lang)}${RESET}`);
   console.log(`    ${DIM}\u201c${RESET}${t("prompt_calendar_today", lang)}${DIM}\u201d${RESET}`);

--- a/src/cli/modules.ts
+++ b/src/cli/modules.ts
@@ -1,13 +1,20 @@
 /**
  * `npx airmcp modules` — inspect and edit AirMCP's module-pack activation set.
  *
- * This is the user-facing seam before physical add-on packages exist: the
- * universal runtime still ships all built-ins, while config decides which
- * packs activate on this host.
+ * This is the user-facing entry point for on-demand add-ons: config decides
+ * which packs activate on this host, and --install/--uninstall manage the
+ * matching physical npm companion packages in the same install prefix as AirMCP.
  */
 
+import { execFileSync } from "node:child_process";
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
-import { dirname } from "node:path";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  getAddonInstallPackageJsonPath,
+  getAddonInstallPrefix,
+  getAddonPackageInstallPath,
+} from "../shared/addon-packages.js";
 import { PATHS } from "../shared/constants.js";
 import {
   CORE_MODULE_PACK_NAME,
@@ -19,13 +26,30 @@ import {
 import { isPlainObject } from "../shared/validate.js";
 import { BOLD, CYAN, DIM, GREEN, RESET, WHITE, YELLOW } from "./style.js";
 
-type ModulesCommand = "list" | "doctor" | "enable" | "disable" | "help";
+type ModulesCommand = "list" | "doctor" | "enable" | "disable" | "install" | "uninstall" | "help";
 
 interface ParsedArgs {
   command: ModulesCommand;
   tokens: string[];
   json: boolean;
+  install: boolean;
+  uninstall: boolean;
+  dryRun: boolean;
+  prefix?: string;
 }
+
+interface AddonOperation {
+  action: "install" | "uninstall";
+  prefix: string;
+  packages: string[];
+  command: string[];
+  skipped: boolean;
+}
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const PKG_ROOT = resolve(__dirname, "..", "..");
+const ROOT_PACKAGE = readJson(join(PKG_ROOT, "package.json"));
+const ROOT_VERSION = String(ROOT_PACKAGE.version ?? "0.0.0");
 
 function readConfig(): Record<string, unknown> {
   if (!existsSync(PATHS.CONFIG)) return {};
@@ -37,6 +61,10 @@ function readConfig(): Record<string, unknown> {
   }
 }
 
+function readJson(path: string): Record<string, unknown> {
+  return JSON.parse(readFileSync(path, "utf-8")) as Record<string, unknown>;
+}
+
 function writeConfig(config: Record<string, unknown>): void {
   mkdirSync(dirname(PATHS.CONFIG), { recursive: true });
   writeFileSync(PATHS.CONFIG, JSON.stringify(config, null, 2) + "\n");
@@ -46,13 +74,29 @@ function parseArgs(argv = process.argv.slice(3)): ParsedArgs {
   let command: ModulesCommand = "list";
   const tokens: string[] = [];
   let json = false;
+  let install = false;
+  let uninstall = false;
+  let dryRun = false;
+  let prefix: string | undefined;
 
-  for (const arg of argv) {
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i]!;
     if (arg === "--json") {
       json = true;
+    } else if (arg === "--install") {
+      install = true;
+    } else if (arg === "--uninstall") {
+      uninstall = true;
+    } else if (arg === "--dry-run") {
+      dryRun = true;
+    } else if (arg === "--prefix") {
+      prefix = argv[i + 1];
+      i++;
+    } else if (arg.startsWith("--prefix=")) {
+      prefix = arg.slice("--prefix=".length);
     } else if (arg === "--help" || arg === "-h" || arg === "help") {
       command = "help";
-    } else if (["list", "doctor", "enable", "disable"].includes(arg)) {
+    } else if (["list", "doctor", "enable", "disable", "install", "uninstall"].includes(arg)) {
       command = arg as ModulesCommand;
     } else {
       tokens.push(
@@ -64,7 +108,9 @@ function parseArgs(argv = process.argv.slice(3)): ParsedArgs {
     }
   }
 
-  return { command, tokens, json };
+  if (command === "install") install = true;
+  if (command === "uninstall") uninstall = true;
+  return { command, tokens, json, install, uninstall, dryRun, prefix };
 }
 
 function currentPackSet(config: Record<string, unknown>): Set<ModulePackName> {
@@ -81,14 +127,85 @@ function packNamesFor(tokens: string[]): Set<ModulePackName> {
   return selection.packs;
 }
 
-function statusPayload(config: Record<string, unknown>) {
+function addonPackageSpecs(packs: ReadonlySet<ModulePackName>): string[] {
+  return MODULE_PACK_MANIFEST.filter((pack) => pack.name !== CORE_MODULE_PACK_NAME && packs.has(pack.name)).map(
+    (pack) => `${pack.packageName}@${ROOT_VERSION}`,
+  );
+}
+
+function addonPackageNames(packs: ReadonlySet<ModulePackName>): string[] {
+  return MODULE_PACK_MANIFEST.filter((pack) => pack.name !== CORE_MODULE_PACK_NAME && packs.has(pack.name)).map(
+    (pack) => pack.packageName,
+  );
+}
+
+function installedAddonPackages(prefix: string): Set<string> {
+  const installed = new Set<string>();
+  for (const pack of MODULE_PACK_MANIFEST) {
+    if (pack.name === CORE_MODULE_PACK_NAME) {
+      installed.add(pack.name);
+      continue;
+    }
+    if (existsSync(join(getAddonPackageInstallPath(prefix, pack.packageName), "package.json")))
+      installed.add(pack.name);
+  }
+  return installed;
+}
+
+function ensureAddonInstallProject(prefix: string): void {
+  mkdirSync(prefix, { recursive: true });
+  const packageJsonPath = getAddonInstallPackageJsonPath(prefix);
+  if (!existsSync(packageJsonPath)) {
+    writeFileSync(packageJsonPath, JSON.stringify({ private: true, name: "airmcp-addons" }, null, 2) + "\n");
+  }
+}
+
+function formatShellCommand(command: string[]): string {
+  return command.map((part) => (/^[a-zA-Z0-9_./:@=-]+$/.test(part) ? part : JSON.stringify(part))).join(" ");
+}
+
+function runAddonPackageOperation(
+  action: "install" | "uninstall",
+  packs: ReadonlySet<ModulePackName>,
+  args: ParsedArgs,
+): AddonOperation {
+  const prefix = getAddonInstallPrefix(args.prefix);
+  const packages = action === "install" ? addonPackageSpecs(packs) : addonPackageNames(packs);
+  const npmArgs =
+    action === "install"
+      ? ["install", "--prefix", prefix, "--no-save", "--no-audit", "--no-fund", "--ignore-scripts", ...packages]
+      : ["uninstall", "--prefix", prefix, "--no-audit", "--no-fund", "--ignore-scripts", ...packages];
+  const operation: AddonOperation = {
+    action,
+    prefix,
+    packages,
+    command: ["npm", ...npmArgs],
+    skipped: packages.length === 0 || args.dryRun,
+  };
+
+  if (!operation.skipped) {
+    ensureAddonInstallProject(prefix);
+    execFileSync("npm", npmArgs, { stdio: args.json ? "pipe" : "inherit" });
+  }
+  return operation;
+}
+
+function statusPayload(config: Record<string, unknown>, prefix = getAddonInstallPrefix()) {
   const configured = process.env.AIRMCP_MODULE_PACKS !== undefined || config.modulePacks !== undefined;
   const packs = getModulePackStatuses(currentPackSet(config));
+  const installed = installedAddonPackages(prefix);
   return {
     configPath: PATHS.CONFIG,
     configured,
+    installPrefix: prefix,
     active: packs.filter((pack) => pack.available).map((pack) => pack.name),
-    packs,
+    packs: packs.map((pack) => ({
+      ...pack,
+      installed: installed.has(pack.name),
+      installSpec: pack.name === CORE_MODULE_PACK_NAME ? "airmcp" : `${pack.packageName}@${ROOT_VERSION}`,
+      installCommand: pack.name === CORE_MODULE_PACK_NAME ? null : `npx airmcp modules enable ${pack.name} --install`,
+      uninstallCommand: pack.name === CORE_MODULE_PACK_NAME ? null : `npx airmcp modules uninstall ${pack.name}`,
+    })),
   };
 }
 
@@ -99,10 +216,12 @@ function printList(payload: ReturnType<typeof statusPayload>): void {
   console.log("");
   for (const pack of payload.packs) {
     const state = pack.available ? `${GREEN}enabled${RESET}` : `${DIM}disabled${RESET}`;
+    const installState = pack.installed ? `${GREEN}installed${RESET}` : `${YELLOW}not installed${RESET}`;
     const required = pack.required ? ` ${DIM}(required)${RESET}` : "";
     console.log(`  ${state.padEnd(18)} ${CYAN}${pack.name}${RESET}${required}`);
-    console.log(`    ${DIM}${pack.packageName} · ${pack.modules.join(", ")}${RESET}`);
+    console.log(`    ${DIM}${pack.packageName} · ${installState} · ${pack.modules.join(", ")}${RESET}`);
   }
+  console.log(`  ${DIM}Install prefix: ${payload.installPrefix}${RESET}`);
   console.log("");
 }
 
@@ -114,8 +233,9 @@ function printDoctor(payload: ReturnType<typeof statusPayload>): void {
   );
   console.log(`    ${GREEN}ok${RESET} package names: add-ons omit pack-* naming`);
   console.log(`    ${GREEN}ok${RESET} package staging: npm run addons:build creates tarball-ready add-on directories`);
+  console.log(`    ${GREEN}ok${RESET} on-demand command: use --install/--uninstall to manage companion npm packages`);
   console.log(
-    `    ${YELLOW}wait${RESET} publish split: current npm package keeps bundled fallback until shipped-artifact checks cover add-ons`,
+    `    ${GREEN}ok${RESET} publish split: npm pack/publish ships a slim root and restores the universal local dist after packing`,
   );
   console.log("");
 }
@@ -127,6 +247,8 @@ function printHelp(): void {
   console.log(`    ${GREEN}$${RESET} npx airmcp ${BOLD}modules${RESET}`);
   console.log(`    ${GREEN}$${RESET} npx airmcp ${BOLD}modules list --json${RESET}`);
   console.log(`    ${GREEN}$${RESET} npx airmcp ${BOLD}modules enable productivity,communications${RESET}`);
+  console.log(`    ${GREEN}$${RESET} npx airmcp ${BOLD}modules enable productivity --install${RESET}`);
+  console.log(`    ${GREEN}$${RESET} npx airmcp ${BOLD}modules uninstall media${RESET}`);
   console.log(`    ${GREEN}$${RESET} npx airmcp ${BOLD}modules disable media${RESET}`);
   console.log(`    ${GREEN}$${RESET} npx airmcp ${BOLD}modules doctor${RESET}`);
   console.log("");
@@ -144,34 +266,49 @@ export async function runModules(): Promise<void> {
   }
 
   const config = readConfig();
-  if ((args.command === "enable" || args.command === "disable") && process.env.AIRMCP_MODULE_PACKS !== undefined) {
+  if (
+    ["enable", "disable", "install", "uninstall"].includes(args.command) &&
+    process.env.AIRMCP_MODULE_PACKS !== undefined
+  ) {
     console.error("AIRMCP_MODULE_PACKS is set; unset it before editing config.json with `airmcp modules`.");
     process.exitCode = 1;
     return;
   }
 
-  if (args.command === "enable") {
+  let operation: AddonOperation | undefined;
+  let plannedActive: ModulePackName[] | undefined;
+  if (args.command === "enable" || args.command === "install") {
     try {
+      const requested = packNamesFor(args.tokens);
+      if (args.install) operation = runAddonPackageOperation("install", requested, args);
       const next =
         config.modulePacks === undefined ? new Set<ModulePackName>([CORE_MODULE_PACK_NAME]) : currentPackSet(config);
-      for (const pack of packNamesFor(args.tokens)) next.add(pack);
+      for (const pack of requested) next.add(pack);
       next.add(CORE_MODULE_PACK_NAME);
-      config.modulePacks = sortedPackList(next);
-      writeConfig(config);
+      plannedActive = sortedPackList(next);
+      if (!args.dryRun) {
+        config.modulePacks = plannedActive;
+        writeConfig(config);
+      }
     } catch (error) {
       console.error(error instanceof Error ? error.message : String(error));
       process.exitCode = 1;
       return;
     }
-  } else if (args.command === "disable") {
+  } else if (args.command === "disable" || args.command === "uninstall") {
     try {
       const next = currentPackSet(config);
-      for (const pack of packNamesFor(args.tokens)) {
+      const requested = packNamesFor(args.tokens);
+      for (const pack of requested) {
         if (pack !== CORE_MODULE_PACK_NAME) next.delete(pack);
       }
       next.add(CORE_MODULE_PACK_NAME);
-      config.modulePacks = sortedPackList(next);
-      writeConfig(config);
+      plannedActive = sortedPackList(next);
+      if (!args.dryRun) {
+        config.modulePacks = plannedActive;
+        writeConfig(config);
+      }
+      if (args.uninstall) operation = runAddonPackageOperation("uninstall", requested, args);
     } catch (error) {
       console.error(error instanceof Error ? error.message : String(error));
       process.exitCode = 1;
@@ -179,12 +316,25 @@ export async function runModules(): Promise<void> {
     }
   }
 
-  const payload = statusPayload(config);
+  const payload = {
+    ...statusPayload(config, getAddonInstallPrefix(args.prefix)),
+    ...(plannedActive ? { plannedActive } : {}),
+    ...(operation ? { operation } : {}),
+  };
   if (args.json) {
     console.log(JSON.stringify(payload, null, 2));
   } else if (args.command === "doctor") {
     printDoctor(payload);
   } else {
+    if (operation) {
+      console.log("");
+      console.log(`  ${BOLD}${operation.action === "install" ? "Install" : "Uninstall"} command${RESET}`);
+      console.log(`    ${DIM}${formatShellCommand(operation.command)}${RESET}`);
+      if (operation.skipped) console.log(`    ${YELLOW}skipped${RESET} dry-run or no non-core add-ons selected`);
+    }
+    if (args.dryRun && plannedActive) {
+      console.log(`    ${DIM}planned active packs: ${plannedActive.join(", ")}${RESET}`);
+    }
     printList(payload);
   }
 }

--- a/src/server/mcp-setup.ts
+++ b/src/server/mcp-setup.ts
@@ -27,6 +27,8 @@ import {
   type AirMcpConfig,
 } from "../shared/config.js";
 import { getModulePackPlan, loadModuleRegistry, setModuleRegistry } from "../shared/modules.js";
+import { CORE_MODULE_PACK_NAME, MODULE_PACK_MANIFEST, getModulePackNameForModule } from "../shared/module-packs.js";
+import { getMissingAddonPackageModules } from "../shared/module-loader.js";
 import { resolveModuleCompatibility } from "../shared/compatibility.js";
 import { registerDynamicShortcutTools } from "../shortcuts/tools.js";
 import { HitlClient } from "../shared/hitl.js";
@@ -50,6 +52,29 @@ export interface CreateServerOptions {
   hitlClient: HitlClient | null;
   osVersion: number;
   pkg: { version: string; description?: string; license?: string; homepage?: string };
+}
+
+function buildMissingPackInstallHints(
+  modulesMissingPacks: string[],
+  missingAddonPackageModules: string[],
+  version: string,
+) {
+  const missingByPack = new Map<string, string[]>();
+  for (const moduleName of [...modulesMissingPacks, ...missingAddonPackageModules]) {
+    const packName = getModulePackNameForModule(moduleName);
+    if (!packName || packName === CORE_MODULE_PACK_NAME) continue;
+    const current = missingByPack.get(packName) ?? [];
+    if (!current.includes(moduleName)) current.push(moduleName);
+    missingByPack.set(packName, current);
+  }
+
+  return MODULE_PACK_MANIFEST.filter((pack) => missingByPack.has(pack.name)).map((pack) => ({
+    pack: pack.name,
+    packageName: pack.packageName,
+    installSpec: `${pack.packageName}@${version}`,
+    modules: missingByPack.get(pack.name) ?? [],
+    command: `npx airmcp modules enable ${pack.name} --install`,
+  }));
 }
 
 export async function createServer(
@@ -92,6 +117,12 @@ export async function createServer(
   const modulePackPlan = getModulePackPlan(config);
   const modulePacksAvailable = modulePackPlan.packs.filter((pack) => pack.available).map((pack) => pack.name);
   const modulesMissingPacks = modulePackPlan.modulesMissingPacks;
+  const missingAddonPackageModules = getMissingAddonPackageModules();
+  const missingPackInstallHints = buildMissingPackInstallHints(
+    modulesMissingPacks,
+    missingAddonPackageModules,
+    pkg.version,
+  );
 
   // RFC 0004: route every module through the compatibility resolver. The
   // resolver folds in minMacosVersion (legacy gate), maxMacosVersion, brokenOn,
@@ -224,6 +255,9 @@ export async function createServer(
             modules: z.array(z.string()),
             available: z.boolean(),
             required: z.boolean(),
+            installSpec: z.string().nullable(),
+            installCommand: z.string().nullable(),
+            uninstallCommand: z.string().nullable(),
           }),
         ),
       },
@@ -233,7 +267,13 @@ export async function createServer(
       return okStructured({
         configured: config.modulePacksConfigured,
         active: modulePacksAvailable,
-        packs: modulePackPlan.packs,
+        packs: modulePackPlan.packs.map((pack) => ({
+          ...pack,
+          installSpec: pack.name === CORE_MODULE_PACK_NAME ? null : `${pack.packageName}@${pkg.version}`,
+          installCommand:
+            pack.name === CORE_MODULE_PACK_NAME ? null : `npx airmcp modules enable ${pack.name} --install`,
+          uninstallCommand: pack.name === CORE_MODULE_PACK_NAME ? null : `npx airmcp modules uninstall ${pack.name}`,
+        })),
       });
     },
   );
@@ -253,6 +293,16 @@ export async function createServer(
         modulePacksConfigured: z.boolean(),
         modulePacksAvailable: z.array(z.string()),
         modulesMissingPacks: z.array(z.string()),
+        modulesMissingAddonPackages: z.array(z.string()),
+        missingPackInstallHints: z.array(
+          z.object({
+            pack: z.string(),
+            packageName: z.string(),
+            installSpec: z.string(),
+            modules: z.array(z.string()),
+            command: z.string(),
+          }),
+        ),
         requireToolSession: z.boolean(),
         harnessAdapter: z.string(),
         modulesEnabled: z.array(z.string()),
@@ -271,6 +321,8 @@ export async function createServer(
         modulePacksConfigured: config.modulePacksConfigured,
         modulePacksAvailable,
         modulesMissingPacks,
+        modulesMissingAddonPackages: missingAddonPackageModules,
+        missingPackInstallHints,
         requireToolSession: config.requireToolSession,
         harnessAdapter: harness.name,
         modulesEnabled: enabled,

--- a/src/shared/addon-packages.ts
+++ b/src/shared/addon-packages.ts
@@ -1,0 +1,34 @@
+import { createRequire } from "node:module";
+import { homedir } from "node:os";
+import { join, resolve } from "node:path";
+
+export const ADDON_INSTALL_PREFIX_ENV = "AIRMCP_ADDON_INSTALL_PREFIX";
+
+export function getDefaultAddonInstallPrefix(): string {
+  return join(homedir(), ".airmcp", "addons");
+}
+
+export function getAddonInstallPrefix(explicitPrefix?: string): string {
+  return resolve(explicitPrefix ?? process.env[ADDON_INSTALL_PREFIX_ENV] ?? getDefaultAddonInstallPrefix());
+}
+
+export function getAddonInstallPackageJsonPath(prefix = getAddonInstallPrefix()): string {
+  return join(prefix, "package.json");
+}
+
+export function getAddonPackageInstallPath(prefix: string, packageName: string): string {
+  if (packageName.startsWith("@")) {
+    const [scope, name] = packageName.split("/");
+    return join(prefix, "node_modules", scope!, name!);
+  }
+  return join(prefix, "node_modules", packageName);
+}
+
+export function resolveAddonPackageImport(spec: string): string | null {
+  const prefix = getAddonInstallPrefix();
+  try {
+    return createRequire(getAddonInstallPackageJsonPath(prefix)).resolve(spec);
+  } catch {
+    return null;
+  }
+}

--- a/src/shared/module-loader.ts
+++ b/src/shared/module-loader.ts
@@ -1,9 +1,13 @@
 import type { ModuleRegistration } from "./registry.js";
 import type { ModuleManifestEntry } from "./modules.js";
+import { pathToFileURL } from "node:url";
+import { resolveAddonPackageImport } from "./addon-packages.js";
 import { getModuleAddonImportSpec, getModulePackNameForModule } from "./module-packs.js";
 import { log, errToCtx } from "./logger.js";
 
 type AddonPackageMode = "prefer-installed" | "bundled" | "external-only";
+
+const missingAddonPackageModules = new Set<string>();
 
 function getAddonPackageMode(): AddonPackageMode {
   const raw = (process.env.AIRMCP_ADDON_PACKAGE_MODE ?? "prefer-installed").trim().toLowerCase();
@@ -16,6 +20,18 @@ function isOptionalPackageMiss(error: unknown): boolean {
   if (code === "ERR_MODULE_NOT_FOUND" || code === "MODULE_NOT_FOUND") return true;
   const message = error instanceof Error ? error.message : String(error);
   return message.includes("Cannot find package '@heznpc/airmcp-");
+}
+
+export function clearMissingAddonPackageModules(): void {
+  missingAddonPackageModules.clear();
+}
+
+export function getMissingAddonPackageModules(): string[] {
+  return [...missingAddonPackageModules].sort();
+}
+
+function rememberMissingAddonPackageModule(moduleName: string): void {
+  missingAddonPackageModules.add(moduleName);
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -42,12 +58,38 @@ async function importModuleFile(
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
 ): Promise<Record<string, any> | null> {
   const externalSpec = getModuleAddonImportSpec(def.name, kind);
+  let externalPackageMissing = false;
 
   if (externalSpec && mode !== "bundled") {
     try {
       return (await import(externalSpec)) as Record<string, unknown>;
     } catch (error) {
+      const resolvedFromPrefix = resolveAddonPackageImport(externalSpec);
+      if (resolvedFromPrefix) {
+        try {
+          return (await import(pathToFileURL(resolvedFromPrefix).href)) as Record<string, unknown>;
+        } catch (prefixError) {
+          if (mode === "external-only") {
+            log.error("required add-on package module failed to load", {
+              module: def.name,
+              kind,
+              spec: externalSpec,
+              resolved: resolvedFromPrefix,
+              err: errToCtx(prefixError),
+            });
+            return null;
+          }
+          log.warn("installed add-on package failed from configured prefix; falling back to bundled module", {
+            module: def.name,
+            kind,
+            spec: externalSpec,
+            resolved: resolvedFromPrefix,
+            err: errToCtx(prefixError),
+          });
+        }
+      }
       if (mode === "external-only") {
+        if (isOptionalPackageMiss(error)) rememberMissingAddonPackageModule(def.name);
         log.error("required add-on package module failed to load", {
           module: def.name,
           kind,
@@ -63,11 +105,18 @@ async function importModuleFile(
           spec: externalSpec,
           err: errToCtx(error),
         });
+      } else {
+        externalPackageMissing = true;
       }
     }
   }
 
-  return (await import(`../${def.name}/${kind}.js`)) as Record<string, unknown>;
+  try {
+    return (await import(`../${def.name}/${kind}.js`)) as Record<string, unknown>;
+  } catch (error) {
+    if (externalSpec && externalPackageMissing) rememberMissingAddonPackageModule(def.name);
+    throw error;
+  }
 }
 
 /** Import a single module definition, returning null on failure. */

--- a/src/shared/modules.ts
+++ b/src/shared/modules.ts
@@ -9,7 +9,7 @@ import {
   isModulePackAvailable,
   type ModulePackStatus,
 } from "./module-packs.js";
-import { importModuleRegistration } from "./module-loader.js";
+import { clearMissingAddonPackageModules, importModuleRegistration } from "./module-loader.js";
 
 /**
  * Module manifest — the single source of truth for all AirMCP modules.
@@ -158,6 +158,7 @@ export async function loadModuleRegistry(config?: AirMcpConfig): Promise<ModuleR
   const targets = getTargetManifestEntries(config, whitelist);
   const cacheKey = `${process.env.AIRMCP_ADDON_PACKAGE_MODE ?? "prefer-installed"}|${targets.map((m) => m.name).join(",")}`;
   if (cacheByKey.has(cacheKey)) return cacheByKey.get(cacheKey)!;
+  clearMissingAddonPackageModules();
 
   const sequential = process.env.AIRMCP_DEBUG_SEQUENTIAL === "true";
 

--- a/swift/Sources/AirMCPKit/Generated/MCPIntents.swift
+++ b/swift/Sources/AirMCPKit/Generated/MCPIntents.swift
@@ -501,6 +501,9 @@ public struct MCPListModulePacksOutput: Codable, Sendable {
         public let modules: [String]
         public let available: Bool
         public let required: Bool
+        public let installSpec: String?
+        public let installCommand: String?
+        public let uninstallCommand: String?
     }
 
     public let configured: Bool
@@ -786,11 +789,21 @@ public struct MCPProactiveContextOutput: Codable, Sendable {
 
 // Output type for: profile_status
 public struct MCPProfileStatusOutput: Codable, Sendable {
+    public struct MissingpackinstallhintsItem: Codable, Sendable {
+        public let pack: String
+        public let packageName: String
+        public let installSpec: String
+        public let modules: [String]
+        public let command: String
+    }
+
     public let profile: String
     public let toolExposure: String
     public let modulePacksConfigured: Bool
     public let modulePacksAvailable: [String]
     public let modulesMissingPacks: [String]
+    public let modulesMissingAddonPackages: [String]
+    public let missingPackInstallHints: [MissingpackinstallhintsItem]
     public let requireToolSession: Bool
     public let harnessAdapter: String
     public let modulesEnabled: [String]
@@ -9752,6 +9765,20 @@ public struct MCPProfileStatusSnippetView: View {
                 Text("Modules Missing Packs")
                 Spacer()
                 Text(String(describing: data.modulesMissingPacks))
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+            }
+            HStack {
+                Text("Modules Missing Addon Packages")
+                Spacer()
+                Text(String(describing: data.modulesMissingAddonPackages))
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+            }
+            HStack {
+                Text("Missing Pack Install Hints")
+                Spacer()
+                Text(String(describing: data.missingPackInstallHints))
                     .lineLimit(1)
                     .truncationMode(.tail)
             }

--- a/tests/app-addons-ui.test.js
+++ b/tests/app-addons-ui.test.js
@@ -1,0 +1,38 @@
+import { describe, expect, test } from "@jest/globals";
+import { readFileSync } from "node:fs";
+
+const menuContent = readFileSync(new URL("../app/Sources/AirMCPApp/Views/MenuContent.swift", import.meta.url), "utf8");
+const app = readFileSync(new URL("../app/Sources/AirMCPApp/AirMCPApp.swift", import.meta.url), "utf8");
+const addonManager = readFileSync(new URL("../app/Sources/AirMCPApp/AddonManager.swift", import.meta.url), "utf8");
+const enStrings = readFileSync(
+  new URL("../app/Sources/AirMCPApp/Resources/en.lproj/Localizable.strings", import.meta.url),
+  "utf8",
+);
+
+describe("AirMCP.app module add-on management", () => {
+  test("menubar app wires an add-on manager into MenuContent", () => {
+    expect(app).toContain("@State private var addonManager = AddonManager()");
+    expect(app).toContain("addonManager: addonManager");
+    expect(menuContent).toContain("let addonManager: AddonManager");
+  });
+
+  test("module menu exposes pack-level add-on controls", () => {
+    expect(menuContent).toContain('Menu(L("addons.menu"))');
+    expect(menuContent).toContain('Button(L("addons.install"))');
+    expect(menuContent).toContain('Button(L("addons.uninstall"))');
+    expect(menuContent).toContain('Button(L("addons.copyInstallCommand"))');
+    expect(menuContent).toContain("@heznpc/airmcp-productivity");
+    expect(menuContent).toContain("@heznpc/airmcp-spatial");
+  });
+
+  test("app install path invokes the pinned AirMCP package specifier", () => {
+    expect(addonManager).toContain("AirMcpConstants.npmPackageSpecifier");
+    expect(addonManager).toContain('"modules"');
+    expect(addonManager).toContain('"--install"');
+  });
+
+  test("localized strings cover the add-on controls", () => {
+    expect(enStrings).toContain('"addons.menu" = "Module Add-ons"');
+    expect(enStrings).toContain('"addon.spatial" = "Spatial"');
+  });
+});

--- a/tests/app-config-defaults.test.js
+++ b/tests/app-config-defaults.test.js
@@ -26,6 +26,8 @@ describe("AirMCP.app ConfigManager defaults", () => {
   test("preserves module pack activation written by the CLI", () => {
     expect(source).toMatch(/var modulePacks:\s*\[String\]\?/);
     expect(source).toMatch(/decodeIfPresent\(\[String\]\.self,\s*forKey:\s*\.modulePacks\)/);
+    expect(source).toContain('func setModulePack(_ pack: String, enabled: Bool)');
+    expect(source).toContain('"core"');
   });
 
   test("module toggles switch the JSON config to custom profile", () => {

--- a/tests/cli-modules.test.js
+++ b/tests/cli-modules.test.js
@@ -1,8 +1,10 @@
 import { describe, test, expect } from "@jest/globals";
 import { execFileSync } from "node:child_process";
-import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+
+const pkg = JSON.parse(readFileSync(new URL("../package.json", import.meta.url), "utf8"));
 
 function runModules(home, args) {
   return execFileSync(process.execPath, ["dist/index.js", "modules", ...args], {
@@ -53,6 +55,7 @@ describe("airmcp modules CLI", () => {
     try {
       const payload = JSON.parse(runModules(home, ["list", "--json"]));
       expect(payload.active).toContain("core");
+      expect(payload.installPrefix).toBe(join(home, ".airmcp", "addons"));
       expect(payload.packs.some((pack) => pack.packageName.includes("pack-"))).toBe(false);
       expect(payload.packs.find((pack) => pack.name === "productivity").packageName).toBe(
         "@heznpc/airmcp-productivity",
@@ -67,6 +70,42 @@ describe("airmcp modules CLI", () => {
     try {
       const payload = JSON.parse(runModules(home, ["enable", "productivity", "--json"]));
       expect(payload.active).toEqual(["core", "productivity"]);
+
+      const config = JSON.parse(readFileSync(join(home, ".config", "airmcp", "config.json"), "utf8"));
+      expect(config.modulePacks).toEqual(["core", "productivity"]);
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  test("enable --install dry-run plans companion package install before activation", () => {
+    const home = mkdtempSync(join(tmpdir(), "airmcp-modules-"));
+    try {
+      const payload = JSON.parse(runModules(home, ["enable", "productivity", "--install", "--dry-run", "--json"]));
+      expect(payload.plannedActive).toEqual(["core", "productivity"]);
+      expect(payload.operation.action).toBe("install");
+      expect(payload.operation.packages).toEqual([`@heznpc/airmcp-productivity@${pkg.version}`]);
+      expect(payload.operation.command).toEqual(
+        expect.arrayContaining(["npm", "install", "--no-save", `@heznpc/airmcp-productivity@${pkg.version}`]),
+      );
+      expect(existsSync(join(home, ".config", "airmcp", "config.json"))).toBe(false);
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  test("uninstall dry-run plans companion package removal without disabling the pack", () => {
+    const home = mkdtempSync(join(tmpdir(), "airmcp-modules-"));
+    try {
+      runModules(home, ["enable", "productivity", "--json"]);
+      const payload = JSON.parse(runModules(home, ["uninstall", "productivity", "--dry-run", "--json"]));
+      expect(payload.active).toEqual(["core", "productivity"]);
+      expect(payload.plannedActive).toEqual(["core"]);
+      expect(payload.operation.action).toBe("uninstall");
+      expect(payload.operation.packages).toEqual(["@heznpc/airmcp-productivity"]);
+      expect(payload.operation.command).toEqual(
+        expect.arrayContaining(["npm", "uninstall", "@heznpc/airmcp-productivity"]),
+      );
 
       const config = JSON.parse(readFileSync(join(home, ".config", "airmcp", "config.json"), "utf8"));
       expect(config.modulePacks).toEqual(["core", "productivity"]);

--- a/tests/mcp-setup.test.js
+++ b/tests/mcp-setup.test.js
@@ -74,25 +74,30 @@ jest.unstable_mockModule('@modelcontextprotocol/sdk/server/mcp.js', () => ({
 
 // loadModuleRegistry → fixture set per-test via this Jest mock.
 let fakeModuleRegistry = [];
+let fakeModulePackPlan = {
+  packs: [
+    {
+      name: 'core',
+      packageName: 'airmcp',
+      title: 'Core Workspace',
+      description: 'Core',
+      modules: ['notes'],
+      available: true,
+      required: true,
+    },
+  ],
+  modulesMissingPacks: [],
+};
+let fakeMissingAddonPackageModules = [];
 jest.unstable_mockModule('../dist/shared/modules.js', () => ({
   loadModuleRegistry: jest.fn(async () => fakeModuleRegistry),
-  getModulePackPlan: jest.fn(() => ({
-    packs: [
-      {
-        name: 'core',
-        packageName: 'airmcp',
-        title: 'Core Workspace',
-        description: 'Core',
-        modules: ['notes'],
-        available: true,
-        required: true,
-      },
-    ],
-    modulesMissingPacks: [],
-  })),
+  getModulePackPlan: jest.fn(() => fakeModulePackPlan),
   setModuleRegistry: jest.fn(),
   MODULE_REGISTRY: [],
   getModuleNames: jest.fn(() => fakeModuleRegistry.map((m) => m.name)),
+}));
+jest.unstable_mockModule('../dist/shared/module-loader.js', () => ({
+  getMissingAddonPackageModules: jest.fn(() => fakeMissingAddonPackageModules),
 }));
 
 // Compatibility resolver — drives the enabled / osBlocked / broken / deprecated
@@ -274,6 +279,21 @@ beforeEach(() => {
   hitlInstallCalls.length = 0;
   toolRegistryInstalled = false;
   fakeModuleRegistry = [];
+  fakeModulePackPlan = {
+    packs: [
+      {
+        name: 'core',
+        packageName: 'airmcp',
+        title: 'Core Workspace',
+        description: 'Core',
+        modules: ['notes'],
+        available: true,
+        required: true,
+      },
+    ],
+    modulesMissingPacks: [],
+  };
+  fakeMissingAddonPackageModules = [];
   resolveCompatImpl = () => ({ decision: 'register-clean', reason: '' });
 });
 
@@ -495,5 +515,114 @@ describe('createServer — installation order invariant', () => {
     }
     expect(hitlInstallCalls).toHaveLength(1);
     expect(hitlInstallCalls[0].serverPresent).toBe(true);
+  });
+});
+
+describe('createServer — module add-on install hints', () => {
+  test('profile_status and list_module_packs expose on-demand install commands for missing packs', async () => {
+    fakeModuleRegistry = [{ name: 'notes', tools: () => {} }];
+    fakeModulePackPlan = {
+      packs: [
+        {
+          name: 'core',
+          packageName: 'airmcp',
+          title: 'Core Workspace',
+          description: 'Core',
+          modules: ['notes'],
+          available: true,
+          required: true,
+        },
+        {
+          name: 'productivity',
+          packageName: '@heznpc/airmcp-productivity',
+          title: 'Productivity',
+          description: 'iWork',
+          modules: ['pages', 'numbers', 'keynote'],
+          available: false,
+          required: false,
+        },
+      ],
+      modulesMissingPacks: ['pages', 'numbers'],
+    };
+
+    const origError = console.error;
+    console.error = () => {};
+    try {
+      await createServer(mkOptions({ pkg: { ...mkPkg(), version: '2.15.0' } }));
+    } finally {
+      console.error = origError;
+    }
+
+    const statusTool = sdkRegisterToolCalls.find((call) => call.name === 'profile_status');
+    const packsTool = sdkRegisterToolCalls.find((call) => call.name === 'list_module_packs');
+    const status = await statusTool.cb();
+    const packs = await packsTool.cb();
+
+    expect(status.structuredContent.missingPackInstallHints).toEqual([
+      {
+        pack: 'productivity',
+        packageName: '@heznpc/airmcp-productivity',
+        installSpec: '@heznpc/airmcp-productivity@2.15.0',
+        modules: ['pages', 'numbers'],
+        command: 'npx airmcp modules enable productivity --install',
+      },
+    ]);
+    expect(status.structuredContent.modulesMissingAddonPackages).toEqual([]);
+    expect(packs.structuredContent.packs.find((pack) => pack.name === 'productivity')).toMatchObject({
+      installSpec: '@heznpc/airmcp-productivity@2.15.0',
+      installCommand: 'npx airmcp modules enable productivity --install',
+      uninstallCommand: 'npx airmcp modules uninstall productivity',
+    });
+  });
+
+  test('profile_status folds physically missing add-on packages into install hints', async () => {
+    fakeModuleRegistry = [{ name: 'notes', tools: () => {} }];
+    fakeModulePackPlan = {
+      packs: [
+        {
+          name: 'core',
+          packageName: 'airmcp',
+          title: 'Core Workspace',
+          description: 'Core',
+          modules: ['notes'],
+          available: true,
+          required: true,
+        },
+        {
+          name: 'productivity',
+          packageName: '@heznpc/airmcp-productivity',
+          title: 'Productivity',
+          description: 'iWork',
+          modules: ['pages', 'numbers', 'keynote'],
+          available: true,
+          required: false,
+        },
+      ],
+      modulesMissingPacks: [],
+    };
+    fakeMissingAddonPackageModules = ['pages'];
+
+    const origError = console.error;
+    console.error = () => {};
+    try {
+      await createServer(mkOptions({ pkg: { ...mkPkg(), version: '2.15.0' } }));
+    } finally {
+      console.error = origError;
+    }
+
+    const statusTool = sdkRegisterToolCalls.find((call) => call.name === 'profile_status');
+    const status = await statusTool.cb();
+
+    expect(status.structuredContent.modulesMissingPacks).toEqual([]);
+    expect(status.structuredContent.modulesMissingAddonPackages).toEqual(['pages']);
+    expect(status.structuredContent.missingPackInstallHints).toEqual([
+      {
+        pack: 'productivity',
+        packageName: '@heznpc/airmcp-productivity',
+        installSpec: '@heznpc/airmcp-productivity@2.15.0',
+        modules: ['pages'],
+        command: 'npx airmcp modules enable productivity --install',
+      },
+    ]);
   });
 });

--- a/tests/modules.test.js
+++ b/tests/modules.test.js
@@ -122,11 +122,13 @@ describe('loadModuleRegistry() — debug filtering', () => {
   let savedDebugModules;
   let savedDebugSequential;
   let savedAddonPackageMode;
+  let savedAddonInstallPrefix;
 
   beforeEach(() => {
     savedDebugModules = process.env.AIRMCP_DEBUG_MODULES;
     savedDebugSequential = process.env.AIRMCP_DEBUG_SEQUENTIAL;
     savedAddonPackageMode = process.env.AIRMCP_ADDON_PACKAGE_MODE;
+    savedAddonInstallPrefix = process.env.AIRMCP_ADDON_INSTALL_PREFIX;
   });
 
   afterEach(() => {
@@ -136,6 +138,8 @@ describe('loadModuleRegistry() — debug filtering', () => {
     else process.env.AIRMCP_DEBUG_SEQUENTIAL = savedDebugSequential;
     if (savedAddonPackageMode === undefined) delete process.env.AIRMCP_ADDON_PACKAGE_MODE;
     else process.env.AIRMCP_ADDON_PACKAGE_MODE = savedAddonPackageMode;
+    if (savedAddonInstallPrefix === undefined) delete process.env.AIRMCP_ADDON_INSTALL_PREFIX;
+    else process.env.AIRMCP_ADDON_INSTALL_PREFIX = savedAddonInstallPrefix;
   });
 
   test('AIRMCP_DEBUG_MODULES filters to only specified modules', async () => {
@@ -231,11 +235,13 @@ describe('loadModuleRegistry() — debug filtering', () => {
   test('loadModuleRegistry external-only mode refuses missing add-on packages', async () => {
     process.env.AIRMCP_DEBUG_MODULES = 'pages';
     process.env.AIRMCP_ADDON_PACKAGE_MODE = 'external-only';
+    process.env.AIRMCP_ADDON_INSTALL_PREFIX = '/tmp/airmcp-missing-addon-prefix';
     delete process.env.AIRMCP_DEBUG_SEQUENTIAL;
 
     const { loadModuleRegistry } = await import(
       `../dist/shared/modules.js?t=${Date.now()}${Math.random()}`
     );
+    const { getMissingAddonPackageModules } = await import('../dist/shared/module-loader.js');
 
     const errors = [];
     const origError = console.error;
@@ -262,6 +268,7 @@ describe('loadModuleRegistry() — debug filtering', () => {
 
       expect(registry.some((mod) => mod.name === 'pages')).toBe(false);
       expect(errors.some((line) => line.includes('required add-on package module failed to load'))).toBe(true);
+      expect(getMissingAddonPackageModules()).toContain('pages');
     } finally {
       console.error = origError;
     }


### PR DESCRIPTION
## Summary
- add on-demand module add-on install/uninstall CLI flow with persistent user-level add-on prefix and dry-run planning
- surface missing add-on install hints over MCP and add AirMCP.app add-on management UI
- make npm/MCPB release artifacts use slim root packaging and gate all staged add-ons in CI/preflight

## Verification
- npm test
- npm run release:preflight
- npm run app-build
- swift test
- npm run typecheck
- npm run lint
- npm run gen:manifest:check
- npm run gen:intents:check
- npm run version:check
- npm run stats:check