### PR TITLE
test(iWork): add injection-focused generator suites for Pages, Numbers, Keynote

### DIFF
--- a/tests/keynote-scripts.test.js
+++ b/tests/keynote-scripts.test.js
@@ -1,0 +1,141 @@
+/**
+ * Keynote JXA generator suite — injection focused.
+ *
+ * Keynote's untrusted surface is the document name, the presenter notes body,
+ * and the export path. Slide numbers are numeric and are interpolated raw in
+ * three places (array index, throw message, echoed result), so the assertions
+ * below pin them as bare numeric literals — a string-typed slide param would
+ * become an injection point in the throw message, which sits inside a
+ * single-quoted JXA string.
+ *
+ * No Keynote process is launched; only the generated source string is inspected.
+ */
+import { describe, test, expect } from '@jest/globals';
+import {
+  listDocumentsScript,
+  createDocumentScript,
+  listSlidesScript,
+  getSlideScript,
+  addSlideScript,
+  setPresenterNotesScript,
+  exportPdfScript,
+  startSlideshowScript,
+  closeDocumentScript,
+} from '../dist/keynote/scripts.js';
+
+// A single-quote terminator followed by a statement. The prefix is a sentinel
+// that cannot collide with any document name used in these tests — using "Deck"
+// here would trip on the benign `Document not found: Deck');` line instead of on
+// a real escaping failure.
+const BREAKOUT = "INJECT'); Application('Finder').trash(); ('";
+
+describe('keynote script generators — normal path', () => {
+  test('listDocumentsScript targets the stable bundle id', () => {
+    expect(listDocumentsScript()).toContain("Application('com.apple.Keynote')");
+  });
+
+  test('createDocumentScript pushes a new document', () => {
+    const script = createDocumentScript();
+    expect(script).toContain('Document()');
+    expect(script).toContain('documents.push');
+  });
+
+  test('listSlidesScript reads title and body defensively', () => {
+    const script = listSlidesScript('Kickoff');
+    expect(script).toContain("documents.whose({name: 'Kickoff'})");
+    // Title/body accessors throw on slides without those placeholders, so each
+    // is wrapped and degrades to null rather than failing the whole listing.
+    expect(script).toContain('defaultTitleItem()');
+    expect(script).toContain('defaultBodyItem()');
+    expect(script).toContain('catch(e) { return null; }');
+    expect(script).toContain('presenterNotes()');
+  });
+
+  test('addSlideScript returns the resulting slide count', () => {
+    const script = addSlideScript('Kickoff');
+    expect(script).toContain('Keynote.Slide()');
+    expect(script).toContain('slides.push(slide)');
+    expect(script).toContain('slideNumber: total');
+  });
+
+  test('closeDocumentScript maps saving to a yes/no literal', () => {
+    expect(closeDocumentScript('Kickoff', true)).toContain("saving: 'yes'");
+    expect(closeDocumentScript('Kickoff', false)).toContain("saving: 'no'");
+  });
+
+  test('exportPdfScript exports to the given path as PDF', () => {
+    const script = exportPdfScript('Kickoff', '/tmp/deck.pdf');
+    expect(script).toContain("Path('/tmp/deck.pdf')");
+    expect(script).toContain("as: 'PDF'");
+  });
+});
+
+describe('keynote slide numbers stay numeric literals', () => {
+  test('getSlideScript converts to a zero-based index and echoes the 1-based number', () => {
+    const script = getSlideScript('Kickoff', 3);
+    expect(script).toContain('docs[0].slides[2]');
+    expect(script).toContain('number: 3');
+    expect(script).toContain("throw new Error('Slide 3 not found')");
+    // The throw message sits inside a single-quoted JXA literal, so a quoted
+    // slide number here would mean a string param had slipped through.
+    expect(script).not.toContain("slides['2']");
+  });
+
+  test('setPresenterNotesScript indexes and echoes the same slide', () => {
+    const script = setPresenterNotesScript('Kickoff', 5, 'talk track');
+    expect(script).toContain('docs[0].slides[4]');
+    expect(script).toContain("slide.presenterNotes = 'talk track'");
+    expect(script).toContain('slideNumber: 5');
+  });
+
+  test('startSlideshowScript starts from a zero-based index', () => {
+    const script = startSlideshowScript('Kickoff', 2);
+    expect(script).toContain('from: docs[0].slides[1]');
+    expect(script).toContain('fromSlide: 2');
+  });
+});
+
+describe('keynote esc() injection prevention', () => {
+  test.each([
+    ['document name', (v) => listSlidesScript(v)],
+    ['get-slide document name', (v) => getSlideScript(v, 1)],
+    ['presenter-notes document name', (v) => setPresenterNotesScript(v, 1, 'notes')],
+    ['presenter notes body', (v) => setPresenterNotesScript('Deck', 1, v)],
+    ['slideshow document name', (v) => startSlideshowScript(v, 1)],
+    ['export path', (v) => exportPdfScript('Deck', v)],
+    ['close document name', (v) => closeDocumentScript(v, false)],
+  ])('%s cannot terminate its JXA literal', (_label, build) => {
+    const script = build(BREAKOUT);
+    expect(script).not.toContain("INJECT');");
+    expect(script).toContain("INJECT\\');");
+  });
+
+  test('a hostile name is escaped in the filter and the throw message', () => {
+    const script = listSlidesScript("O'Brien");
+    expect(script).toContain("whose({name: 'O\\'Brien'})");
+    expect(script).toContain("Document not found: O\\'Brien");
+    expect(script).not.toMatch(/name: 'O'Brien'/);
+  });
+
+  test('presenter notes keep newlines as escapes', () => {
+    // Notes are the one genuinely multi-line input here, so a raw newline would
+    // terminate the JXA literal on the first line break.
+    const script = setPresenterNotesScript('Deck', 1, 'point one\npoint two');
+    expect(script).toContain('point one\\npoint two');
+    expect(script).not.toContain('point one\npoint two');
+  });
+
+  test('backslashes are doubled before quote escaping', () => {
+    const script = setPresenterNotesScript('Deck', 1, 'C:\\notes\\');
+    expect(script).toContain("'C:\\\\notes\\\\'");
+  });
+
+  test('NUL and control characters are stripped from notes', () => {
+    expect(setPresenterNotesScript('Deck', 1, 'a\u0000b\u0007c')).toContain("'abc'");
+  });
+
+  test('U+2028 / U+2029 in notes are escaped', () => {
+    const script = setPresenterNotesScript('Deck', 1, 'a\u2028b\u2029c');
+    expect(script).toContain('a\\u2028b\\u2029c');
+  });
+});

--- a/tests/numbers-scripts.test.js
+++ b/tests/numbers-scripts.test.js
@@ -1,0 +1,174 @@
+/**
+ * Numbers JXA generator suite — injection focused.
+ *
+ * Numbers interpolates more untrusted surface than the other iWork modules:
+ * document name, sheet name, cell address, new sheet name, and a cell VALUE
+ * that is deliberately emitted unquoted when it is a number or boolean. That
+ * last one is the interesting case — the quoting decision is made in TypeScript,
+ * so these tests pin both branches.
+ *
+ * Row/column bounds are interpolated raw as numeric literals; the tool schema
+ * constrains them to integers, and the assertions here document that contract
+ * so a future change to a string-typed param is visible.
+ *
+ * No Numbers process is launched; only the generated source string is inspected.
+ */
+import { describe, test, expect } from '@jest/globals';
+import {
+  listDocumentsScript,
+  createDocumentScript,
+  listSheetsScript,
+  getCellScript,
+  setCellScript,
+  readCellsScript,
+  addSheetScript,
+  exportPdfScript,
+  closeDocumentScript,
+  listTablesScript,
+  getFormulaScript,
+  renameSheetScript,
+} from '../dist/numbers/scripts.js';
+
+// The prefix is a sentinel that cannot collide with a document or sheet name
+// used in these tests — reusing a real name would trip on a benign
+// `not found: <name>');` line instead of on a genuine escaping failure.
+const BREAKOUT = "INJECT'); Application('Finder').trash(); ('";
+
+describe('numbers script generators — normal path', () => {
+  test('listDocumentsScript targets the stable bundle id', () => {
+    expect(listDocumentsScript()).toContain("Application('com.apple.Numbers')");
+  });
+
+  test('createDocumentScript pushes a new document', () => {
+    const script = createDocumentScript();
+    expect(script).toContain('Document()');
+    expect(script).toContain('documents.push');
+  });
+
+  test('listSheetsScript reports per-sheet table counts', () => {
+    const script = listSheetsScript('Budget');
+    expect(script).toContain("documents.whose({name: 'Budget'})");
+    expect(script).toContain('tableCount');
+  });
+
+  test('getCellScript reads value and formattedValue for the address', () => {
+    const script = getCellScript('Budget', 'Q1', 'B7');
+    expect(script).toContain("sheets.whose({name: 'Q1'})");
+    expect(script).toContain("table.cells['B7']");
+    expect(script).toContain("address: 'B7'");
+    expect(script).toContain('formattedValue()');
+  });
+
+  test('readCellsScript emits its bounds as bare numeric literals', () => {
+    const script = readCellsScript('Budget', 'Q1', 1, 2, 3, 4);
+    expect(script).toContain('for (let r = 1; r <= 3; r++)');
+    expect(script).toContain('for (let c = 2; c <= 4; c++)');
+    expect(script).toContain('startRow: 1');
+    expect(script).toContain('endCol: 4');
+    // Bounds must not arrive quoted — a quoted bound would mean a string param
+    // slipped through and the loop guard would be comparing text.
+    expect(script).not.toContain("let r = '1'");
+  });
+
+  test('listTablesScript enumerates every table in the sheet', () => {
+    const script = listTablesScript('Budget', 'Q1');
+    expect(script).toContain("sheets.whose({name: 'Q1'})");
+    expect(script).toContain('rowCount()');
+    expect(script).toContain('columnCount()');
+  });
+
+  test('getFormulaScript tolerates constant cells', () => {
+    const script = getFormulaScript('Budget', 'Q1', 'B7');
+    expect(script).toContain('formula = c.formula()');
+    expect(script).toContain('let formula = null');
+  });
+
+  test('renameSheetScript reports both names', () => {
+    const script = renameSheetScript('Budget', 'Q1', 'Q1 final');
+    expect(script).toContain("sheets[0].name = 'Q1 final'");
+    expect(script).toContain("from: 'Q1'");
+    expect(script).toContain("to: 'Q1 final'");
+  });
+
+  test('closeDocumentScript maps saving to a yes/no literal', () => {
+    expect(closeDocumentScript('Budget', true)).toContain("saving: 'yes'");
+    expect(closeDocumentScript('Budget', false)).toContain("saving: 'no'");
+  });
+});
+
+describe('numbers setCellScript value literal', () => {
+  test('numbers are emitted unquoted so the cell stays numeric', () => {
+    const script = setCellScript('Budget', 'Q1', 'B7', 42.5);
+    expect(script).toContain("table.cells['B7'].value = 42.5");
+    expect(script).not.toContain("value = '42.5'");
+  });
+
+  test('booleans are emitted unquoted', () => {
+    expect(setCellScript('Budget', 'Q1', 'B7', true)).toContain("value = true");
+    expect(setCellScript('Budget', 'Q1', 'B7', false)).toContain("value = false");
+  });
+
+  test('strings are quoted and escaped', () => {
+    const script = setCellScript('Budget', 'Q1', 'B7', "O'Brien");
+    expect(script).toContain("value = 'O\\'Brien'");
+  });
+
+  test('a formula string stays a quoted string literal', () => {
+    // Numbers interprets '=SUM(...)' as a formula on assignment, which is the
+    // documented behaviour — but it must still reach Numbers as JXA data, not
+    // as JXA source.
+    const script = setCellScript('Budget', 'Q1', 'B7', '=SUM(A1:A10)');
+    expect(script).toContain("value = '=SUM(A1:A10)'");
+  });
+
+  test('a hostile string value cannot terminate its literal', () => {
+    const script = setCellScript('Budget', 'Q1', 'B7', BREAKOUT);
+    expect(script).not.toContain("INJECT');");
+    expect(script).toContain("INJECT\\');");
+  });
+});
+
+describe('numbers esc() injection prevention', () => {
+  test.each([
+    ['document name', (v) => listSheetsScript(v)],
+    ['sheet name', (v) => getCellScript('Doc', v, 'A1')],
+    ['cell address', (v) => getCellScript('Doc', 'Q1', v)],
+    ['new sheet name', (v) => addSheetScript('Doc', v)],
+    ['rename target', (v) => renameSheetScript('Doc', 'Q1', v)],
+    ['formula cell address', (v) => getFormulaScript('Doc', 'Q1', v)],
+    ['table sheet name', (v) => listTablesScript('Doc', v)],
+    ['export path', (v) => exportPdfScript('Doc', v)],
+  ])('%s cannot terminate its JXA literal', (_label, build) => {
+    const script = build(BREAKOUT);
+    expect(script).not.toContain("INJECT');");
+    expect(script).toContain("INJECT\\');");
+  });
+
+  test('a hostile sheet name is escaped in the filter and the throw message', () => {
+    const script = getCellScript('Doc', "O'Brien", 'A1');
+    expect(script).toContain("sheets.whose({name: 'O\\'Brien'})");
+    expect(script).toContain("Sheet not found: O\\'Brien");
+    expect(script).not.toMatch(/name: 'O'Brien'/);
+  });
+
+  test('a cell address is escaped in both the accessor and the echo', () => {
+    const script = setCellScript('Doc', 'Q1', "A1'] = 1; x['B2", 0);
+    expect(script).not.toContain("cells['A1'] = 1;");
+    expect(script).toContain("A1\\'] = 1; x[\\'B2");
+  });
+
+  test('backslashes are doubled before quote escaping', () => {
+    const script = addSheetScript('Doc', 'C:\\sheets\\');
+    expect(script).toContain("'C:\\\\sheets\\\\'");
+  });
+
+  test('newlines become escapes, not raw line breaks', () => {
+    const script = addSheetScript('Doc', 'a\nb');
+    expect(script).toContain('a\\nb');
+    expect(script).not.toContain('a\nb');
+  });
+
+  test('NUL and control characters are stripped', () => {
+    expect(addSheetScript('Doc', 'a\u0000b\u0007c')).toContain("'abc'");
+  });
+});

--- a/tests/pages-scripts.test.js
+++ b/tests/pages-scripts.test.js
@@ -1,0 +1,121 @@
+/**
+ * Pages JXA generator suite — injection focused.
+ *
+ * Pages interpolates a document name, body text, and an export path into
+ * single-quoted JXA literals. `esc()` is the only thing standing between a
+ * hostile document title and executable JXA, so these assertions check the
+ * escaped form rather than merely that the value appears somewhere: an
+ * assertion like `toContain(hostileInput)` would pass even if the quote broke
+ * out of its literal.
+ *
+ * No Pages process is launched; only the generated source string is inspected.
+ */
+import { describe, test, expect } from '@jest/globals';
+import {
+  listDocumentsScript,
+  openDocumentScript,
+  createDocumentScript,
+  getBodyTextScript,
+  setBodyTextScript,
+  exportPdfScript,
+  closeDocumentScript,
+} from '../dist/pages/scripts.js';
+
+// A single-quote terminator followed by a statement is the payload that matters:
+// if it survives unescaped, everything after it is evaluated as JXA. The prefix
+// is a sentinel that cannot collide with a document name used in these tests —
+// reusing a real name would trip on a benign `not found: <name>');` line instead
+// of on a genuine escaping failure.
+const BREAKOUT = "INJECT'); Application('Finder').trash(); ('";
+
+describe('pages script generators — normal path', () => {
+  test('listDocumentsScript targets the stable bundle id', () => {
+    const script = listDocumentsScript();
+    // macOS 26 renamed the iWork apps, so the bundle id is the contract.
+    expect(script).toContain("Application('com.apple.Pages')");
+    expect(script).toContain('JSON.stringify');
+  });
+
+  test('createDocumentScript pushes a new document', () => {
+    const script = createDocumentScript();
+    expect(script).toContain("Application('com.apple.Pages')");
+    expect(script).toContain('Document()');
+    expect(script).toContain('documents.push');
+  });
+
+  test('getBodyTextScript looks the document up by name and caps the read', () => {
+    const script = getBodyTextScript('Q3 Report');
+    expect(script).toContain("documents.whose({name: 'Q3 Report'})");
+    expect(script).toContain('bodyText()');
+    expect(script).toContain('substring(0, 10000)');
+  });
+
+  test('setBodyTextScript assigns the escaped text', () => {
+    const script = setBodyTextScript('Q3 Report', 'hello world');
+    expect(script).toContain("docs[0].bodyText = 'hello world'");
+  });
+
+  test('openDocumentScript wraps the path in Path()', () => {
+    const script = openDocumentScript('/Users/example/Docs/report.pages');
+    expect(script).toContain("Path('/Users/example/Docs/report.pages')");
+  });
+
+  test('closeDocumentScript maps saving to a yes/no literal', () => {
+    expect(closeDocumentScript('Q3 Report', true)).toContain("saving: 'yes'");
+    expect(closeDocumentScript('Q3 Report', false)).toContain("saving: 'no'");
+  });
+
+  test('exportPdfScript exports to the given path as PDF', () => {
+    const script = exportPdfScript('Q3 Report', '/tmp/out.pdf');
+    expect(script).toContain("Path('/tmp/out.pdf')");
+    expect(script).toContain("as: 'PDF'");
+  });
+});
+
+describe('pages esc() injection prevention', () => {
+  test.each([
+    ['document name', (v) => getBodyTextScript(v)],
+    ['body text', (v) => setBodyTextScript('Doc', v)],
+    ['open path', (v) => openDocumentScript(v)],
+    ['export document name', (v) => exportPdfScript(v, '/tmp/out.pdf')],
+    ['export path', (v) => exportPdfScript('Doc', v)],
+    ['close document name', (v) => closeDocumentScript(v, true)],
+  ])('%s cannot terminate its JXA literal', (_label, build) => {
+    const script = build(BREAKOUT);
+    // The raw breakout sequence must never appear...
+    expect(script).not.toContain("INJECT');");
+    // ...and the quote must be carried through as an escaped quote instead.
+    expect(script).toContain("INJECT\\');");
+  });
+
+  test('backslashes are doubled before quote escaping', () => {
+    // A lone trailing backslash would otherwise escape the closing quote.
+    const script = setBodyTextScript('Doc', 'C:\\path\\');
+    expect(script).toContain("'C:\\\\path\\\\'");
+  });
+
+  test('newlines and tabs become escapes, not raw line breaks', () => {
+    const script = setBodyTextScript('Doc', 'line1\nline2\tend\r');
+    expect(script).toContain('line1\\nline2\\tend\\r');
+    expect(script).not.toContain('line1\nline2');
+  });
+
+  test('NUL and control characters are stripped', () => {
+    const script = setBodyTextScript('Doc', 'a\u0000b\u0007c');
+    expect(script).toContain("'abc'");
+  });
+
+  test('U+2028 / U+2029 are escaped so they cannot break the line', () => {
+    const script = setBodyTextScript('Doc', 'a\u2028b\u2029c');
+    expect(script).toContain('a\\u2028b\\u2029c');
+  });
+
+  test('a hostile name is escaped in every place it is interpolated', () => {
+    // iworkDocLookup emits the name twice: the whose() filter and the throw
+    // message. Both have to be escaped, not just the first.
+    const script = getBodyTextScript("O'Brien");
+    expect(script).toContain("whose({name: 'O\\'Brien'})");
+    expect(script).toContain("Document not found: O\\'Brien");
+    expect(script).not.toMatch(/name: 'O'Brien'/);
+  });
+});


### PR DESCRIPTION
## Summary

Pages, Numbers, and Keynote had handler-level tool tests but no dedicated script-generator suites, so nothing proved that a hostile document title, sheet name, cell address, or presenter-notes body stays **data** rather than becoming executable JXA.

Adds `tests/pages-scripts.test.js` (18), `tests/numbers-scripts.test.js` (27), `tests/keynote-scripts.test.js` (21) — 66 tests, following the conventions in `calendar-scripts.test.js` / `shortcuts-scripts.test.js`.

## The assertions check the escaped form, not mere presence

`expect(script).toContain(hostileInput)` would pass even if the quote had broken out of its literal — that is the exact failure being guarded. So each case asserts both directions:

```js
expect(script).not.toContain("INJECT');");   // raw terminator must not survive
expect(script).toContain("INJECT\\');");     // it must arrive escaped
```

The payload is a single-quote terminator followed by a statement, prefixed with an `INJECT` sentinel so it cannot collide with a document name used in the same test. Worth noting: my first draft reused `"Deck"` as both the payload prefix and the document name, and the assertion tripped on the benign `Document not found: Deck');` line rather than on a real defect. The sentinel removes that class of false positive.

## Coverage beyond the shared `esc()` path

- **Numbers `setCellScript` decides quoting in TypeScript.** Numbers and booleans are emitted as bare literals so the cell stays numeric and formula-referenceable; strings are quoted and escaped. Both branches are pinned, including that a `'=SUM(A1:A10)'` string stays a quoted string literal — Numbers interpreting it as a formula on assignment is intended, but it must reach Numbers as JXA data, not JXA source.
- **Raw numeric interpolation is pinned as numeric.** Numbers row/column bounds and Keynote slide numbers are interpolated without quotes, and Keynote's `throw new Error('Slide N not found')` puts one *inside* a single-quoted string. The assertions require bare numbers, so a future change to a string-typed param becomes visible instead of becoming an injection point.
- **`iworkDocLookup` emits the document name twice** — the `whose()` filter and the throw message. Both are asserted escaped, not just the first.
- Backslash doubling, newline/tab escaping, NUL and control-character stripping, and U+2028/U+2029 escaping each have a case.

## No production defect found

The shared `esc()` and the `iwork.ts` app-name allowlist held up under every case, so no `src/` change was needed.

## Validation

- `npm test -- tests/pages-scripts.test.js tests/numbers-scripts.test.js tests/keynote-scripts.test.js` — 66 passed
- full suite: **225 suites / 2893 tests passing**
- tests import compiled generators from `dist/`; no Pages, Numbers, or Keynote process is launched

Closes #404
