### PR TITLE
fix: run release npx smoke from clean cwd

### DIFF
--- a/scripts/verify-release-state.mjs
+++ b/scripts/verify-release-state.mjs
@@ -107,15 +107,27 @@ function verifyAddonRegistryInstall(addonPacks) {
   }
 }
 
+function verifyNpxSmoke() {
+  const work = mkdtempSync(join(tmpdir(), "airmcp-release-npx-"));
+  try {
+    const npx = run("npx", ["-y", `${pkg.name}@${version}`, "--version"], {
+      cwd: work,
+      timeout: 120_000,
+    });
+    if (npx.status !== 0) fail(`npx smoke failed for ${pkg.name}@${version}`, npx.stderr || npx.stdout);
+    if (npx.stdout !== version) fail(`npx --version mismatch: expected ${version}, got ${npx.stdout}`);
+    console.log(`ok: npx -y ${pkg.name}@${version} --version`);
+  } finally {
+    rmSync(work, { recursive: true, force: true });
+  }
+}
+
 console.log(`release-verify: ${pkg.name}@${version}`);
 
 verifyPublishedPackage(pkg.name, version, "npm root");
 
 if (!skipNpx) {
-  const npx = run("npx", ["-y", `${pkg.name}@${version}`, "--version"], { timeout: 120_000 });
-  if (npx.status !== 0) fail(`npx smoke failed for ${pkg.name}@${version}`, npx.stderr || npx.stdout);
-  if (npx.stdout !== version) fail(`npx --version mismatch: expected ${version}, got ${npx.stdout}`);
-  console.log(`ok: npx -y ${pkg.name}@${version} --version`);
+  verifyNpxSmoke();
 }
 
 if (!skipGithub) {

--- a/tests/release-verify-addons.test.js
+++ b/tests/release-verify-addons.test.js
@@ -18,4 +18,11 @@ describe("release:verify add-on registry coverage", () => {
     expect(script).toContain("await import(name)");
     expect(script).toContain("packageName export mismatch");
   });
+
+  test("runs npx smoke from a fresh directory instead of the repo root", () => {
+    expect(script).toContain("function verifyNpxSmoke()");
+    expect(script).toContain('mkdtempSync(join(tmpdir(), "airmcp-release-npx-"))');
+    expect(script).toContain("cwd: work");
+    expect(script).toContain("verifyNpxSmoke()");
+  });
 });


### PR DESCRIPTION
## Summary
- run release:verify npx smoke from a fresh temporary directory instead of the repository root
- keep the fresh registry add-on install/import smoke unchanged
- add a regression test for the clean-cwd npx smoke contract

## Evidence
- npm test -- --runTestsByPath tests/release-verify-addons.test.js --runInBand
- npm run release:verify -- --skip-github
- npm run typecheck
- npm run lint

## Context
The public airmcp@2.15.0 package and all 10 @heznpc/airmcp-* add-ons are visible in npm. The old verifier could fail from the repo root while the same npx command succeeds from a fresh directory, so this moves the smoke test to match the first-user install path.