### PR TITLE
fix: make release publish resumable

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -34,7 +34,7 @@ jobs:
 
       - name: Version guard
         run: |
-          if git rev-parse "v${{ steps.pkg.outputs.version }}" >/dev/null 2>&1; then
+          if git show-ref --tags --verify --quiet "refs/tags/v${{ steps.pkg.outputs.version }}"; then
             echo "::error::Tag v${{ steps.pkg.outputs.version }} already exists. Bump the version first."
             exit 1
           fi
@@ -62,13 +62,18 @@ jobs:
       - name: Release preflight
         run: npm run release:preflight
 
-      - name: Publish add-ons with provenance
-        run: npm run addons:publish -- --publish --all --no-build --skip-verify
+      - name: Publish root with provenance
+        run: |
+          if npm view "${{ steps.pkg.outputs.name }}@${{ steps.pkg.outputs.version }}" version >/dev/null 2>&1; then
+            echo "${{ steps.pkg.outputs.name }}@${{ steps.pkg.outputs.version }} is already published; skipping root publish."
+          else
+            npm publish --provenance --access public
+          fi
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
-      - name: Publish root with provenance
-        run: npm publish --provenance --access public
+      - name: Publish add-ons with provenance
+        run: npm run addons:publish -- --publish --all --no-build --skip-verify
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 

--- a/scripts/publish-addon-packages.mjs
+++ b/scripts/publish-addon-packages.mjs
@@ -38,6 +38,16 @@ function run(cmd, args, options = {}) {
   }
 }
 
+function runCaptured(cmd, args, options = {}) {
+  return spawnSync(cmd, args, {
+    cwd: ROOT,
+    env: process.env,
+    encoding: "utf8",
+    maxBuffer: 64 * 1024 * 1024,
+    ...options,
+  });
+}
+
 function parseList(value) {
   return value
     .split(",")
@@ -155,13 +165,37 @@ function verifyPackageDirFallback(pack) {
   return join(ROOT, "build", "addons", packageDirName(pack.packageName), "package");
 }
 
-function publishPackage({ packageRoot, pack, args }) {
+function isVersionPublished(packageName, version) {
+  const result = runCaptured("npm", ["view", `${packageName}@${version}`, "version"]);
+  return result.status === 0 && result.stdout.trim() === version;
+}
+
+function publishPackage({ packageRoot, pack, args, version }) {
   const npmArgs = ["publish", "--access", args.access, "--tag", args.tag];
   if (!args.publish) npmArgs.push("--dry-run");
   if (args.publish && args.provenance) npmArgs.push("--provenance");
 
+  if (isVersionPublished(pack.packageName, version)) {
+    console.log(`[addons:publish] skip ${pack.packageName}@${version} — already published`);
+    return;
+  }
+
   console.log(`[addons:publish] ${args.publish ? "publish" : "dry-run"} ${pack.packageName}`);
-  run("npm", npmArgs, { cwd: packageRoot });
+  const result = runCaptured("npm", npmArgs, { cwd: packageRoot });
+  if (result.status === 0) {
+    if (result.stdout) process.stdout.write(result.stdout);
+    if (result.stderr) process.stderr.write(result.stderr);
+    return;
+  }
+
+  const output = `${result.stdout ?? ""}\n${result.stderr ?? ""}`;
+  if (output.includes(`previously published versions: ${version}`)) {
+    console.log(`[addons:publish] skip ${pack.packageName}@${version} — already published`);
+    return;
+  }
+  if (result.stdout) process.stdout.write(result.stdout);
+  if (result.stderr) process.stderr.write(result.stderr);
+  fail(`command failed (${result.status ?? "signal"}): npm ${npmArgs.join(" ")}`);
 }
 
 function main() {
@@ -193,7 +227,7 @@ function main() {
   for (const pack of selected) {
     let packageRoot = verifyStagedPackage(manifest, pack);
     if (!existsSync(packageRoot)) packageRoot = verifyPackageDirFallback(pack);
-    publishPackage({ packageRoot, pack, args });
+    publishPackage({ packageRoot, pack, args, version: manifest.version });
   }
 
   console.log(`ok: ${args.publish ? "published" : "dry-run checked"} ${selected.length} add-on package(s)`);

--- a/tests/addon-publish.test.js
+++ b/tests/addon-publish.test.js
@@ -22,13 +22,22 @@ describe("add-on publish release lane", () => {
     expect(script).toContain('"--provenance"');
   });
 
-  test("CD publishes add-ons before the slim root and releases the preflight mcpb", () => {
+  test("publish command can resume when an add-on version already exists", () => {
+    expect(script).toContain("function isVersionPublished(packageName, version)");
+    expect(script).toContain('["view", `${packageName}@${version}`, "version"]');
+    expect(script).toContain("already published");
+    expect(script).toContain("previously published versions");
+  });
+
+  test("CD publishes the slim root before add-ons and releases the preflight mcpb", () => {
     expect(cdWorkflow).toContain("npm run release:preflight");
-    expect(cdWorkflow).toContain("npm run addons:publish -- --publish --all --no-build --skip-verify");
-    expect(cdWorkflow.indexOf("Publish add-ons with provenance")).toBeLessThan(
-      cdWorkflow.indexOf("Publish root with provenance"),
+    expect(cdWorkflow).toContain('git show-ref --tags --verify --quiet "refs/tags/v${{ steps.pkg.outputs.version }}"');
+    expect(cdWorkflow.indexOf("Publish root with provenance")).toBeLessThan(
+      cdWorkflow.indexOf("Publish add-ons with provenance"),
     );
     expect(cdWorkflow).toContain("npm publish --provenance --access public");
+    expect(cdWorkflow).toContain("is already published; skipping root publish");
+    expect(cdWorkflow).toContain("npm run addons:publish -- --publish --all --no-build --skip-verify");
     expect(cdWorkflow).toContain("build/release-preflight/airmcp-${{ steps.pkg.outputs.version }}.mcpb");
   });
 });


### PR DESCRIPTION
## Summary
- make add-on publishing skip package versions that are already visible in npm
- tolerate npm's already-published publish response so release retries can continue
- publish the root package before add-ons in CD and guard already-published root versions
- tighten the release tag guard to check real tag refs

## Verification
- npm test -- --runTestsByPath tests/addon-publish.test.js tests/release-verify-addons.test.js --runInBand
- npm run typecheck
- npm run lint
- npm run addons:publish -- --pack communications --no-build --skip-verify
- npm run release:preflight