### PR TITLE
test(calendar): add script/outputSchema shape contract and fix three drifts

### DIFF
--- a/docs/tool-manifest.json
+++ b/docs/tool-manifest.json
@@ -11958,6 +11958,9 @@
           "total": {
             "type": "number"
           },
+          "returned": {
+            "type": "number"
+          },
           "events": {
             "type": "array",
             "items": {
@@ -11996,6 +11999,7 @@
         },
         "required": [
           "total",
+          "returned",
           "events"
         ],
         "additionalProperties": false
@@ -14137,6 +14141,9 @@
           "total": {
             "type": "number"
           },
+          "returned": {
+            "type": "number"
+          },
           "events": {
             "type": "array",
             "items": {
@@ -14179,6 +14186,7 @@
         },
         "required": [
           "total",
+          "returned",
           "events"
         ],
         "additionalProperties": false

--- a/src/calendar/scripts.ts
+++ b/src/calendar/scripts.ts
@@ -1,7 +1,181 @@
 // JXA scripts for Apple Calendar automation.
 // Each function returns a JXA script string to be executed via osascript.
+//
+// The interfaces below pin the shape of each script's final
+// `JSON.stringify(...)`, and the `*_EXAMPLE` constants carry a concrete
+// instance of that shape. `tests/script-shape-contract.test.js` parses every
+// example through the matching tool's real `outputSchema`, so changing what a
+// script emits without updating the example (and the outputSchema) fails a
+// test instead of silently passing the tautological mock-in-mock-out runtime
+// check. Examples and scripts must be kept in lockstep by hand.
+//
+// Calendar tools run through `runAutomation`, so these shapes are a contract
+// for BOTH backends: the EventKit Swift bridge (`AirMCPKit/Types.swift`
+// `EventListOutput` / `SearchEventsOutput` / `UpcomingEventsOutput` /
+// `TodayEventsOutput`) and the JXA fallback below must agree field for field.
 
 import { esc } from "../shared/esc.js";
+
+// ── Return shapes ───────────────────────────────────────────────────────
+export interface CalendarInfo {
+  id: string;
+  name: string;
+  color: string | null;
+  writable: boolean;
+}
+
+/** `list_calendars` wraps the script's bare array as `{ calendars }`. */
+export interface CalendarListCalendarsOutput {
+  calendars: CalendarInfo[];
+}
+
+export interface CalendarEventListItem {
+  id: string;
+  summary: string;
+  startDate: string;
+  endDate: string;
+  allDay: boolean;
+  calendar: string;
+}
+
+export interface CalendarListEventsOutput {
+  total: number;
+  offset: number;
+  returned: number;
+  events: CalendarEventListItem[];
+}
+
+export interface CalendarAttendee {
+  name: string | null;
+  email: string | null;
+  status: string | null;
+}
+
+export interface CalendarReadEventOutput {
+  id: string;
+  summary: string;
+  description: string | null;
+  location: string | null;
+  startDate: string;
+  endDate: string;
+  allDay: boolean;
+  recurrence: string | null;
+  url: string | null;
+  calendar: string;
+  attendees: CalendarAttendee[];
+}
+
+export interface CalendarSearchEventsOutput {
+  total: number;
+  returned: number;
+  events: CalendarEventListItem[];
+}
+
+/** Upcoming/today rows carry `location`; the Swift bridge types it
+ *  non-optional, so the JXA fallback emits `''` rather than `null`. */
+export interface CalendarLocatedEventItem extends CalendarEventListItem {
+  location: string;
+}
+
+export interface CalendarUpcomingEventsOutput {
+  total: number;
+  returned: number;
+  events: CalendarLocatedEventItem[];
+}
+
+export interface CalendarTodayEventsOutput {
+  total: number;
+  returned: number;
+  events: CalendarLocatedEventItem[];
+}
+
+// ── Example fixtures (hand-maintained; see tests/script-shape-contract) ──
+export const LIST_CALENDARS_EXAMPLE: CalendarListCalendarsOutput = {
+  calendars: [
+    { id: "CAL-1", name: "Work", color: "#FF5733", writable: true },
+    // `color` and `writable` are read behind their own try/catch in the
+    // script, so an unreadable calendar still returns a row.
+    { id: "CAL-2", name: "Subscribed Holidays", color: null, writable: false },
+  ],
+};
+
+export const LIST_EVENTS_EXAMPLE: CalendarListEventsOutput = {
+  total: 3,
+  offset: 0,
+  returned: 2,
+  events: [
+    {
+      id: "EV-1",
+      summary: "Standup",
+      startDate: "2026-03-15T09:00:00.000Z",
+      endDate: "2026-03-15T09:15:00.000Z",
+      allDay: false,
+      calendar: "Work",
+    },
+    {
+      // `summary` falls back to '' when the event has no title.
+      id: "EV-2",
+      summary: "",
+      startDate: "2026-03-16T00:00:00.000Z",
+      endDate: "2026-03-17T00:00:00.000Z",
+      allDay: true,
+      calendar: "Work",
+    },
+  ],
+};
+
+export const READ_EVENT_EXAMPLE: CalendarReadEventOutput = {
+  id: "EV-1",
+  summary: "Standup",
+  description: "Daily sync",
+  location: "Room 2",
+  startDate: "2026-03-15T09:00:00.000Z",
+  endDate: "2026-03-15T09:15:00.000Z",
+  allDay: false,
+  recurrence: "FREQ=WEEKLY",
+  url: "https://example.test/standup",
+  calendar: "Work",
+  attendees: [{ name: "Alice", email: "alice@example.com", status: "accepted" }],
+};
+
+/** Same tool, unset-optional case: the script passes `ev.description()` and
+ *  friends through verbatim, so every nullable field really can be null and
+ *  `attendees` is `[]` when the read throws. */
+export const READ_EVENT_EXAMPLE_EMPTY: CalendarReadEventOutput = {
+  id: "EV-3",
+  summary: "",
+  description: null,
+  location: null,
+  startDate: "2026-03-20T12:00:00.000Z",
+  endDate: "2026-03-20T13:00:00.000Z",
+  allDay: false,
+  recurrence: null,
+  url: null,
+  calendar: "Personal",
+  attendees: [],
+};
+
+export const SEARCH_EVENTS_EXAMPLE: CalendarSearchEventsOutput = {
+  total: 5,
+  returned: 1,
+  events: [LIST_EVENTS_EXAMPLE.events[0]!],
+};
+
+export const GET_UPCOMING_EVENTS_EXAMPLE: CalendarUpcomingEventsOutput = {
+  total: 4,
+  returned: 2,
+  events: [
+    { ...LIST_EVENTS_EXAMPLE.events[0]!, location: "Room 2" },
+    // Location-less events emit '' so the shape matches the Swift bridge.
+    { ...LIST_EVENTS_EXAMPLE.events[1]!, location: "" },
+  ],
+};
+
+export const TODAY_EVENTS_EXAMPLE: CalendarTodayEventsOutput = {
+  total: 2,
+  returned: 2,
+  events: GET_UPCOMING_EVENTS_EXAMPLE.events,
+};
 
 export function listCalendarsScript(): string {
   return `
@@ -281,7 +455,7 @@ export function getUpcomingEventsScript(limit: number): string {
         all.push({
           id: eUids[i], summary: eSummaries[i] || '',
           startDate: eStarts[i].toISOString(), endDate: eEnds[i].toISOString(),
-          allDay: eAllDay[i] ?? false, location: eLocs[i] || null, calendar: calName
+          allDay: eAllDay[i] ?? false, location: eLocs[i] || '', calendar: calName
         });
       }
     }
@@ -318,7 +492,7 @@ export function todayEventsScript(): string {
         all.push({
           id: eUids[i], summary: eSummaries[i] || '',
           startDate: eStarts[i].toISOString(), endDate: eEnds[i].toISOString(),
-          allDay: eAllDay[i] ?? false, location: eLocs[i] || null, calendar: calName
+          allDay: eAllDay[i] ?? false, location: eLocs[i] || '', calendar: calName
         });
       }
     }

--- a/src/calendar/tools.ts
+++ b/src/calendar/tools.ts
@@ -15,43 +15,17 @@ import {
   getUpcomingEventsScript,
   todayEventsScript,
 } from "./scripts.js";
-
-interface CalendarItem {
-  id: string;
-  name: string;
-  color: string;
-  writable: boolean;
-}
-
-interface EventListItem {
-  id: string;
-  summary: string;
-  startDate: string;
-  endDate: string;
-  allDay: boolean;
-  calendar: string;
-}
-
-interface EventListResult {
-  total: number;
-  offset: number;
-  returned: number;
-  events: EventListItem[];
-}
-
-interface Attendee {
-  name: string;
-  email: string;
-  status: string;
-}
-
-interface EventDetail extends EventListItem {
-  description: string;
-  location: string;
-  recurrence: string;
-  url: string;
-  attendees: Attendee[];
-}
+// Return shapes live next to the scripts that emit them (and are pinned by the
+// `*_EXAMPLE` fixtures in `tests/script-shape-contract.test.js`), so this file
+// consumes them rather than re-declaring a second, driftable copy.
+import type {
+  CalendarInfo,
+  CalendarListEventsOutput,
+  CalendarReadEventOutput,
+  CalendarSearchEventsOutput,
+  CalendarUpcomingEventsOutput,
+  CalendarTodayEventsOutput,
+} from "./scripts.js";
 
 interface MutationResult {
   id: string;
@@ -61,26 +35,6 @@ interface MutationResult {
 interface DeleteResult {
   deleted: boolean;
   summary: string;
-}
-
-interface SearchResult {
-  total: number;
-  events: EventListItem[];
-}
-
-interface UpcomingEventItem extends EventListItem {
-  location: string;
-}
-
-interface UpcomingEventsResult {
-  total: number;
-  returned: number;
-  events: UpcomingEventItem[];
-}
-
-interface TodayEventsResult {
-  total: number;
-  events: UpcomingEventItem[];
 }
 
 interface RecurringEventResult {
@@ -115,7 +69,7 @@ export function registerCalendarTools(server: McpServer, _config: AirMcpConfig):
     },
     async () => {
       try {
-        const result = await runAutomation<CalendarItem[]>({
+        const result = await runAutomation<CalendarInfo[]>({
           swift: { command: "list-calendars" },
           jxa: () => listCalendarsScript(),
         });
@@ -170,7 +124,7 @@ export function registerCalendarTools(server: McpServer, _config: AirMcpConfig):
     },
     async ({ startDate, endDate, calendar, limit, offset }) => {
       try {
-        const result = await runAutomation<EventListResult>({
+        const result = await runAutomation<CalendarListEventsOutput>({
           swift: {
             command: "list-events",
             input: { startDate, endDate, calendar, limit, offset },
@@ -221,7 +175,7 @@ export function registerCalendarTools(server: McpServer, _config: AirMcpConfig):
     },
     async ({ id }) => {
       try {
-        const result = await runAutomation<EventDetail>({
+        const result = await runAutomation<CalendarReadEventOutput>({
           swift: { command: "read-event", input: { id } },
           jxa: () => readEventScript(id),
         });
@@ -353,6 +307,10 @@ export function registerCalendarTools(server: McpServer, _config: AirMcpConfig):
       },
       outputSchema: {
         total: z.number(),
+        // Both backends have always emitted `returned` (Swift
+        // `SearchEventsOutput`, and the JXA `result.length`); the schema simply
+        // omitted it, so the field was undeclared to clients.
+        returned: z.number(),
         events: z.array(
           z.object({
             id: z.string(),
@@ -373,7 +331,7 @@ export function registerCalendarTools(server: McpServer, _config: AirMcpConfig):
     },
     async ({ query, startDate, endDate, limit }) => {
       try {
-        const result = await runAutomation<SearchResult>({
+        const result = await runAutomation<CalendarSearchEventsOutput>({
           swift: {
             command: "search-events",
             input: { query, startDate, endDate, limit },
@@ -420,7 +378,7 @@ export function registerCalendarTools(server: McpServer, _config: AirMcpConfig):
     },
     async ({ limit }) => {
       try {
-        const result = await runAutomation<UpcomingEventsResult>({
+        const result = await runAutomation<CalendarUpcomingEventsOutput>({
           swift: { command: "get-upcoming-events", input: { limit } },
           jxa: () => getUpcomingEventsScript(limit),
         });
@@ -439,6 +397,9 @@ export function registerCalendarTools(server: McpServer, _config: AirMcpConfig):
       inputSchema: {},
       outputSchema: {
         total: z.number(),
+        // Swift `TodayEventsOutput` and the JXA script both emit `returned`;
+        // the schema omitted it.
+        returned: z.number(),
         events: z.array(
           z.object({
             id: z.string(),
@@ -460,7 +421,7 @@ export function registerCalendarTools(server: McpServer, _config: AirMcpConfig):
     },
     async () => {
       try {
-        const result = await runAutomation<TodayEventsResult>({
+        const result = await runAutomation<CalendarTodayEventsOutput>({
           swift: { command: "today-events" },
           jxa: () => todayEventsScript(),
         });

--- a/swift/Sources/AirMCPKit/Generated/MCPIntents.swift
+++ b/swift/Sources/AirMCPKit/Generated/MCPIntents.swift
@@ -1061,6 +1061,7 @@ public struct MCPSearchEventsOutput: Codable, Sendable {
     }
 
     public let total: Double
+    public let returned: Double
     public let events: [EventsItem]
 }
 
@@ -1213,6 +1214,7 @@ public struct MCPTodayEventsOutput: Codable, Sendable {
     }
 
     public let total: Double
+    public let returned: Double
     public let events: [EventsItem]
 }
 

--- a/tests/output-schema-structured.test.js
+++ b/tests/output-schema-structured.test.js
@@ -81,7 +81,10 @@ const TOOL_FIXTURES = {
   },
   search_events: {
     args: { query: 'test', startDate: '2026-01-01T00:00:00Z', endDate: '2026-12-31T23:59:59Z', limit: 10 },
-    mock: { total: 0, events: [] },
+    // `returned` was missing here and from the outputSchema, while both the
+    // Swift bridge and the JXA script always emitted it — the mock was the only
+    // thing defining the shape. See tests/script-shape-contract.test.js.
+    mock: { total: 0, returned: 0, events: [] },
   },
   get_upcoming_events: {
     args: { limit: 5 },
@@ -89,7 +92,7 @@ const TOOL_FIXTURES = {
   },
   today_events: {
     args: {},
-    mock: { total: 0, events: [] },
+    mock: { total: 0, returned: 0, events: [] },
   },
   // contacts
   list_contacts: {

--- a/tests/script-shape-contract.test.js
+++ b/tests/script-shape-contract.test.js
@@ -7,7 +7,8 @@
  * They cannot detect a real drift where `scripts.ts` changes the JSON it
  * emits without the matching outputSchema update (or vice versa).
  *
- * This file closes that gap for the Wave 3 JXA modules (messages, shortcuts).
+ * This file closes that gap for the Wave 3 JXA modules (messages, shortcuts)
+ * and for calendar.
  * Each `scripts.ts` exports a hand-maintained `*_EXAMPLE` constant pinned to
  * the same TypeScript interface the script's final `JSON.stringify(...)` is
  * expected to produce. Here we parse every example through the tool's real
@@ -29,10 +30,12 @@ setupPlatformMocks();
 
 const { registerMessagesTools } = await import('../dist/messages/tools.js');
 const { registerShortcutsTools } = await import('../dist/shortcuts/tools.js');
+const { registerCalendarTools } = await import('../dist/calendar/tools.js');
 const healthTools = await import('../dist/health/tools.js');
 const { registerHealthTools } = healthTools;
 const messagesScripts = await import('../dist/messages/scripts.js');
 const shortcutsScripts = await import('../dist/shortcuts/scripts.js');
+const calendarScripts = await import('../dist/calendar/scripts.js');
 
 function schemaFor(server, toolName) {
   const tool = server._tools.get(toolName);
@@ -88,6 +91,60 @@ describe('Script shape ↔ outputSchema contract — shortcuts', () => {
   });
   test('get_shortcut_detail example conforms', () => {
     assertExampleFits(server, 'get_shortcut_detail', shortcutsScripts.GET_SHORTCUT_DETAIL_EXAMPLE);
+  });
+});
+
+// Calendar tools route through `runAutomation`, so each shape is a contract for
+// two backends at once: the EventKit Swift bridge and the JXA fallback. Writing
+// this contract down surfaced three real drifts that no runtime test could see —
+// `search_events` and `today_events` emitted `returned` from both backends
+// without declaring it, and the JXA upcoming/today scripts emitted a null
+// `location` against a non-nullable schema (Swift types it `String`).
+describe('Script shape ↔ outputSchema contract — calendar', () => {
+  let server;
+  beforeAll(() => {
+    server = createMockServer();
+    registerCalendarTools(server, createMockConfig());
+  });
+
+  test('list_calendars example conforms', () => {
+    assertExampleFits(server, 'list_calendars', calendarScripts.LIST_CALENDARS_EXAMPLE);
+  });
+  test('list_events example conforms', () => {
+    assertExampleFits(server, 'list_events', calendarScripts.LIST_EVENTS_EXAMPLE);
+  });
+  test('read_event example conforms', () => {
+    assertExampleFits(server, 'read_event', calendarScripts.READ_EVENT_EXAMPLE);
+  });
+  test('read_event unset-optional example conforms', () => {
+    assertExampleFits(server, 'read_event', calendarScripts.READ_EVENT_EXAMPLE_EMPTY);
+  });
+  test('search_events example conforms', () => {
+    assertExampleFits(server, 'search_events', calendarScripts.SEARCH_EVENTS_EXAMPLE);
+  });
+  test('get_upcoming_events example conforms', () => {
+    assertExampleFits(server, 'get_upcoming_events', calendarScripts.GET_UPCOMING_EVENTS_EXAMPLE);
+  });
+  test('today_events example conforms', () => {
+    assertExampleFits(server, 'today_events', calendarScripts.TODAY_EVENTS_EXAMPLE);
+  });
+
+  // The guard has to bite in both directions, or it is just a snapshot of
+  // whatever the example happens to say. A field the schema does not declare
+  // must fail (strict), and a renamed field must fail too.
+  test('an undeclared field fails the contract', () => {
+    expect(() =>
+      assertExampleFits(server, 'today_events', {
+        ...calendarScripts.TODAY_EVENTS_EXAMPLE,
+        unexpected: true,
+      }),
+    ).toThrow(/drifted from outputSchema/);
+  });
+  test('a renamed field fails the contract', () => {
+    const { returned, ...withoutReturned } = calendarScripts.TODAY_EVENTS_EXAMPLE;
+    expect(() =>
+      assertExampleFits(server, 'today_events', { ...withoutReturned, returnedCount: returned }),
+    ).toThrow(/drifted from outputSchema/);
   });
 });
 


### PR DESCRIPTION
## Summary

Extends `tests/script-shape-contract.test.js` to calendar, following the messages/shortcuts pattern from the issue: `scripts.ts` exports hand-maintained `*_EXAMPLE` constants typed against the interfaces its `JSON.stringify(...)` produces, and the test parses each one through the tool's **real declared `outputSchema`** via strict Zod.

Covers all six outputSchema-bearing JXA-fed tools: `list_calendars`, `list_events`, `read_event`, `search_events`, `get_upcoming_events`, `today_events`.

## Three real drifts this surfaced

Calendar tools route through `runAutomation`, so every shape is a contract for **two backends at once** — the EventKit Swift bridge and the JXA fallback. Runtime tests mock the automation layer, so the mock return value becomes `structuredContent` verbatim and none of these were visible:

| Drift | Detail |
| --- | --- |
| `search_events` undeclared field | Swift `SearchEventsOutput` and the JXA script both emit `returned`; `outputSchema` never declared it, so the field was undocumented to clients |
| `today_events` undeclared field | Same missing `returned` |
| `location` nullability | JXA upcoming/today emitted `location: eLocs[i] \|\| null` against a non-nullable `z.string()`, while Swift `UpcomingEventItem.location` is a non-optional `String` — **the two backends disagreed with each other** |

## Fixes, with the Swift bridge as authoritative

- `returned: z.number()` added to both outputSchemas. It was always being sent by both paths; this declares reality rather than changing behaviour.
- The JXA scripts now emit `''` for an empty location, matching Swift and the `summary: ... || ''` convention already used in the same loops. Making the schema nullable instead would have weakened the contract for the Swift path.

## Single source of truth

Removes the duplicate return-shape interfaces from `calendar/tools.ts` in favour of importing them from `scripts.ts`, so the shape lives next to the code that emits it. The old local copies had already drifted — `CalendarItem.color` was `string` while the schema said nullable, and `EventDetail`/`Attendee` declared non-nullable fields the schema allows to be null.

## Generated artifacts

`docs/tool-manifest.json` and `swift/.../Generated/MCPIntents.swift` are regenerated. Both gain `returned` on `MCPSearchEventsOutput` and `MCPTodayEventsOutput` — the generated Swift now matches what the Swift bridge actually returns. Diff is limited to those two additions.

`tests/output-schema-structured.test.js` mocks for `search_events` / `today_events` gained `returned` — they were the only thing defining the shape before, which is precisely the weakness this contract test exists to close.

## Guard bites in both directions

An undeclared extra field and a renamed field are each asserted to fail, so the test cannot decay into a snapshot of whatever the example happens to say. `read_event` carries both a populated and an all-nullable example.

## Validation

- `tsc --noEmit`, `eslint src/`, `prettier --check src/` clean
- `gen:manifest:check`, `gen:intents:check`, `gen:app-catalog:check`, `stats:check` all pass after regeneration
- full suite: **221 suites / 2796 tests passing**
- no Apple app is launched; tests import from `dist/`

Closes #407

## Pattern for the remaining four

#408 (notes), #409 (reminders), #410 (mail), #411 (finder) are the same shape of work. The reusable steps: export `*_EXAMPLE` constants from that module's `scripts.ts` typed against interfaces declared in the same file, drop any duplicate interfaces from `tools.ts` in favour of importing them, add a `describe` block here, and check each script's real `JSON.stringify(...)` against the declared schema field by field — including nullability, and including a second backend if the tool uses `runAutomation`.
