### PR TITLE
fix(release): gate the signed app lane on a variable instead of a phantom approval

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -186,15 +186,34 @@ jobs:
       # Events created with GITHUB_TOKEN do not recursively trigger tag-push
       # workflows. Dispatch the signed lane explicitly and let that workflow
       # re-check the immutable tag, package, bundle, and signing environment.
+      #
+      # Gated on the SIGNED_APP_RELEASE repository variable rather than dispatched
+      # unconditionally. Until the Apple signing secrets exist in the `release`
+      # environment, dispatching only produced a deployment-approval request for a
+      # run whose first step would then discover it cannot sign — and, because it
+      # was dispatched with require_signing=false, exit 0 and record a green
+      # "signed release" that produced no artifact. A variable is readable without
+      # entering a protected environment, so the decision can be made before the
+      # approval gate instead of after it.
       - name: Dispatch signed app release
+        if: vars.SIGNED_APP_RELEASE == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
           RELEASE_TAG: v${{ steps.pkg.outputs.version }}
         run: |
+          # require_signing=true: once an operator has declared signing enabled, a
+          # missing secret is a real failure, not something to skip past quietly.
           gh workflow run release-app.yml \
             --ref "$RELEASE_TAG" \
             --field tag="$RELEASE_TAG" \
-            --field require_signing=false
+            --field require_signing=true
+
+      - name: Note that the signed app lane was skipped
+        if: vars.SIGNED_APP_RELEASE != 'true'
+        run: |
+          echo "::notice::Signed app release skipped — repository variable SIGNED_APP_RELEASE is not 'true'."
+          echo "::notice::To enable: add APPLE_DEVELOPER_ID, APPLE_ID, APPLE_ID_PASSWORD, APPLE_TEAM_ID, APPLE_CERT_P12_BASE64, APPLE_CERT_P12_PASSWORD to the 'release' environment, then set SIGNED_APP_RELEASE=true."
+          echo "::notice::npm and .mcpb distribution are unaffected."
 
       - name: Verify public release state
         env:

--- a/.github/workflows/release-app.yml
+++ b/.github/workflows/release-app.yml
@@ -118,6 +118,14 @@ jobs:
 
   release-app:
     needs: resolve-release
+    # `environment: release` requests a deployment approval the moment this job is
+    # reached, and the signing-secret preflight is a STEP inside it — so without
+    # this guard a human is asked to approve a run that then discovers it cannot
+    # sign. Secrets are unreadable outside a protected environment, but a
+    # repository variable is not, so the switch has to live here to be evaluated
+    # before the gate. Unset or not 'true' means the whole lane is skipped rather
+    # than approved-then-skipped.
+    if: vars.SIGNED_APP_RELEASE == 'true'
     runs-on: macos-latest
     environment: release
     permissions:


### PR DESCRIPTION
## The signed app lane has never produced an artifact

Not "is broken" — has never worked. Evidence:

- its one "success", run `28551821523` (2026-07-01), records `signing-preflight => success` and **`release-app => skipped`**
- no GitHub Release carries anything but `airmcp-<version>.mcpb` — no signed app, at any version
- the `release` environment holds **none** of the six Apple secrets, the repo holds only `NPM_TOKEN`, and the owner is a personal account so nothing is inherited from an org

## Two failure modes

**A human was asked to approve a run that provably could not do anything.** `release-app` declares `environment: release` with no `if:`, so the deployment approval is requested the moment the job is reached — while the signing-secret preflight is a *step inside that job*. Approval therefore comes **before** the check. An older job graph gated this with a separate `signing-preflight` job; collapsing it into a step moved the gate ahead of the check.

**And approving it would have recorded a false green.** `cd.yml` dispatched with `require_signing=false`, so the preflight's response to missing secrets is `::notice` + `exit 0`. Every signing step is `if: steps.signing.outputs.ready == 'true'`, so they all skip and the run reports success having shipped nothing.

## Fix

Secrets cannot be read outside a protected environment, but a **repository variable can** — so the switch has to live where it is evaluated before the gate.

- `release-app` runs only when `vars.SIGNED_APP_RELEASE == 'true'` — an unconfigured repo skips the lane instead of approving-then-skipping
- `cd.yml` dispatches only under the same condition, and now passes `require_signing=true`: once an operator has declared signing enabled, a missing secret is a real failure rather than something to step past
- when the variable is unset, `cd.yml` emits a notice naming the six secrets and the variable, and states that npm and `.mcpb` distribution are unaffected

## How to turn signing on later

1. add `APPLE_DEVELOPER_ID`, `APPLE_ID`, `APPLE_ID_PASSWORD`, `APPLE_TEAM_ID`, `APPLE_CERT_P12_BASE64`, `APPLE_CERT_P12_PASSWORD` to the `release` environment
2. set repository variable `SIGNED_APP_RELEASE=true`

Nothing else changes. Until then the lane is silent instead of noisy.

## Pending deployment

The approval waiting on run `30539316193` was **rejected**, not approved — approving it could only have produced another green run with no artifact. That run is now closed and there are 0 pending deployments.

## No public claim needed correcting

`docs/REGISTRY_SUBMISSIONS.md` already states notarization is not shipped, and the README makes no signing or Gatekeeper claim. So unlike #414, there was no overclaim to walk back here — the gap was in the pipeline, not the docs.

## Validation

- both workflow files parse as YAML
- `tests/governed-acceptance-wiring.test.js` and `tests/release-workflow-hardening.test.js` both assert against `release-app.yml` structure and still pass
- full suite: **225 suites / 2893 tests passing**
