### PR TITLE
docs: lead the README with what the reader can do

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,20 +9,45 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![GitHub stars](https://img.shields.io/github/stars/heznpc/AirMCP)](https://github.com/heznpc/AirMCP/stargazers)
 
-**Governed MCP runtime for the Apple ecosystem.** AirMCP lets Claude, Codex,
-Cursor, Raycast, Xcode agents, and other MCP clients work across Notes, Mail,
-Calendar, Reminders, Finder, Safari, Shortcuts, and the rest of your Apple
-workspace. The macOS runtime is available today; the iOS runtime is in preview.
+**Your AI assistant can use the Mac apps you already use.** Ask for something in
+plain language and AirMCP does it in the real Notes, Mail, Calendar, Reminders,
+Messages, Photos, Safari, Finder, and Shortcuts on your machine — your actual
+data, not a copy and not a sandbox. The macOS runtime is available today; the
+iOS runtime is in preview.
 
-AirMCP is the connector and control layer, not another agent. It mediates Apple
-workspace actions through profiles, progressive exposure, per-call human
-approval, HMAC-chained audit logs, rate limits, OAuth scopes, and local controls.
+```text
+"Brief me on today's calendar, overdue reminders, and unread mail."
+"For my next meeting, pull up the related notes, contacts, files, and reminders."
+"Search my Safari tabs for that article and save a summary to Notes."
+"Draft replies to the urgent mail, but ask me before sending anything."
+"Run my Morning Routine shortcut."
+```
+
+Start on macOS with Node.js 20+:
+
+```bash
+npx airmcp init
+```
+
+Then ask your client. Works with Claude, Codex, Cursor, Raycast, Xcode agents,
+and any other MCP client. Nothing reads or changes a client's settings until you
+opt in.
+
+More to try: [Common Workflows](#common-workflows) ·
+[every tool](llms-full.txt) · [Quick Start](#quick-start)
+
+### It does not act behind your back
+
+AirMCP is the connector and control layer, not another agent. Destructive calls
+preview before they run, approval is per-call, and the audit chain is
+tamper-evident and verifiable by you — read `airmcp://trust` and check it
+yourself. Details in [Safety Model](#safety-model).
 
 <p align="center">
-  <a href="docs/demo.gif"><img src="docs/demo.gif" alt="Real AirMCP governance flow: live trust assurance, zero-side-effect destructive preview, and verified audit chain" width="900"></a>
+  <a href="docs/demo.gif"><img src="docs/demo.gif" alt="A real AirMCP session showing the live trust verdict, a destructive delete previewed without executing, and a verified audit chain" width="900"></a>
 </p>
 
-<p align="center"><strong>Preview the action. Inspect live trust. Verify the audit chain.</strong><br>The recording is generated from a real local MCP round-trip by <code>scripts/demo/governed-flow.mjs</code>.</p>
+<p align="center">Generated from a real local MCP round-trip by <code>scripts/demo/governed-flow.mjs</code> — real terminal output, not a staged transcript.</p>
 
 > Multi-language project page: [heznpc.github.io/AirMCP](https://heznpc.github.io/AirMCP/)
 

--- a/tests/positioning-surface.test.js
+++ b/tests/positioning-surface.test.js
@@ -9,13 +9,38 @@ const aggregateCount = /\b\d+\s+(?:tools?|modules?)\b/i;
 const visibleText = (html) => html.replace(/<[^>]*>/g, " ").replace(/\s+/g, " ");
 
 describe("public positioning surfaces", () => {
-  test("README discovery copy leads with the governed Apple ecosystem runtime, not catalog size", () => {
+  // The README's first screen is a conversion surface, not a spec sheet. It
+  // used to open on what AirMCP *is* (a governed runtime that mediates through
+  // profiles, progressive exposure, HMAC-chained audit logs, OAuth scopes) and
+  // reached the end of the fold without a single user-visible result. Traffic
+  // arrived and did not convert. So this guards the opposite failure from the
+  // rest of this file: the intro must lead with what a reader can *do*, and the
+  // governance story must stay present but stay below it.
+  test("README discovery copy leads with what the reader can do, not with what AirMCP is", () => {
     const intro = read("README.md").split("## What You Get")[0];
+    const [lead, governance] = intro.split("### It does not act behind your back");
 
-    expect(intro).toMatch(/Governed MCP runtime for the Apple ecosystem/);
-    expect(intro).toMatch(/macOS runtime is available today/i);
-    expect(intro).toMatch(/iOS runtime is in preview/i);
-    expect(intro).toMatch(/Notes.*Mail.*Calendar.*Reminders.*Shortcuts/s);
+    // A capability claim, in the reader's terms, before anything else.
+    expect(lead).toMatch(/can use the Mac apps you already use/i);
+    expect(lead).toMatch(/plain language/i);
+    // At least three literal prompts, so "ask for something" is shown not asserted.
+    expect((lead.match(/^"[^"]+\.?"$/gm) ?? []).length).toBeGreaterThanOrEqual(3);
+    // And a way to act on it without scrolling.
+    expect(lead).toMatch(/npx airmcp init/);
+
+    // Platform reality still has to be stated up front.
+    expect(lead).toMatch(/macOS runtime is available today/i);
+    expect(lead).toMatch(/iOS runtime is in preview/i);
+    expect(lead).toMatch(/Notes.*Mail.*Calendar.*Reminders.*Shortcuts/s);
+
+    // Governance is the reason to trust it, not the reason to click. It must
+    // exist, and it must come after the capability lead.
+    expect(governance).toMatch(/connector and control layer, not another agent/);
+    expect(governance).toMatch(/approval/i);
+    expect(governance).toMatch(/audit chain/i);
+    // The attribute pitch must not climb back above the capability lead.
+    expect(lead).not.toMatch(/progressive exposure|HMAC|OAuth scopes/i);
+
     expect(intro).not.toMatch(aggregateCount);
   });
 


### PR DESCRIPTION
## Why

The first screen sold attributes, not capability.

It opened on "Governed MCP runtime for the Apple ecosystem", then spent its second paragraph on profiles, progressive exposure, per-call approval, HMAC-chained audit logs, rate limits, OAuth scopes, and local controls. A reader reached the end of the fold without a single user-visible result, and the next heading — "What You Get" — was another attribute list.

The capability copy already existed in this repo. `## Common Workflows` is a list of real things a user can ask for. It sat 120 lines down, below the attribute list and a platform roadmap table.

## What changed

The fold now leads with the capability and **shows** it:

- one claim in the reader's terms ("Your AI assistant can use the Mac apps you already use")
- five literal prompts, lifted from `Common Workflows`
- `npx airmcp init`, above the fold

Governance moves just below, under **"It does not act behind your back"** — which is the job it actually does for a reader. It is the reason to trust the tool, not the reason to click it.

The gif moves down with that section, because that is honestly what it shows: a trust verdict, a previewed destructive call, a verified audit chain. Its alt text no longer front-loads "governance flow" jargon, but it still describes the frame accurately rather than promising a capability demo that has not been recorded yet.

Nothing was dropped. The platform reality (macOS today, iOS preview), the app coverage list, and the client list are all still in the first screen.

## The guard

`positioning-surface.test.js` pinned the old opening phrase in the README. That guard exists to stop the copy regressing to a catalog-size pitch ("297 tools"), and this change does not reintroduce counts — so the count-free assertion stays.

The README assertion is re-aimed at the new intent. The lead must now carry:

- a capability claim in the reader's terms
- at least three literal prompts, so "ask in plain language" is shown rather than asserted
- a runnable install command
- the platform reality and the app list

and governance must be present but *below* the lead, with the attribute vocabulary (`progressive exposure`, `HMAC`, `OAuth scopes`) explicitly barred from climbing back above it.

Assertions for the landing page, docs home, npm description, `llms.txt`, and the registry manifests are untouched.

## Verification

Every suite that reads `README.md`:

```
tests/positioning-surface.test.js      7 passed
tests/tool-count-drift.test.js
tests/spatial-prep-tools.test.js       29 passed (3 suites)
tests/experiment-bypass-tripwire.test.js
```

No TypeScript is touched, so this is docs plus one test file. CI runs the full suite against a clean checkout.

## Known follow-up (not in this PR)

The landing page, docs home, npm description, `llms.txt`, and the registry manifests still open with the attribute phrasing, so the README and `docs/index.html` now differ. Aligning them means rewriting the landing hero, which is a separate change with its own review.

The gif itself is still the governance demo. Re-recording it around the capability verb is the other half of this work — see the note below.

## Note on the gif

`docs/demo.gif` is a terminal recording produced by VHS (`scripts/demo.tape`) driving a real MCP stdio round-trip. Re-recording it to show capability instead of governance means a new tape and a new demo script, and it raises a question this PR does not answer: a capability demo calls tools like `today_events` or `search_notes`, which read real personal data. That needs either a fixture mode or a throwaway account before anything gets published to a public README.
