### PR TITLE
docs(template): ask PRs to link the issue with Closes

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,6 +2,16 @@
 
 <!-- What does this PR do? Keep it to 1-3 sentences. -->
 
+## Linked Issue
+
+<!--
+  Use `Closes #123` so merging closes the issue automatically. `Refs #123`
+  only cross-links it and leaves it open for a maintainer to close by hand.
+  Use `Refs` only when the PR is a partial step toward the issue.
+-->
+
+Closes #
+
 ## Type of Change
 
 - [ ] New feature (new tool, module, or prompt)


### PR DESCRIPTION
## Summary

The PR template had no issue-link section at all, so contributors defaulted to `Refs #NNN` — which cross-links but does not close. #412, #415, and #417 each needed a maintainer to close #401, #400, and #403 by hand after merge. #406 used `Closes #402` and closed itself.

Adds a **Linked Issue** section with `Closes #` prefilled, and documents when `Refs` is actually the right choice (a partial step toward an issue).

## Validation

- `tests/contribution-template-modules.test.js` still passes — the `### Modules Affected` parser added in #415 is unaffected, since the new section sits above it and the regex keys on that heading.
