### PR TITLE
fix(release): widen registry propagation window so a shipped publish is not a red release

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -156,7 +156,7 @@ jobs:
       - name: Verify root registry identity
         env:
           AIRMCP_RELEASE_SHA: ${{ github.sha }}
-        run: node scripts/verify-publish-identity.mjs --retry-seconds=60
+        run: node scripts/verify-publish-identity.mjs --retry-seconds=600
 
       - name: Publish add-ons with provenance
         if: steps.npm-auth.outputs.mode == 'trusted-publishing'

--- a/scripts/lib/publish-identity.mjs
+++ b/scripts/lib/publish-identity.mjs
@@ -159,8 +159,18 @@ export function waitForPublishedIdentity({
   }
 
   if (lastPublished) assertPublishedIdentity({ local, published: lastPublished, expectedGitHead, label });
-  if (lastQueryError) throw new Error(`${label} registry metadata remained unavailable after bounded retry`);
-  throw new Error(`${label} was not visible after bounded registry retry`);
+
+  // Reaching here means the publish itself SUCCEEDED and only the registry read
+  // path failed to confirm it in time. Say so explicitly: the previous wording
+  // ("was not visible") read as a failed publish and sent an operator through
+  // thirteen re-runs of an already-shipped release. Re-running is still the
+  // correct recovery — publish is idempotent and skips packages whose registry
+  // SRI and gitHead already match — but only once propagation catches up.
+  const resume =
+    "the publish succeeded; this is a registry read-path (propagation) timeout, not a failed publish. " +
+    "Re-run once the version resolves via `npm view` — already-published packages are skipped.";
+  if (lastQueryError) throw new Error(`${label} registry metadata remained unavailable after bounded retry — ${resume}`);
+  throw new Error(`${label} was not visible after bounded registry retry — ${resume}`);
 }
 
 export function verifyPublishedIdentity({

--- a/scripts/publish-addon-packages.mjs
+++ b/scripts/publish-addon-packages.mjs
@@ -186,7 +186,13 @@ function expectedReleaseGitHead() {
 
 function verifyRegistryIdentity(local, expectedGitHead, { retryAfterPublish = false } = {}) {
   if (retryAfterPublish) {
-    waitForPublishedIdentity({ local, expectedGitHead, timeoutMs: 60_000 });
+    // 60s was too tight and turned a shipped v2.16.2 add-on into a red release
+    // thirteen times: `npm view` resolves the packument, and for a brand-new
+    // scoped package name that read path lagged the successful publish by more
+    // than five minutes. A mismatch still fails immediately — only missing or
+    // incomplete metadata waits — so widening this window costs time solely in
+    // the lagging case, never correctness.
+    waitForPublishedIdentity({ local, expectedGitHead, timeoutMs: 600_000 });
     return true;
   }
   const published = queryPublishedIdentity(local.name, local.version);

--- a/scripts/verify-publish-identity.mjs
+++ b/scripts/verify-publish-identity.mjs
@@ -28,8 +28,13 @@ const allowMissing = process.argv.includes("--allow-missing");
 const retrySecondsValue = valueArg("--retry-seconds") || "0";
 const retrySeconds = Number(retrySecondsValue);
 
-if (!Number.isInteger(retrySeconds) || retrySeconds < 0 || retrySeconds > 300) {
-  console.error("publish-identity: --retry-seconds must be an integer from 0 to 300");
+// Upper bound raised from 300 to 900 after the v2.16.2 release: the registry
+// read path (`npm view`, which resolves the packument) lagged a SUCCESSFUL
+// immutable publish by well over five minutes for a brand-new scoped package
+// name, while the version-specific endpoint already served the tarball. A cap
+// below that lag turns a shipped artifact into a red release.
+if (!Number.isInteger(retrySeconds) || retrySeconds < 0 || retrySeconds > 900) {
+  console.error("publish-identity: --retry-seconds must be an integer from 0 to 900");
   process.exit(1);
 }
 

--- a/tests/addon-publish.test.js
+++ b/tests/addon-publish.test.js
@@ -49,7 +49,7 @@ describe("add-on publish release lane", () => {
     expect(cdWorkflow).toContain("Inspect root registry identity");
     expect(cdWorkflow).toContain("node scripts/verify-publish-identity.mjs --allow-missing");
     expect(cdWorkflow).toContain("npm publish --provenance --access public");
-    expect(cdWorkflow).toContain("node scripts/verify-publish-identity.mjs --retry-seconds=60");
+    expect(cdWorkflow).toContain("node scripts/verify-publish-identity.mjs --retry-seconds=600");
     expect(cdWorkflow).toContain("npm run addons:publish -- --publish --all --no-build --skip-verify");
     expect(cdWorkflow).toContain("build/release-preflight/airmcp-${{ steps.pkg.outputs.version }}.mcpb");
   });

--- a/tests/publish-identity.test.js
+++ b/tests/publish-identity.test.js
@@ -60,6 +60,27 @@ describe("immutable npm publish identity", () => {
     expect(clock).toBe(30);
   });
 
+  // Regression: the v2.16.2 release shipped every package, but a bare "was not
+  // visible" timeout read as a failed publish and drove thirteen re-runs of an
+  // already-published release. The propagation timeout must name itself as a
+  // read-path timeout and state that re-running skips published packages.
+  test("propagation timeout reports a shipped publish, not a failed one", () => {
+    let clock = 0;
+    expect(() =>
+      waitForPublishedIdentity({
+        local,
+        expectedGitHead,
+        timeoutMs: 100,
+        retryDelayMs: 50,
+        now: () => clock,
+        sleep: (milliseconds) => {
+          clock += milliseconds;
+        },
+        query: () => null, // registry read path still 404s after a successful publish
+      }),
+    ).toThrow(/publish succeeded.*propagation.*Re-run.*skipped/s);
+  });
+
   test("post-publish retry never waits through a complete identity mismatch", () => {
     let sleeps = 0;
     expect(() =>


### PR DESCRIPTION
## Summary

The v2.16.2 release published every package but reported failure **thirteen times**. The publish itself always succeeded; only the registry read path failed to confirm it inside the 60s post-publish window.

`npm view` resolves the packument, and for a brand-new scoped package name that read path lagged the successful immutable publish by **more than five minutes** while the version-specific endpoint already served the tarball. Because the add-on step aborts on that failure, every downstream step was skipped:

- `@heznpc/airmcp-powerautomate@2.16.2` went unpublished, so an opt-in user hit `E404` on the exact `installSpec` pinned in `src/server/front-door-tools.ts`
- no `v2.16.2` tag, no GitHub Release, no `.mcpb` asset
- the signed app lane (`release-app.yml`) was never dispatched
- `release:verify` never ran

## Changes

- add-on post-publish window `60s` → `600s` (`scripts/publish-addon-packages.mjs`)
- `--retry-seconds` cap `300` → `900`, and CD now passes `600` (`scripts/verify-publish-identity.mjs`, `.github/workflows/cd.yml`)
- the timeout error now states that the publish **succeeded**, that this is a read-path propagation timeout, and that re-running resumes by skipping packages whose registry SRI and gitHead already match (`scripts/lib/publish-identity.mjs`)

The wording matters as much as the timeout: a bare "was not visible" read as a failed publish and drove thirteen re-runs of an already-shipped release.

## Supply-chain gate is unchanged

A complete-but-mismatched SRI or gitHead still fails **immediately** — `waitForPublishedIdentity` only waits on missing or incomplete metadata. Widening the window costs time solely in the lagging case, never correctness. `tests/publish-identity.test.js` still asserts the mismatch path never sleeps.

## Validation

- `node --experimental-vm-modules node_modules/.bin/jest tests/publish-identity.test.js tests/addon-publish.test.js` — 13 passed
- full suite — 219/220 suites pass; the one failure is `runtime-error-contract.test.js` › `gws_drive_list` hitting a 10s contract timeout on a Google API call, which is a local network/credential limitation unrelated to this change and green in CI
- `node scripts/verify-publish-identity.mjs --retry-seconds=901` correctly rejects with the new bound
- new regression test asserts the propagation timeout reports a shipped publish rather than a failed one

v2.16.2 was completed by re-dispatching CD, which confirmed the resume path works: all 11 already-published add-ons logged `skip — registry SRI and gitHead match`, powerautomate published, then tag, Release, signed-app dispatch, and release verification all succeeded.
