### PR TITLE
fix(registry): add the Dockerfile Glama needs, and a CI gate so it cannot break silently

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -216,3 +216,26 @@ jobs:
 
       - name: Swift — Test AirMCPServer
         run: cd ios && swift test
+
+  # Glama builds every listed MCP server from a Dockerfile and runs the protocol
+  # introspection exchange inside a sandbox. If that build fails the listing stays
+  # up but distribution is withheld — the server drops out of search results,
+  # category listings, and recommendations until a reproducible build succeeds.
+  # That failure is invisible from this repo, so it is asserted here: the image
+  # has to build on Linux and the server has to boot, state its identity, and
+  # answer tools/list. This does NOT claim AirMCP runs on Linux; tool calls need
+  # macOS and fail in the container by design.
+  registry-introspection:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: 22
+
+      - name: Build the registry-introspection image
+        run: docker build -t airmcp-registry-introspection .
+
+      - name: Introspect the container the way an indexer does
+        run: npm run registry:verify

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,50 @@
+# Registry-introspection image. NOT a supported way to run AirMCP.
+#
+# WHY THIS EXISTS
+# Glama builds every listed MCP server from a Dockerfile — the maintainer's if
+# one is checked in, otherwise one its AI infers from the project structure. When
+# that build fails the listing stays up but distribution is withheld: the server
+# stops appearing in search results, category listings, and recommendations until
+# a reproducible build succeeds. AirMCP's inferred build cannot succeed, because
+# `package.json` declares `"os": ["darwin"]` and npm refuses to install the
+# package on Linux (EBADPLATFORM). This file makes the build reproducible so the
+# listing is indexable and its tool schemas can be scored.
+#
+# WHAT IT DOES NOT DO
+# It does not make AirMCP work on Linux. Every Apple-app tool goes through JXA /
+# osascript / the Swift bridges, which exist only on macOS. Inside this container
+# the server boots, reports its identity, and answers tools/list, prompts/list,
+# and resources/list — enough for protocol introspection and nothing more. Any
+# tool CALL will fail. To actually use AirMCP, install it on macOS:
+#
+#     npx airmcp@latest
+#
+FROM node:22-alpine
+
+WORKDIR /app
+
+# Manifests first so dependency layers cache independently of source churn.
+COPY package.json package-lock.json ./
+
+# --force downgrades the darwin-only EBADPLATFORM check to a warning; the six
+# runtime dependencies (@modelcontextprotocol/sdk, @modelcontextprotocol/ext-apps,
+# express, jose, yaml, zod) are all pure JavaScript, so nothing here needs a
+# native macOS toolchain.
+# --ignore-scripts skips the `prepare` hook, which runs husky — a git hook
+# installer that has no repository to attach to in this image.
+RUN npm ci --force --ignore-scripts
+
+COPY tsconfig.json ./
+COPY scripts ./scripts
+COPY src ./src
+
+RUN npm run build
+
+# Drop dev dependencies now that dist/ is built.
+RUN npm prune --omit=dev --force
+
+# Expose the full catalogue rather than the cold-boot front door, so the schemas
+# an indexer captures match the documented surface instead of the starter subset.
+ENV AIRMCP_PROFILE=full
+# stdio only: no port is bound, and no HTTP transport is enabled by default.
+ENTRYPOINT ["node", "dist/index.js"]

--- a/package.json
+++ b/package.json
@@ -103,6 +103,7 @@
     "start": "node dist/index.js",
     "test": "node --experimental-vm-modules node_modules/.bin/jest",
     "smoke": "node scripts/smoke-mcp.mjs",
+    "registry:verify": "node scripts/verify-container-introspection.mjs",
     "premcp:validate": "npm run build",
     "mcp:validate": "node scripts/mcp-validate.mjs",
     "profiles:check": "node scripts/verify-profiles.mjs",

--- a/scripts/verify-container-introspection.mjs
+++ b/scripts/verify-container-introspection.mjs
@@ -1,0 +1,110 @@
+#!/usr/bin/env node
+/**
+ * Verify the registry-introspection container the way Glama does.
+ *
+ * Glama builds every listed server from a Dockerfile and runs the MCP
+ * introspection exchange inside a sandbox. When that build or exchange fails the
+ * listing stays up but distribution is withheld — the server drops out of search
+ * results, category listings, and recommendations until a reproducible build
+ * succeeds. That failure is silent from this side of the fence, which is why it
+ * is asserted here rather than discovered from a registry email.
+ *
+ * This does NOT claim AirMCP works on Linux. Tool CALLS need JXA / osascript /
+ * the Swift bridges and will fail in the container. What must hold is narrower:
+ * the image builds, the server boots, it states its identity, and it answers
+ * tools/list — which is the whole of what an indexer reads.
+ *
+ * Usage: node scripts/verify-container-introspection.mjs [--image <tag>]
+ */
+import { spawn } from "node:child_process";
+
+const args = process.argv.slice(2);
+const imageIndex = args.indexOf("--image");
+const IMAGE = imageIndex >= 0 ? args[imageIndex + 1] : "airmcp-registry-introspection";
+// The cold-boot front door deliberately exposes a subset, so this floor only has
+// to prove a real catalogue came back rather than an empty list.
+const MIN_TOOLS = Number(process.env.CONTAINER_MIN_TOOLS ?? 10);
+const TIMEOUT_MS = Number(process.env.CONTAINER_TIMEOUT_MS ?? 60_000);
+
+function fail(message, detail) {
+  console.error(`[container-introspection] FAIL — ${message}`);
+  if (detail) console.error(detail);
+  process.exit(1);
+}
+
+const child = spawn("docker", ["run", "--rm", "-i", IMAGE], {
+  stdio: ["pipe", "pipe", "pipe"],
+});
+
+let stdout = "";
+let stderr = "";
+const messages = [];
+
+child.stdout.on("data", (chunk) => {
+  stdout += chunk.toString();
+  let newline;
+  while ((newline = stdout.indexOf("\n")) >= 0) {
+    const line = stdout.slice(0, newline).trim();
+    stdout = stdout.slice(newline + 1);
+    if (!line) continue;
+    try {
+      messages.push(JSON.parse(line));
+    } catch {
+      // Boot banner and other non-JSON stdout noise.
+    }
+  }
+});
+child.stderr.on("data", (chunk) => {
+  stderr += chunk.toString();
+});
+child.on("error", (error) => fail(`could not run docker: ${error.message}`));
+
+function send(message) {
+  child.stdin.write(`${JSON.stringify(message)}\n`);
+}
+
+send({
+  jsonrpc: "2.0",
+  id: 1,
+  method: "initialize",
+  params: {
+    protocolVersion: "2025-06-18",
+    capabilities: {},
+    clientInfo: { name: "registry-introspection-probe", version: "0" },
+  },
+});
+
+const initDeadline = Date.now() + TIMEOUT_MS;
+const waitForInit = setInterval(() => {
+  const init = messages.find((m) => m.id === 1);
+  if (init) {
+    clearInterval(waitForInit);
+    if (!init.result) fail("initialize returned no result", JSON.stringify(init));
+    if (!init.result.instructions) {
+      fail("initialize carried no `instructions` — the identity claim an indexer reads would be empty");
+    }
+    send({ jsonrpc: "2.0", method: "notifications/initialized" });
+    send({ jsonrpc: "2.0", id: 2, method: "tools/list", params: {} });
+
+    const listDeadline = Date.now() + TIMEOUT_MS;
+    const waitForList = setInterval(() => {
+      const list = messages.find((m) => m.id === 2);
+      if (list) {
+        clearInterval(waitForList);
+        const tools = list.result?.tools;
+        if (!Array.isArray(tools)) fail("tools/list returned no tools array", JSON.stringify(list).slice(0, 400));
+        if (tools.length < MIN_TOOLS) {
+          fail(`tools/list returned ${tools.length} tools, expected at least ${MIN_TOOLS}`);
+        }
+        console.log(
+          `[container-introspection] ok: ${IMAGE} booted, stated its identity, and listed ${tools.length} tools`,
+        );
+        child.kill();
+        process.exit(0);
+      }
+      if (Date.now() > listDeadline) fail("timed out waiting for tools/list", stderr.slice(-800));
+    }, 200);
+    return;
+  }
+  if (Date.now() > initDeadline) fail("timed out waiting for initialize", stderr.slice(-800));
+}, 200);


### PR DESCRIPTION
## What happened

Glama sent a failed-build notice. Per [its indexing methodology](https://glama.ai/mcp/methodology), Glama builds every listed MCP server from a Dockerfile — the maintainer's if one is checked in, otherwise one its AI infers from the project structure — and runs protocol introspection inside a Firecracker sandbox. When that build fails, the listing page is kept but **distribution is withheld**: the server stops appearing in search results, category listings, and recommendations until a reproducible build succeeds. (Content rephrased for compliance with licensing restrictions.)

AirMCP had no Dockerfile, so it was on the inferred path — and that path cannot succeed, because `package.json` declares `"os": ["darwin"]` and npm refuses to install on Linux with `EBADPLATFORM`.

**So this is a discoverability outage, not a cosmetic badge.** AirMCP is currently absent from Glama search and category listings.

## Why a Linux build is viable at all

I checked before writing anything:

- all six runtime dependencies (`@modelcontextprotocol/sdk`, `@modelcontextprotocol/ext-apps`, `express`, `jose`, `yaml`, `zod`) are pure JavaScript — no native or darwin-only package, no `optionalDependencies`
- nothing exits or throws on a non-darwin platform. `getOsVersion()` returns `0` there, which is the documented **inert ceiling where every OS gate passes** — the same value `scripts/dump-tool-manifest.mjs` pins to keep the checked-in manifest reproducible across runners
- verified locally that the server boots, carries `instructions` in the initialize result, and answers `tools/list` under those conditions

## The Dockerfile is explicit about what it is not

It states in its header that it is **not a supported way to run AirMCP**. Tool calls go through JXA / osascript / the Swift bridges and will fail in a container; the image exists so an indexer can complete introspection and score the tool schemas.

Three deliberate choices:

- `npm ci --force` — downgrades the darwin `EBADPLATFORM` check to a warning
- `--ignore-scripts` — skips the `prepare` hook, which runs husky, a git-hook installer with no repository to attach to in the image
- `AIRMCP_PROFILE=full` — so the captured schemas match the documented surface instead of the cold-boot starter subset

## The gate matters as much as the fix

Adds a `registry-introspection` job on `ubuntu-latest` that builds the image and runs `scripts/verify-container-introspection.mjs` against it, asserting the server boots, states its identity, and returns a non-empty `tools/list`.

This break was **invisible from inside the repo** until a registry email arrived. Same reasoning as the `format:check` gate in #416: a check that exists but nothing runs is not a check.

## Validation

- `eslint src/`, `prettier --check src/` clean; `package.json` and `ci.yml` both parse
- full suite: **225 suites / 2893 tests passing**
- **the Docker build itself is verified by this PR's own new CI job**, not locally — the local container VM (`colima`) points at an unmounted external volume, so I could not build the image on this machine and am deliberately not claiming otherwise. The `ubuntu-latest` job is the real verification; if `npm ci --force` does not clear `EBADPLATFORM` as expected, this PR fails rather than merging on my assumption.

## Follow-up worth considering

Glama scores every captured tool with its Tool Definition Quality Score and publishes the per-dimension breakdown on the listing. Once the build is green, that score becomes visible and actionable — a separate pass over tool descriptions (usage constraints, side-effect transparency) would land on a surface that is now being measured.
