### PR TITLE
chore(ci): enforce src formatting so the gate cannot drift silently

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,6 +83,14 @@ jobs:
       - name: Lint
         run: npm run lint
 
+      # lint-staged formats src/**/*.ts on commit, but that only covers files
+      # staged through a local hook — a bypassed hook, a web edit, or a merge
+      # can still land unformatted source. front-door-tools.ts drifted exactly
+      # that way and stayed red locally while every CI run passed, because
+      # nothing here checked it.
+      - name: Format check
+        run: npm run format:check
+
       - name: Build
         run: npm run build
 

--- a/src/server/front-door-tools.ts
+++ b/src/server/front-door-tools.ts
@@ -478,9 +478,7 @@ export function registerFrontDoorTools(server: McpServer, options: RegisterFront
         tool: z.string(),
         exists: z.boolean(),
         exposed: z.boolean().optional(),
-        annotations: z
-          .object({ destructive: z.boolean(), readOnly: z.boolean(), sensitive: z.boolean() })
-          .optional(),
+        annotations: z.object({ destructive: z.boolean(), readOnly: z.boolean(), sensitive: z.boolean() }).optional(),
         argsValid: z.boolean().optional(),
         validationError: z.string().optional(),
         wouldRequireApproval: z.boolean().optional(),


### PR DESCRIPTION
## Summary

`format:check` has existed in `package.json` for a while, but **no workflow ran it**. `src/server/front-door-tools.ts` therefore sat unformatted on `main` while every CI run passed — the drift was invisible to CI and only showed up when running prettier locally.

`lint-staged` covers `src/**/*.ts`, but only for files staged through a local hook. A bypassed hook, a web edit, or a merge all sidestep it, which is exactly how this file drifted.

## Changes

- reflow the one drifted declaration in `front-door-tools.ts` — formatting only, no semantic change (a `z.object({...}).optional()` chain that fit on one line)
- run `npm run format:check` in CI immediately after `Lint`

## Why a gate rather than just the fix

Without CI enforcement the same drift returns silently. This repo already leans on CI-enforced drift guards (`stats:check`, `gen:manifest:check`, `gen:intents:check`, `gen:app-catalog:check`, and now the contribution-template guard from #415), so formatting is the odd one out in having a script but no gate.

`src/` is prettier-clean as of this commit, so the gate starts green.

## Validation

- `prettier --check src/` — clean across the whole tree, not just the touched file
- `eslint src/` — clean
- `tsc --noEmit` — clean
- `node scripts/build.mjs` — succeeds
- full suite — **221 suites / 2786 tests, all passing**
