### PR TITLE
feat(addons): harden release add-on UX

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -59,22 +59,15 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Build
-        run: npm run build
+      - name: Release preflight
+        run: npm run release:preflight
 
-      - name: Verify package contents
-        run: |
-          PACK_OUT=$(npm pack --dry-run 2>&1)
-          echo "$PACK_OUT"
-          if echo "$PACK_OUT" | grep -Ev '\.d\.ts$' | grep -qE '\.(map|ts|env|token)$'; then
-            echo "::error::Unexpected files detected in package (source maps, .ts, .env, or token files)!"
-            exit 1
-          fi
+      - name: Publish add-ons with provenance
+        run: npm run addons:publish -- --publish --all --no-build --skip-verify
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
-      - name: Build .mcpb Desktop Extension
-        run: npm run build:mcpb
-
-      - name: Publish with provenance
+      - name: Publish root with provenance
         run: npm publish --provenance --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
@@ -85,7 +78,7 @@ jobs:
           tag_name: v${{ steps.pkg.outputs.version }}
           name: v${{ steps.pkg.outputs.version }}
           generate_release_notes: true
-          files: build/mcpb/airmcp-${{ steps.pkg.outputs.version }}.mcpb
+          files: build/release-preflight/airmcp-${{ steps.pkg.outputs.version }}.mcpb
           fail_on_unmatched_files: true
 
       - name: Verify public release state

--- a/app/Sources/AirMCPApp/AddonManager.swift
+++ b/app/Sources/AirMCPApp/AddonManager.swift
@@ -15,7 +15,18 @@ final class AddonManager {
         case failure(String)
     }
 
+    private struct ModulesListPayload: Decodable {
+        let packs: [PackStatus]
+    }
+
+    private struct PackStatus: Decodable {
+        let name: String
+        let installed: Bool
+    }
+
     var state: State = .idle
+    var installedPacks: Set<String> = ["core"]
+    var hasLoadedInstallStatus = false
 
     var isRunning: Bool {
         if case .running = state { return true }
@@ -26,8 +37,8 @@ final class AddonManager {
         switch state {
         case .idle:
             return nil
-        case .running(let pack):
-            return L("addons.installing", pack)
+        case .running(let message):
+            return message
         case .done(let message):
             return message
         case .failed(let message):
@@ -43,13 +54,30 @@ final class AddonManager {
         run(action: "uninstall", pack: pack, flag: nil, configManager: configManager)
     }
 
+    func refresh() {
+        guard !isRunning else { return }
+        state = .running(L("addons.refreshing"))
+
+        Task {
+            if let message = await loadInstalledPacks() {
+                state = .failed(message)
+            } else {
+                state = .done(L("addons.statusUpdated"))
+            }
+        }
+    }
+
+    func isInstalled(pack: String) -> Bool {
+        pack == "core" || installedPacks.contains(pack)
+    }
+
     func reset() {
         state = .idle
     }
 
     private func run(action: String, pack: String, flag: String?, configManager: ConfigManager) {
         guard !isRunning else { return }
-        state = .running(pack)
+        state = .running(L("addons.installing", pack))
 
         var args = ["modules", action, pack]
         if let flag {
@@ -61,10 +89,30 @@ final class AddonManager {
             switch result {
             case .success:
                 configManager.load()
+                _ = await loadInstalledPacks()
                 state = .done(L("addons.doneRestart"))
             case .failure(let message):
                 state = .failed(message)
             }
+        }
+    }
+
+    private func loadInstalledPacks() async -> String? {
+        let result = await Self.runAirMcp(["modules", "list", "--json"])
+        switch result {
+        case .success(let output):
+            do {
+                let payload = try JSONDecoder().decode(ModulesListPayload.self, from: Data(output.utf8))
+                var next = Set(payload.packs.filter(\.installed).map(\.name))
+                next.insert("core")
+                installedPacks = next
+                hasLoadedInstallStatus = true
+                return nil
+            } catch {
+                return error.localizedDescription
+            }
+        case .failure(let message):
+            return message
         }
     }
 

--- a/app/Sources/AirMCPApp/Resources/en.lproj/Localizable.strings
+++ b/app/Sources/AirMCPApp/Resources/en.lproj/Localizable.strings
@@ -172,10 +172,17 @@
 
 /* Module Add-ons */
 "addons.active" = "Active";
+"addons.refresh" = "Refresh Add-on Status";
 "addons.install" = "Install and Activate";
 "addons.uninstall" = "Uninstall";
 "addons.copyInstallCommand" = "Copy Install Command";
 "addons.installing" = "Installing %@...";
+"addons.refreshing" = "Refreshing add-on status...";
+"addons.statusUpdated" = "Add-on status refreshed.";
+"addons.statusUnknown" = "Install status not checked";
+"addons.installed" = "Installed";
+"addons.notInstalled" = "Not installed";
+"addons.activeButMissing" = "Active but not installed";
 "addons.doneRestart" = "Add-on updated. Restart server to apply.";
 "addons.failed" = "Add-on failed: %@";
 "addon.core" = "Core Workspace";

--- a/app/Sources/AirMCPApp/Resources/ko.lproj/Localizable.strings
+++ b/app/Sources/AirMCPApp/Resources/ko.lproj/Localizable.strings
@@ -172,10 +172,17 @@
 
 /* Module Add-ons */
 "addons.active" = "활성화";
+"addons.refresh" = "애드온 상태 새로고침";
 "addons.install" = "설치 및 활성화";
 "addons.uninstall" = "제거";
 "addons.copyInstallCommand" = "설치 명령 복사";
 "addons.installing" = "%@ 설치 중...";
+"addons.refreshing" = "애드온 상태 확인 중...";
+"addons.statusUpdated" = "애드온 상태를 새로고침했습니다.";
+"addons.statusUnknown" = "설치 상태 미확인";
+"addons.installed" = "설치됨";
+"addons.notInstalled" = "미설치";
+"addons.activeButMissing" = "활성화되었지만 미설치";
 "addons.doneRestart" = "애드온이 업데이트되었습니다. 서버를 재시작하면 반영됩니다.";
 "addons.failed" = "애드온 실패: %@";
 "addon.core" = "Core Workspace";

--- a/app/Sources/AirMCPApp/Views/MenuContent.swift
+++ b/app/Sources/AirMCPApp/Views/MenuContent.swift
@@ -602,6 +602,13 @@ struct MenuContent: View {
                 Divider()
             }
 
+            Button(L("addons.refresh")) {
+                addonManager.refresh()
+            }
+            .disabled(addonManager.isRunning)
+
+            Divider()
+
             ForEach(allModulePacks) { pack in
                 addOnMenu(for: pack)
             }
@@ -617,6 +624,8 @@ struct MenuContent: View {
     @ViewBuilder
     private func addOnMenu(for pack: ModulePackInfo) -> some View {
         let isActive = configManager.modulePacks.contains(pack.id)
+        let isInstalled = addonManager.isInstalled(pack: pack.id)
+        let isActiveButMissing = isActive && !isInstalled
 
         Menu {
             Text(pack.localizedDescription)
@@ -626,6 +635,11 @@ struct MenuContent: View {
             Text(pack.packageName)
                 .font(.caption)
                 .foregroundStyle(.secondary)
+
+            Label(
+                addonInstallStatusText(isInstalled: isInstalled, isActiveButMissing: isActiveButMissing),
+                systemImage: addonInstallStatusIcon(isInstalled: isInstalled, isActiveButMissing: isActiveButMissing)
+            )
 
             Divider()
 
@@ -646,15 +660,45 @@ struct MenuContent: View {
                 Button(L("addons.uninstall")) {
                     addonManager.uninstall(pack: pack.id, configManager: configManager)
                 }
-                .disabled(addonManager.isRunning)
+                .disabled(addonManager.isRunning || !isInstalled)
 
                 Button(L("addons.copyInstallCommand")) {
                     AirMcpConstants.copyToClipboard(pack.installCommand)
                 }
             }
         } label: {
-            Label(pack.localizedTitle, systemImage: isActive ? "checkmark.circle" : pack.icon)
+            Label(pack.localizedTitle, systemImage: addOnMenuIcon(pack: pack, isActive: isActive, isInstalled: isInstalled))
         }
+    }
+
+    private func addOnMenuIcon(pack: ModulePackInfo, isActive: Bool, isInstalled: Bool) -> String {
+        if isActive && !isInstalled {
+            return "exclamationmark.triangle"
+        }
+        if isActive {
+            return "checkmark.circle"
+        }
+        return pack.icon
+    }
+
+    private func addonInstallStatusText(isInstalled: Bool, isActiveButMissing: Bool) -> String {
+        if !addonManager.hasLoadedInstallStatus {
+            return L("addons.statusUnknown")
+        }
+        if isActiveButMissing {
+            return L("addons.activeButMissing")
+        }
+        return L(isInstalled ? "addons.installed" : "addons.notInstalled")
+    }
+
+    private func addonInstallStatusIcon(isInstalled: Bool, isActiveButMissing: Bool) -> String {
+        if !addonManager.hasLoadedInstallStatus {
+            return "questionmark.circle"
+        }
+        if isActiveButMissing {
+            return "exclamationmark.triangle"
+        }
+        return isInstalled ? "checkmark.seal" : "icloud.and.arrow.down"
     }
 
     private var addonStatusIcon: String {

--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -108,9 +108,10 @@ Breaking을 포함한 minor/patch는 **금지**. 직전 메이저에 묶어 둘 
 - [ ] `ci.yml` 전 단계 green
 - [ ] CodeQL·Scorecard 경고 신규 없음
 
-### 3.4 npm publish + .mcpb → GitHub Release
-- [ ] CD workflow(`cd.yml`) 자동 트리거 확인, 또는 수동 `npm publish --provenance`
+### 3.4 add-on publish + root npm publish + .mcpb → GitHub Release
+- [ ] CD workflow(`cd.yml`) 자동 트리거 확인. 수동 실행 시 `npm run release:preflight` 이후 `npm run addons:publish -- --publish --all --no-build --skip-verify`를 먼저 실행하고, 그 다음 root `npm publish --provenance --access public`을 실행한다.
 - [ ] `NPM_TOKEN`을 쓰는 경우 `npm whoami`가 통과하고 해당 토큰이 `airmcp` publish 권한을 가진 automation/granular token인지 확인. 토큰이 비어 있으면 npm trusted publishing이 GitHub environment `npm` + 이 workflow에 설정되어 있어야 한다.
+- [ ] `npm view @heznpc/airmcp-productivity@X.Y.Z` 등 add-on package가 같은 버전으로 반영됐는지 확인
 - [ ] `npm view airmcp@X.Y.Z` 로 반영 검증
 - [ ] `npx -y airmcp@X.Y.Z --version` 스모크
 - [ ] Release에 `airmcp-X.Y.Z.mcpb`가 첨부되어 있는지 확인 (Claude Desktop 원클릭 설치용)

--- a/docs/environment.md
+++ b/docs/environment.md
@@ -226,7 +226,7 @@ Built-in packs:
 - `google-workspace`: Google Workspace
 - `spatial`: experimental spatial prep
 
-Use `npx airmcp modules list` locally or `list_module_packs` over MCP to inspect the active pack set, package names, and install commands. Use `npx airmcp modules enable productivity,communications` to write a narrow `modulePacks` config, or add `--install` when the physical companion package should be installed on demand. `profile_status` also reports `modulePacksConfigured`, `modulePacksAvailable`, `modulesMissingPacks`, `modulesMissingAddonPackages`, and `missingPackInstallHints` so a client can prompt for the exact add-on install command when a requested profile is missing a pack or a slim-root runtime cannot find the package.
+Use `npx airmcp modules list` locally or `list_module_packs` over MCP to inspect the active pack set, package names, and install commands. Use `npx airmcp modules enable productivity,communications` to write a narrow `modulePacks` config, or add `--install` when the physical companion package should be installed on demand. `profile_status` also reports `modulePacksConfigured`, `modulePacksAvailable`, `modulesMissingPacks`, `modulesMissingAddonPackages`, and `missingPackInstallHints` so a client can prompt for the exact add-on install command when a requested profile is missing a pack or a slim-root runtime cannot find the package. Each install hint includes a human-readable `message` field for clients that want to show a direct install prompt instead of constructing copy from the raw command fields.
 
 ---
 

--- a/docs/rfc/0015-modular-install-and-task-harness.md
+++ b/docs/rfc/0015-modular-install-and-task-harness.md
@@ -44,7 +44,8 @@ The third shipped slice is physical package split:
 - `AIRMCP_ADDON_PACKAGE_MODE=prefer-installed` tries an installed add-on package from normal package resolution and `AIRMCP_ADDON_INSTALL_PREFIX` before bundled fallback,
 - `AIRMCP_ADDON_PACKAGE_MODE=external-only` turns missing add-ons into module-load failures outside `core`,
 - `npm pack` / `npm publish` prepack builds a slim root artifact and postpack restores the universal local `dist`,
-- `npm run addons:check` is wired into CI and `release:preflight`.
+- `npm run addons:check` is wired into CI and `release:preflight`,
+- `npm run addons:publish` dry-runs by default and only publishes staged add-ons when `--publish` is explicit.
 
 ## Implemented install split
 
@@ -68,7 +69,7 @@ Release artifacts now use a slim root by default while the source checkout keeps
 - `npm run addons:measure-split` packs the universal local build with lifecycle scripts disabled, compares it with slim-root plus selected add-ons, and records packed/unpacked/install-size plus startup/list timing deltas.
 - `npm pack --dry-run --json` must include `dist/.airmcp-slim-root.json` and must not include non-core module `tools.js` / `prompts.js` entrypoints.
 - `.mcpb` release artifacts must include the same slim-root marker and must not leak non-core module entrypoints.
-- `list_module_packs`, `profile_status.modulesMissingPacks`, `profile_status.modulesMissingAddonPackages`, and `profile_status.missingPackInstallHints` remain stable public truth surfaces.
+- `list_module_packs`, `profile_status.modulesMissingPacks`, `profile_status.modulesMissingAddonPackages`, and `profile_status.missingPackInstallHints` remain stable public truth surfaces, including a human-readable install prompt message for missing add-ons.
 - At least one real user/workflow needs a smaller install, not only a smaller context window.
 - Pack boundaries have tests proving no profile loads a missing optional module by accident.
 

--- a/docs/tool-manifest.json
+++ b/docs/tool-manifest.json
@@ -9504,6 +9504,9 @@
                 },
                 "command": {
                   "type": "string"
+                },
+                "message": {
+                  "type": "string"
                 }
               },
               "required": [
@@ -9511,7 +9514,8 @@
                 "packageName",
                 "installSpec",
                 "modules",
-                "command"
+                "command",
+                "message"
               ],
               "additionalProperties": false
             }

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "addons:check": "node scripts/build-addon-packages.mjs --check",
     "addons:verify-install": "node scripts/verify-addon-install.mjs",
     "addons:measure-split": "node scripts/measure-addon-split.mjs",
+    "addons:publish": "node scripts/publish-addon-packages.mjs",
     "swift-build": "cd swift && swift build -c release",
     "app-build": "cd app && swift build -c release",
     "app:run": "./scripts/bundle-app.sh run",

--- a/scripts/build-addon-packages.mjs
+++ b/scripts/build-addon-packages.mjs
@@ -111,6 +111,12 @@ function makePackageJson(rootPkg, pack) {
   if (pack.packageName.includes("pack-") || pack.packageName.includes("-pack")) {
     fail(`${pack.name} package name must not contain pack-* wording: ${pack.packageName}`);
   }
+  const repository =
+    rootPkg.repository?.type === "git" &&
+    typeof rootPkg.repository.url === "string" &&
+    rootPkg.repository.url.startsWith("https://")
+      ? { ...rootPkg.repository, url: `git+${rootPkg.repository.url}` }
+      : rootPkg.repository;
   return {
     name: pack.packageName,
     version: rootPkg.version,
@@ -118,7 +124,7 @@ function makePackageJson(rootPkg, pack) {
     keywords: ["airmcp", "mcp", "macos", "module-addon", pack.name],
     homepage: rootPkg.homepage,
     bugs: rootPkg.bugs,
-    repository: rootPkg.repository,
+    repository,
     license: rootPkg.license,
     author: rootPkg.author,
     type: "module",

--- a/scripts/publish-addon-packages.mjs
+++ b/scripts/publish-addon-packages.mjs
@@ -1,0 +1,202 @@
+#!/usr/bin/env node
+/**
+ * Publish staged AirMCP add-on packages.
+ *
+ * The default mode is a dry-run. A real publish requires `--publish`, and the
+ * script always stages packages plus clean-installs them before publish unless
+ * the caller explicitly skips those gates.
+ */
+
+import { existsSync, readFileSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const MANIFEST_PATH = join(ROOT, "build", "addons", "manifest.json");
+
+function fail(message) {
+  console.error(`[addons:publish] FAIL — ${message}`);
+  process.exit(1);
+}
+
+function readJson(path) {
+  return JSON.parse(readFileSync(path, "utf8"));
+}
+
+function run(cmd, args, options = {}) {
+  const result = spawnSync(cmd, args, {
+    cwd: ROOT,
+    env: process.env,
+    encoding: "utf8",
+    stdio: "inherit",
+    maxBuffer: 64 * 1024 * 1024,
+    ...options,
+  });
+  if (result.status !== 0) {
+    fail(`command failed (${result.status ?? "signal"}): ${cmd} ${args.join(" ")}`);
+  }
+}
+
+function parseList(value) {
+  return value
+    .split(",")
+    .map((item) => item.trim())
+    .filter(Boolean);
+}
+
+function parseArgs(argv) {
+  const parsed = {
+    publish: false,
+    noBuild: false,
+    skipVerify: false,
+    tag: "latest",
+    access: "public",
+    provenance: true,
+    packs: [],
+  };
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === "--publish") {
+      parsed.publish = true;
+    } else if (arg === "--dry-run") {
+      parsed.publish = false;
+    } else if (arg === "--no-build") {
+      parsed.noBuild = true;
+    } else if (arg === "--skip-verify") {
+      parsed.skipVerify = true;
+    } else if (arg === "--no-provenance") {
+      parsed.provenance = false;
+    } else if (arg === "--all") {
+      parsed.packs = [];
+    } else if (arg === "--pack") {
+      const value = argv[i + 1];
+      if (!value) fail("--pack requires a pack name");
+      parsed.packs.push(...parseList(value));
+      i += 1;
+    } else if (arg.startsWith("--pack=")) {
+      parsed.packs.push(...parseList(arg.slice("--pack=".length)));
+    } else if (arg === "--tag") {
+      const value = argv[i + 1];
+      if (!value) fail("--tag requires a value");
+      parsed.tag = value;
+      i += 1;
+    } else if (arg.startsWith("--tag=")) {
+      parsed.tag = arg.slice("--tag=".length);
+    } else if (arg === "--access") {
+      const value = argv[i + 1];
+      if (!value) fail("--access requires a value");
+      parsed.access = value;
+      i += 1;
+    } else if (arg.startsWith("--access=")) {
+      parsed.access = arg.slice("--access=".length);
+    } else if (arg === "--help" || arg === "-h") {
+      console.log("");
+      console.log("  AirMCP add-on publish");
+      console.log("");
+      console.log("    npm run addons:publish");
+      console.log("    npm run addons:publish -- --pack productivity");
+      console.log("    npm run addons:publish -- --publish --all");
+      console.log("");
+      process.exit(0);
+    } else {
+      fail(`unknown argument: ${arg}`);
+    }
+  }
+
+  return parsed;
+}
+
+function packageDirName(packageName) {
+  return packageName.replace(/^@/, "").replace("/", "__");
+}
+
+function loadManifest() {
+  if (!existsSync(MANIFEST_PATH)) {
+    fail("build/addons/manifest.json missing; run `npm run addons:build` first");
+  }
+  const manifest = readJson(MANIFEST_PATH);
+  if (!Array.isArray(manifest.packages) || manifest.packages.length === 0) {
+    fail("build/addons/manifest.json has no staged packages");
+  }
+  return manifest;
+}
+
+function selectPackages(manifest, requestedPacks) {
+  if (!requestedPacks.length) return manifest.packages;
+  const requested = new Set(requestedPacks);
+  const selected = manifest.packages.filter((pack) => requested.has(pack.name));
+  const missing = [...requested].filter((name) => !selected.some((pack) => pack.name === name));
+  if (missing.length) fail(`unknown or unstaged add-on pack(s): ${missing.join(", ")}`);
+  return selected;
+}
+
+function verifyStagedPackage(manifest, pack) {
+  const packageRoot = join(ROOT, pack.packageDir ?? "build/addons", "");
+  const packageJsonPath = join(packageRoot, "package.json");
+  if (!existsSync(packageJsonPath)) fail(`${pack.name} package.json missing: ${packageJsonPath}`);
+  const pkg = readJson(packageJsonPath);
+  if (pkg.name !== pack.packageName) fail(`${pack.name} package name mismatch: ${pkg.name} != ${pack.packageName}`);
+  if (pkg.version !== manifest.version) fail(`${pack.name} version mismatch: ${pkg.version} != ${manifest.version}`);
+  if (String(pkg.name).includes("pack-") || String(pkg.name).includes("-pack")) {
+    fail(`${pack.name} package name must not contain pack-* wording: ${pkg.name}`);
+  }
+  if (pkg.peerDependencies?.airmcp !== manifest.version) {
+    fail(`${pack.name} peerDependency must pin airmcp@${manifest.version}`);
+  }
+  if (!existsSync(join(packageRoot, "dist", "index.js"))) {
+    fail(`${pack.name} missing dist/index.js`);
+  }
+  return packageRoot;
+}
+
+function verifyPackageDirFallback(pack) {
+  return join(ROOT, "build", "addons", packageDirName(pack.packageName), "package");
+}
+
+function publishPackage({ packageRoot, pack, args }) {
+  const npmArgs = ["publish", "--access", args.access, "--tag", args.tag];
+  if (!args.publish) npmArgs.push("--dry-run");
+  if (args.publish && args.provenance) npmArgs.push("--provenance");
+
+  console.log(`[addons:publish] ${args.publish ? "publish" : "dry-run"} ${pack.packageName}`);
+  run("npm", npmArgs, { cwd: packageRoot });
+}
+
+function main() {
+  const args = parseArgs(process.argv.slice(2));
+
+  if (!args.noBuild) {
+    run("npm", ["run", "build"]);
+    run(process.execPath, ["scripts/build-addon-packages.mjs", "--check"]);
+  } else if (!existsSync(MANIFEST_PATH)) {
+    fail("cannot use --no-build without build/addons/manifest.json");
+  }
+
+  const manifest = loadManifest();
+  const selected = selectPackages(manifest, args.packs);
+  if (!selected.length) fail("no add-on packages selected");
+
+  if (!args.skipVerify) {
+    const verifyArgs = args.packs.length
+      ? ["run", "addons:verify-install", "--", ...args.packs.flatMap((pack) => ["--pack", pack])]
+      : ["run", "addons:verify-install", "--", "--all"];
+    run("npm", verifyArgs);
+  }
+
+  console.log(
+    `[addons:publish] mode=${args.publish ? "publish" : "dry-run"} version=${manifest.version} tag=${args.tag}`,
+  );
+  console.log(`[addons:publish] packages=${selected.map((pack) => pack.packageName).join(", ")}`);
+
+  for (const pack of selected) {
+    let packageRoot = verifyStagedPackage(manifest, pack);
+    if (!existsSync(packageRoot)) packageRoot = verifyPackageDirFallback(pack);
+    publishPackage({ packageRoot, pack, args });
+  }
+
+  console.log(`ok: ${args.publish ? "published" : "dry-run checked"} ${selected.length} add-on package(s)`);
+}
+
+main();

--- a/src/server/mcp-setup.ts
+++ b/src/server/mcp-setup.ts
@@ -68,13 +68,18 @@ function buildMissingPackInstallHints(
     missingByPack.set(packName, current);
   }
 
-  return MODULE_PACK_MANIFEST.filter((pack) => missingByPack.has(pack.name)).map((pack) => ({
-    pack: pack.name,
-    packageName: pack.packageName,
-    installSpec: `${pack.packageName}@${version}`,
-    modules: missingByPack.get(pack.name) ?? [],
-    command: `npx airmcp modules enable ${pack.name} --install`,
-  }));
+  return MODULE_PACK_MANIFEST.filter((pack) => missingByPack.has(pack.name)).map((pack) => {
+    const modules = missingByPack.get(pack.name) ?? [];
+    const command = `npx airmcp modules enable ${pack.name} --install`;
+    return {
+      pack: pack.name,
+      packageName: pack.packageName,
+      installSpec: `${pack.packageName}@${version}`,
+      modules,
+      command,
+      message: `Install and activate the ${pack.name} add-on to use ${modules.join(", ")}: ${command}. Restart AirMCP after installation.`,
+    };
+  });
 }
 
 export async function createServer(
@@ -301,6 +306,7 @@ export async function createServer(
             installSpec: z.string(),
             modules: z.array(z.string()),
             command: z.string(),
+            message: z.string(),
           }),
         ),
         requireToolSession: z.boolean(),

--- a/swift/Sources/AirMCPKit/Generated/MCPIntents.swift
+++ b/swift/Sources/AirMCPKit/Generated/MCPIntents.swift
@@ -795,6 +795,7 @@ public struct MCPProfileStatusOutput: Codable, Sendable {
         public let installSpec: String
         public let modules: [String]
         public let command: String
+        public let message: String
     }
 
     public let profile: String

--- a/tests/addon-publish.test.js
+++ b/tests/addon-publish.test.js
@@ -1,0 +1,34 @@
+import { describe, expect, test } from "@jest/globals";
+import { readFileSync } from "node:fs";
+
+const pkg = JSON.parse(readFileSync(new URL("../package.json", import.meta.url), "utf8"));
+const script = readFileSync(new URL("../scripts/publish-addon-packages.mjs", import.meta.url), "utf8");
+const cdWorkflow = readFileSync(new URL("../.github/workflows/cd.yml", import.meta.url), "utf8");
+
+describe("add-on publish release lane", () => {
+  test("package scripts expose a publish command that is dry-run by default", () => {
+    expect(pkg.scripts["addons:publish"]).toBe("node scripts/publish-addon-packages.mjs");
+    expect(script).toContain("publish: false");
+    expect(script).toContain('arg === "--publish"');
+    expect(script).toContain('arg === "--dry-run"');
+  });
+
+  test("publish command keeps verification in front of npm publish", () => {
+    expect(script).toContain('run("npm", ["run", "build"])');
+    expect(script).toContain('"scripts/build-addon-packages.mjs", "--check"');
+    expect(script).toContain('"addons:verify-install"');
+    expect(script).toContain('"--all"');
+    expect(script).toContain('"--pack"');
+    expect(script).toContain('"--provenance"');
+  });
+
+  test("CD publishes add-ons before the slim root and releases the preflight mcpb", () => {
+    expect(cdWorkflow).toContain("npm run release:preflight");
+    expect(cdWorkflow).toContain("npm run addons:publish -- --publish --all --no-build --skip-verify");
+    expect(cdWorkflow.indexOf("Publish add-ons with provenance")).toBeLessThan(
+      cdWorkflow.indexOf("Publish root with provenance"),
+    );
+    expect(cdWorkflow).toContain("npm publish --provenance --access public");
+    expect(cdWorkflow).toContain("build/release-preflight/airmcp-${{ steps.pkg.outputs.version }}.mcpb");
+  });
+});

--- a/tests/app-addons-ui.test.js
+++ b/tests/app-addons-ui.test.js
@@ -18,9 +18,12 @@ describe("AirMCP.app module add-on management", () => {
 
   test("module menu exposes pack-level add-on controls", () => {
     expect(menuContent).toContain('Menu(L("addons.menu"))');
+    expect(menuContent).toContain('Button(L("addons.refresh"))');
     expect(menuContent).toContain('Button(L("addons.install"))');
     expect(menuContent).toContain('Button(L("addons.uninstall"))');
     expect(menuContent).toContain('Button(L("addons.copyInstallCommand"))');
+    expect(menuContent).toContain("addonManager.isInstalled(pack: pack.id)");
+    expect(menuContent).toContain('"addons.activeButMissing"');
     expect(menuContent).toContain("@heznpc/airmcp-productivity");
     expect(menuContent).toContain("@heznpc/airmcp-spatial");
   });
@@ -29,10 +32,15 @@ describe("AirMCP.app module add-on management", () => {
     expect(addonManager).toContain("AirMcpConstants.npmPackageSpecifier");
     expect(addonManager).toContain('"modules"');
     expect(addonManager).toContain('"--install"');
+    expect(addonManager).toContain('"list"');
+    expect(addonManager).toContain('"--json"');
+    expect(addonManager).toContain("installedPacks");
   });
 
   test("localized strings cover the add-on controls", () => {
     expect(enStrings).toContain('"addons.menu" = "Module Add-ons"');
+    expect(enStrings).toContain('"addons.refresh" = "Refresh Add-on Status"');
+    expect(enStrings).toContain('"addons.activeButMissing" = "Active but not installed"');
     expect(enStrings).toContain('"addon.spatial" = "Spatial"');
   });
 });

--- a/tests/mcp-setup.test.js
+++ b/tests/mcp-setup.test.js
@@ -565,6 +565,8 @@ describe('createServer — module add-on install hints', () => {
         installSpec: '@heznpc/airmcp-productivity@2.15.0',
         modules: ['pages', 'numbers'],
         command: 'npx airmcp modules enable productivity --install',
+        message:
+          'Install and activate the productivity add-on to use pages, numbers: npx airmcp modules enable productivity --install. Restart AirMCP after installation.',
       },
     ]);
     expect(status.structuredContent.modulesMissingAddonPackages).toEqual([]);
@@ -622,6 +624,8 @@ describe('createServer — module add-on install hints', () => {
         installSpec: '@heznpc/airmcp-productivity@2.15.0',
         modules: ['pages'],
         command: 'npx airmcp modules enable productivity --install',
+        message:
+          'Install and activate the productivity add-on to use pages: npx airmcp modules enable productivity --install. Restart AirMCP after installation.',
       },
     ]);
   });


### PR DESCRIPTION
## Summary
- add dry-run-first add-on publish tooling and wire CD through release preflight -> add-on publish -> slim root publish
- add human-readable missing add-on install prompts to profile_status and regenerate manifest/AppIntents
- show AirMCP.app add-on install status with refresh and active-but-missing UI

## Verification
- npm run build
- npm run gen:manifest && npm run gen:intents
- npm run addons:check
- node scripts/publish-addon-packages.mjs --no-build --skip-verify --pack productivity
- npm run typecheck
- npm test -- tests/addon-publish.test.js tests/app-addons-ui.test.js tests/mcp-setup.test.js
- npm run app-build
- npm run gen:manifest:check
- npm run gen:intents:check
- npm run release:preflight
- npm run lint
- npm run stats:check
- npm run version:check
- npm run i18n:check
- npm test