### PR TITLE
docs(security): match trust claims to the scope the code actually enforces

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -43,6 +43,24 @@ The moderate+ advisory is emitted by `scripts/summarize-audit.mjs`, which runs a
 - **Shared note guard** — Destructive operations blocked on shared notes by default
 - **HITL gating** — Configurable human-in-the-loop approval for destructive operations
 
+## Enforcement Scope and Honest Limits
+
+The features above are real, but each enforces at a specific boundary. A reader who assumes "governed" means "globally enforced" would over-trust the runtime, so this table is the authoritative scope statement and every row is grounded in the cited source. The fuller mechanism-by-mechanism accounting — including the parts that are advisory only — lives in `docs/experiments/defended-vs-undefended-ablation-design.md`.
+
+| Mechanism | Enforced scope | Honest limit |
+| --------- | -------------- | ------------ |
+| Emergency stop | Destructive-classified calls | **Not** a global halt. The gate is `if (destructive && isEmergencyStopActive())` in `src/shared/rate-limit.ts`; non-destructive reads continue while the stop file exists. |
+| Per-call HITL approval | Gated calls at the configured level, when an approval channel exists | Fails **closed** — with no elicitation or approval socket, gated calls are denied (`src/shared/hitl-guard.ts`). But an operator can set `hitl.level: off`, which removes the gate entirely. |
+| Tamper-evident audit chain | Every call | Tamper-**evident**, not tamper-proof. `governed` stays `true` under a host-derived key, so the honest one-line verdict is `assurance`, never bare `governed` (`src/shared/resources.ts`). |
+| Audit key strength | Chain HMAC | `assurance: operator-attested` means the key is not derivable from host facts — it does **not** by itself mean non-repudiation. The `keyfile` variant is readable by any same-user process; only `keySource: "env"` resists a same-user local attacker (`src/shared/identity-key.ts`). |
+| Privacy-sensitive READ classification | Build time only | `src/shared/privacy-sensitive-tools.ts` is imported by no runtime path — only by `tests/safety-annotations.test.js`. It keeps the per-tool `sensitiveHint` annotations from drifting, and that annotation is what gates at runtime. It is **not** wired into the OAuth scope gate. |
+| OAuth scope gate | HTTP requests carrying OAuth claims | Applies only when the OAuth policy is active **and** claims are present; `rejectInsufficientScopes` returns early otherwise (`src/server/http-transport.ts`). stdio, loopback, and legacy bearer sessions are not scope-gated. |
+
+Two consequences worth stating plainly:
+
+- **A successful tool call is evidence that a step ran, not proof that the user's task completed.** The audit chain records calls; it does not verify end state in the target app.
+- **Run identity belongs to the caller.** AirMCP governs individual calls and correlates them via the optional `X-AirMCP-Run-Id` header (UUID-validated in `src/server/http-transport.ts`). Absent that header there is no server-side run object grouping a multi-call task.
+
 ## Outbound Network Calls (JXA / AppleScript / Swift)
 
 AirMCP's inbound attack surface (HTTP transport, stdio JSON-RPC) is defended by the items above. For traffic going the *other* direction — AppleScript `do shell script` with `curl`, JXA using `ObjC.import('Foundation')` for URL requests, or a Swift bridge command hitting the network — the following boundary applies:

--- a/src/shared/icons.ts
+++ b/src/shared/icons.ts
@@ -15,18 +15,34 @@ export const WEBSITE_URL = "https://github.com/heznpc/AirMCP";
  * Wording tracks the canonical public positioning ("governed MCP runtime for the Apple
  * ecosystem … not another agent"). Keep it SHORT, STATIC, and COUNT-FREE: it is injected
  * every session, has no CI drift guard, and must never interpolate tool-returned or user
- * content. Every claim is code-grounded — no model/agent-loop in the request path, audit +
- * rate-limit wrap every call, HITL gates sensitive/destructive actions.
+ * content.
+ *
+ * Every claim here must be code-grounded, and the scope of each claim must match the code
+ * it points at — this string is the most-read thing AirMCP says about itself, so an
+ * overclaim here is the most expensive kind:
+ *   - no model/agent-loop in the request path;
+ *   - audit + rate-limit wrap every call (`src/shared/audit.ts`, `src/shared/rate-limit.ts`);
+ *   - HITL gates sensitive/destructive actions (`src/shared/hitl-guard.ts`);
+ *   - the emergency stop is DESTRUCTIVE-SCOPED, not a global halt — the gate is
+ *     `if (destructive && isEmergencyStopActive())` in `src/shared/rate-limit.ts`. Do not
+ *     restate it as "halts everything".
+ *
+ * Ordering is also load-bearing: leading with tool discovery trains a fresh session to
+ * treat "call a tool" as the goal. The task the user wants done in an Apple app comes
+ * first; the front-door calls are the mechanism that serves it.
  */
 export const SERVER_INSTRUCTIONS =
   "AirMCP is a governed MCP runtime for the Apple ecosystem — a connector and control " +
   "layer, not another agent. You are the agent; AirMCP is the governed layer your tool " +
   "calls pass through, and it runs no model, planner, or agent loop of its own. Rate limits " +
   "and a tamper-evident HMAC-chained audit log wrap every call; sensitive or destructive " +
-  "actions also require per-call human approval, and an emergency stop can halt everything. " +
-  "You start behind a small front door — call discover_tools or start_tool_session to widen " +
-  "access as needed. Skills are deterministic YAML pipelines, not model reasoning; the " +
-  "optional intelligence tools only delegate to on-device models and never drive AirMCP.";
+  "actions also require per-call human approval, and an emergency stop blocks every " +
+  "destructive call until an operator clears it. Start from the task the user wants done in " +
+  "a supported Apple app, then widen access for that task — you start behind a small front " +
+  "door, and discover_tools or start_tool_session open it. A successful call is evidence a " +
+  "step ran, not proof the user's task is complete. Skills are deterministic YAML " +
+  "pipelines, not model reasoning; the optional intelligence tools only delegate to " +
+  "on-device models and never drive AirMCP.";
 
 // Stylized "A" with signal waves
 const SERVER_ICON_SVG = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128" fill="none">

--- a/src/shared/privacy-sensitive-tools.ts
+++ b/src/shared/privacy-sensitive-tools.ts
@@ -23,8 +23,18 @@
  *                 clipboard / photo / health / message reader added
  *                 unmarked fails CI — the smart_clipboard miss).
  *
+ * ENFORCEMENT SCOPE — read this before citing the file as a defense.
+ * Nothing under `src/` imports this module; its only consumer is
+ * tests/safety-annotations.test.js. It is therefore a BUILD-TIME drift guard,
+ * not a runtime gate. What actually gates a call at runtime is the per-tool
+ * `sensitiveHint: true` annotation that src/shared/hitl-guard.ts consumes —
+ * this file exists to make it impossible to land a privacy readout WITHOUT
+ * that annotation. Treat it as the reason the annotations stay correct, never
+ * as an independent enforcement layer.
+ *
  * This set is intended to also back the OAuth scope gate once the
- * sensitive→scope propagation (review finding #6) is ratified.
+ * sensitive→scope propagation (review finding #6) is ratified; that
+ * propagation is NOT wired up today.
  */
 export const PRIVACY_READOUT_TOOLS: ReadonlySet<string> = new Set([
   // clipboard

--- a/src/shared/resources.ts
+++ b/src/shared/resources.ts
@@ -356,11 +356,15 @@ export interface TrustAttestation {
     auditDisabled: boolean;
     /** First integrity break when `verified` is false; null when the chain verifies. */
     firstBreak: { file: string; lineIndex: number; reason: string } | null;
-    /** `operator-key` (external secret) vs `host-fallback` (tamper-evident only). */
+    /** `operator-key` (an `env` secret or the init-generated key file — either
+     *  way, not derivable from host facts) vs `host-fallback` (tamper-evident
+     *  only). This grade deliberately does NOT separate `env` from `keyfile`;
+     *  read `keySource` when the threat model includes a same-user process. */
     keyGrade: "operator-key" | "host-fallback";
-    /** Which variant backs the grade: `env` (strongest, secret outside the
-     *  store), `keyfile` (init-generated, same-user readable), or
-     *  `host-derived` (the fallback). */
+    /** Which variant backs the grade: `env` (the secret lives outside the store
+     *  — the only variant that resists a same-user local reader), `keyfile`
+     *  (init-generated, 0600, but readable by any same-user process), or
+     *  `host-derived` (the fallback, re-derivable by any local shell). */
     keySource: "env" | "keyfile" | "host-derived";
   };
   /** Human-in-the-loop approval posture. */
@@ -399,7 +403,12 @@ export interface TrustAttestation {
 
 /**
  * The honest, key-grade-aware assurance tier for an attestation.
- * - `operator-attested` — chain verifies, not halted, external operator key: strongest, non-repudiable.
+ * - `operator-attested` — chain verifies, not halted, and the chain is keyed by an operator key
+ *                          (`env` secret or the init-generated key file) rather than host facts, so
+ *                          it is not forgeable by someone who merely knows the hostname/platform.
+ *                          This tier is about NON-DERIVABILITY, not non-repudiation: the `keyfile`
+ *                          variant is readable by any same-user process, so only `keySource: "env"`
+ *                          resists a same-user local attacker. See `src/shared/identity-key.ts`.
  * - `tamper-evident`    — chain verifies, not halted, host-fallback key: still trustworthy as a record,
  *                          but an attacker with shell access can re-derive the key. NOT non-repudiation.
  * - `audit-halted`      — chain verifies but logging is currently halted (disk/permission/flush failure).


### PR DESCRIPTION
## Summary

Four trust claims promised more than the code delivers. **No mechanism changes here** — only the claims and their stated scope. All were verified against source before editing.

## The overclaims

**`SERVER_INSTRUCTIONS` said an emergency stop "can halt everything."** The gate is `if (destructive && isEmergencyStopActive())` in `src/shared/rate-limit.ts`, and the denial text itself says "All destructive tools are blocked" — non-destructive reads continue while the stop file exists. This string is injected into every session and the same docstring asserts every claim is code-grounded, so this was the most-read thing AirMCP says about itself contradicting its own contract. The docstring now pins the destructive scope to the exact gate so it cannot regress.

**`operator-attested` was documented as "strongest, non-repudiable."** The `keyfile` variant reaches that tier — `tests/audit-keyfile-grade.test.js` locks it deliberately — while `src/shared/identity-key.ts` states a key file is readable by any same-user process and directs you to `env` for non-repudiation. The tier is about **non-derivability**, not non-repudiation. The mapping is intentional and unchanged; only the claim is corrected, with a pointer to `keySource` for the threat model that distinguishes them. `keyGrade` also no longer calls `operator-key` an "external secret", which was false for the keyfile variant.

**`privacy-sensitive-tools.ts` reads like a defense but has no importer under `src/`** — only `tests/safety-annotations.test.js`. It is a build-time drift guard that keeps the per-tool `sensitiveHint` annotations honest; the annotation is what gates at runtime. It is also not wired into the OAuth scope gate. Now stated explicitly so it is not counted as an independent enforcement layer.

**`SECURITY.md` listed features without saying where each stops enforcing.**

## Also: instruction ordering

`SERVER_INSTRUCTIONS` led with `discover_tools` / `start_tool_session`, which trains a fresh session to treat "call a tool" as the goal. The user's task in an Apple app now comes first and the front door remains as the mechanism that serves it. It also says plainly that a successful call is evidence a step ran, not proof the task completed.

## SECURITY.md

New enforcement-scope table, every row cited to source: emergency stop, per-call HITL (fails closed with no channel, but `hitl.level: off` removes it), the audit chain, key strength, the privacy-read classification, and the OAuth scope gate (only applies when the OAuth policy is active and claims are present, so stdio/loopback/legacy bearer are not scope-gated). Plus two consequences stated plainly: a successful call is not proof of task completion, and run identity belongs to the caller via the optional `X-AirMCP-Run-Id` header.

The fuller mechanism-by-mechanism accounting already lived in `docs/experiments/defended-vs-undefended-ablation-design.md`. This surfaces it where a reader actually looks, and links there for the rest.

## Validation

- `tsc --noEmit` clean, `eslint src/` clean, prettier clean on all touched TS
- targeted suites (`ci-security-policy`, `trust-resource`, `audit-keyfile-grade`, `safety-annotations`, `cli-verify`, `mcp-setup`, `rate-limit`) — 58 passed
- full suite green apart from `runtime-error-contract` › `gws_drive_list` hitting a 10s contract timeout on a Google API call, a local network/credential limitation unrelated to this change
- `SECURITY.md` diff is purely additive (18 insertions, 0 deletions); markdown is intentionally left in the file's existing style since neither CI nor lint-staged formats `*.md`
