### PR TITLE
fix(registry): shorten server.json description under 100-char limit

### DIFF
--- a/server.json
+++ b/server.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.heznpc/airmcp",
-  "description": "Approval-gated local action runtime for Apple workspaces - 295 tools across 31 modules, profiles, progressive exposure, HITL, audit log, rate limits. macOS only.",
+  "description": "Approval-gated local action runtime for Apple workspaces: HITL, audit log, rate limits. macOS.",
   "version": "2.15.0",
   "websiteUrl": "https://github.com/heznpc/AirMCP",
   "repository": {


### PR DESCRIPTION
## Problem
Every release fails **Publish to MCP Registry** with HTTP 422: the `description` in `server.json` is 161 chars but the registry caps it at 100. Confirmed on v2.14.0 (run 28450736656) and v2.15.0 (run 28551821607); `main` still has the 161-char value, so the next release fails too.

## Fix
Shorten to 94 chars and drop the tool/module counts (which change per release and would re-break the limit):
`Approval-gated local action runtime for Apple workspaces: HITL, audit log, rate limits. macOS.`

## Not covered here (owner action required)
- **npm publish** still fails on `NPM_TOKEN` E401 — needs the repo secret rotated (I can't create tokens).
- `release-app.yml` green runs are silent skips — Apple signing secrets are absent in every scope.