### PR TITLE
docs: sync contribution templates with module manifest

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -21,13 +21,13 @@ body:
         - calendar
         - contacts
         - mail
-        - messages
         - music
         - finder
         - safari
         - system
         - photos
         - shortcuts
+        - messages
         - intelligence
         - tv
         - ui
@@ -41,6 +41,13 @@ body:
         - location
         - bluetooth
         - google
+        - speech
+        - health
+        - memory
+        - audit
+        - spatial_prep
+        - webhooks
+        - powerautomate
         - other / multiple
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -28,13 +28,13 @@ body:
         - calendar
         - contacts
         - mail
-        - messages
         - music
         - finder
         - safari
         - system
         - photos
         - shortcuts
+        - messages
         - intelligence
         - tv
         - ui
@@ -48,6 +48,13 @@ body:
         - location
         - bluetooth
         - google
+        - speech
+        - health
+        - memory
+        - audit
+        - spatial_prep
+        - webhooks
+        - powerautomate
         - new module
         - cross-module
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -61,29 +61,38 @@ PASS: ?  |  SKIP: ?  |  FAIL: ?  |  WARN: ?
 
 <!-- Check modules you changed — reviewers will focus on these. -->
 
-- [ ] Notes
-- [ ] Reminders
-- [ ] Calendar
-- [ ] Contacts
-- [ ] Mail
-- [ ] Music
-- [ ] Finder
-- [ ] Safari
-- [ ] System
-- [ ] Photos
-- [ ] Messages
-- [ ] Shortcuts
-- [ ] TV
-- [ ] Screen
-- [ ] Maps
-- [ ] Podcasts
-- [ ] Weather
-- [ ] Location
-- [ ] Bluetooth
-- [ ] Intelligence
-- [ ] Pages / Numbers / Keynote
-- [ ] Semantic
-- [ ] UI Automation
+- [ ] `notes`
+- [ ] `reminders`
+- [ ] `calendar`
+- [ ] `contacts`
+- [ ] `mail`
+- [ ] `music`
+- [ ] `finder`
+- [ ] `safari`
+- [ ] `system`
+- [ ] `photos`
+- [ ] `shortcuts`
+- [ ] `messages`
+- [ ] `intelligence`
+- [ ] `tv`
+- [ ] `ui`
+- [ ] `screen`
+- [ ] `maps`
+- [ ] `podcasts`
+- [ ] `weather`
+- [ ] `pages`
+- [ ] `numbers`
+- [ ] `keynote`
+- [ ] `location`
+- [ ] `bluetooth`
+- [ ] `google`
+- [ ] `speech`
+- [ ] `health`
+- [ ] `memory`
+- [ ] `audit`
+- [ ] `spatial_prep`
+- [ ] `webhooks`
+- [ ] `powerautomate`
 - [ ] Shared / Infrastructure
 
 ### Manual Testing

--- a/tests/contribution-template-modules.test.js
+++ b/tests/contribution-template-modules.test.js
@@ -1,0 +1,70 @@
+import { describe, expect, test } from "@jest/globals";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import YAML from "yaml";
+import { MODULE_MANIFEST } from "../dist/shared/modules.js";
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..");
+const MODULE_NAMES = MODULE_MANIFEST.map((entry) => entry.name);
+
+const ISSUE_TEMPLATE_EXPECTATIONS = [
+  {
+    path: ".github/ISSUE_TEMPLATE/bug_report.yml",
+    nonModuleOptions: ["other / multiple"],
+  },
+  {
+    path: ".github/ISSUE_TEMPLATE/feature_request.yml",
+    nonModuleOptions: ["new module", "cross-module"],
+  },
+];
+
+function readRepoFile(path) {
+  return readFileSync(join(ROOT, path), "utf8");
+}
+
+function getIssueTemplateModuleOptions(path) {
+  const template = YAML.parse(readRepoFile(path));
+  const moduleField = template.body.find((item) => item.type === "dropdown" && item.id === "module");
+
+  if (!moduleField) {
+    throw new Error(`${path} is missing a dropdown with id "module"`);
+  }
+
+  return moduleField.attributes.options;
+}
+
+function getPrTemplateModuleOptions() {
+  const template = readRepoFile(".github/PULL_REQUEST_TEMPLATE.md");
+  const modulesSection = template.match(/### Modules Affected\n\n[\s\S]*?(?=\n### |\n## |$)/)?.[0];
+
+  if (!modulesSection) {
+    throw new Error(".github/PULL_REQUEST_TEMPLATE.md is missing the Modules Affected section");
+  }
+
+  return [...modulesSection.matchAll(/^- \[ \] (.+)$/gm)].map((match) => match[1].replaceAll("`", "").trim());
+}
+
+describe("contribution template module lists", () => {
+  test.each(ISSUE_TEMPLATE_EXPECTATIONS)("$path includes every manifest module", ({ path, nonModuleOptions }) => {
+    const options = getIssueTemplateModuleOptions(path);
+
+    expect(options.filter((option) => MODULE_NAMES.includes(option))).toEqual(MODULE_NAMES);
+    expect(options.filter((option) => !MODULE_NAMES.includes(option))).toEqual(nonModuleOptions);
+  });
+
+  test("pull request template includes every manifest module", () => {
+    const options = getPrTemplateModuleOptions();
+
+    expect(options.filter((option) => MODULE_NAMES.includes(option))).toEqual(MODULE_NAMES);
+    expect(options.filter((option) => !MODULE_NAMES.includes(option))).toEqual(["Shared / Infrastructure"]);
+  });
+
+  test("pull request template does not use stale grouped or non-canonical module labels", () => {
+    const options = getPrTemplateModuleOptions();
+
+    expect(options).not.toContain("Pages / Numbers / Keynote");
+    expect(options).not.toContain("Semantic");
+    expect(options).not.toContain("UI Automation");
+  });
+});


### PR DESCRIPTION
## Summary

- Updates issue forms and the PR template so current MODULE_MANIFEST modules are represented.
- Preserves non-module contribution choices such as cross-module, new module, other/multiple, and shared infrastructure.
- Adds a focused Jest drift test to catch future MODULE_MANIFEST/template mismatches.

## Validation

- `npm test -- --runInBand tests/contribution-template-modules.test.js`
- `npm run lint --if-present`
- `git diff --check`

Refs #400
