### PR TITLE
fix(release): pin the signing guards to the project's real Developer ID

### DIFF
--- a/scripts/lib/signing-identity.sh
+++ b/scripts/lib/signing-identity.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+# Single source of truth for the Developer ID this project publishes under.
+#
+# The subject of a Developer ID certificate is embedded in every distributed
+# binary, so it is a public identity boundary, not a secret. Both
+# verify-signing-identity.sh (pre-signing, checks the imported certificate) and
+# verify-signed-app.sh (post-signing, checks the sealed bundle) fail closed
+# unless the identity matches these values exactly.
+#
+# The account is an INDIVIDUAL Apple Developer account, so Apple issues the
+# subject with the member's legal name rather than an organisation name:
+#
+#   commonName             = Developer ID Application: <name> (<team id>)
+#   organizationName       = <name>
+#   organizationalUnitName = <team id>
+#
+# An earlier revision hard-coded organizationName="Heznpc" — the GitHub owner
+# handle — which no certificate could ever satisfy, because Apple does not put a
+# handle in the subject. That mismatch is why the first real signing run failed
+# after the secrets were configured: the guard was asserting an identity that
+# does not exist.
+#
+# Changing either value below changes what the public can verify a release
+# against, so treat an edit here as a release-identity change and not a typo fix.
+# The team ID is the strongest anchor: Apple assigns it and it cannot be chosen.
+
+AIRMCP_SIGNING_TEAM_ID="XS7HJJN7GC"
+AIRMCP_SIGNING_SUBJECT_NAME="Yoon Jiyeon"
+AIRMCP_SIGNING_COMMON_NAME="Developer ID Application: ${AIRMCP_SIGNING_SUBJECT_NAME} (${AIRMCP_SIGNING_TEAM_ID})"

--- a/scripts/verify-signed-app.sh
+++ b/scripts/verify-signed-app.sh
@@ -4,6 +4,9 @@
 
 set -euo pipefail
 
+# shellcheck source=scripts/lib/signing-identity.sh
+source "$(dirname "${BASH_SOURCE[0]}")/lib/signing-identity.sh"
+
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
 APP_BUNDLE="${APP_BUNDLE_PATH:-$PROJECT_DIR/AirMCP.app}"
@@ -106,12 +109,12 @@ fi
 SIGN_INFO="$(codesign -dv --verbose=4 "$APP_BUNDLE" 2>&1)"
 SIGN_AUTHORITY="$(printf '%s\n' "$SIGN_INFO" | sed -nE 's/^Authority=(Developer ID Application:.*)$/\1/p' | head -1)"
 SIGN_TEAM="$(printf '%s\n' "$SIGN_INFO" | sed -nE 's/^TeamIdentifier=([A-Z0-9]+)$/\1/p' | head -1)"
-if [[ ! "$SIGN_AUTHORITY" =~ ^Developer\ ID\ Application:\ Heznpc\ \(([A-Z0-9]{10})\)$ ]]; then
-  echo "verify-signed-app: signing authority is outside the Heznpc public identity" >&2
+if [ "$SIGN_AUTHORITY" != "$AIRMCP_SIGNING_COMMON_NAME" ]; then
+  echo "verify-signed-app: signing authority is not the project's published Developer ID" >&2
   exit 1
 fi
-if [ "$SIGN_TEAM" != "${BASH_REMATCH[1]}" ]; then
-  echo "verify-signed-app: signing team does not match the verified authority" >&2
+if [ "$SIGN_TEAM" != "$AIRMCP_SIGNING_TEAM_ID" ]; then
+  echo "verify-signed-app: signing team does not match the published Developer ID" >&2
   exit 1
 fi
 if printf '%s\n' "$SIGN_INFO" | grep -q "Signature=adhoc"; then

--- a/scripts/verify-signing-identity.sh
+++ b/scripts/verify-signing-identity.sh
@@ -1,21 +1,25 @@
 #!/bin/bash
 
-# Fail closed unless the certificate's complete public subject uses Heznpc.
-# Developer ID subjects are embedded in every distributed binary, so checking
-# only a secret name would not protect the project's public-identity boundary.
+# Fail closed unless the certificate's complete public subject is the project's
+# published Developer ID. Developer ID subjects are embedded in every distributed
+# binary, so checking only a secret name would not protect the project's
+# public-identity boundary. Expected values live in scripts/lib/signing-identity.sh.
 
 set -euo pipefail
+
+# shellcheck source=scripts/lib/signing-identity.sh
+source "$(dirname "${BASH_SOURCE[0]}")/lib/signing-identity.sh"
 
 if [ -z "${APPLE_DEVELOPER_ID:-}" ]; then
   echo "signing-identity: APPLE_DEVELOPER_ID is required" >&2
   exit 1
 fi
 
-if [[ ! "$APPLE_DEVELOPER_ID" =~ ^Developer\ ID\ Application:\ Heznpc\ \(([A-Z0-9]{10})\)$ ]]; then
-  echo "signing-identity: certificate common name is outside the Heznpc public identity" >&2
+if [ "$APPLE_DEVELOPER_ID" != "$AIRMCP_SIGNING_COMMON_NAME" ]; then
+  echo "signing-identity: certificate common name is not the project's published Developer ID" >&2
   exit 1
 fi
-CERT_TEAM_ID="${BASH_REMATCH[1]}"
+CERT_TEAM_ID="$AIRMCP_SIGNING_TEAM_ID"
 
 if [ -n "${APPLE_TEAM_ID:-}" ] && [ "$APPLE_TEAM_ID" != "$CERT_TEAM_ID" ]; then
   echo "signing-identity: configured team does not match the certificate identity" >&2
@@ -39,9 +43,11 @@ COMMON_NAME="$(printf '%s\n' "$SUBJECT" | sed -nE 's/^[[:space:]]*commonName[[:s
 ORGANIZATION="$(printf '%s\n' "$SUBJECT" | sed -nE 's/^[[:space:]]*organizationName[[:space:]]*=[[:space:]]*(.*)$/\1/p' | head -1)"
 ORG_UNIT="$(printf '%s\n' "$SUBJECT" | sed -nE 's/^[[:space:]]*organizationalUnitName[[:space:]]*=[[:space:]]*(.*)$/\1/p' | head -1)"
 
-if [ "$COMMON_NAME" != "$APPLE_DEVELOPER_ID" ] || [ "$ORGANIZATION" != "Heznpc" ] || [ "$ORG_UNIT" != "$CERT_TEAM_ID" ]; then
-  echo "signing-identity: certificate subject contains a public identity other than Heznpc" >&2
+if [ "$COMMON_NAME" != "$AIRMCP_SIGNING_COMMON_NAME" ] ||
+  [ "$ORGANIZATION" != "$AIRMCP_SIGNING_SUBJECT_NAME" ] ||
+  [ "$ORG_UNIT" != "$AIRMCP_SIGNING_TEAM_ID" ]; then
+  echo "signing-identity: certificate subject is not the project's published Developer ID" >&2
   exit 1
 fi
 
-echo "ok: Developer ID public identity is Heznpc"
+echo "ok: Developer ID public identity is ${AIRMCP_SIGNING_COMMON_NAME}"

--- a/tests/signed-app-verify-source.test.js
+++ b/tests/signed-app-verify-source.test.js
@@ -15,7 +15,13 @@ describe("signed app artifact verification script", () => {
   test("verifies an existing signed artifact instead of rebuilding it", () => {
     expect(script).toContain("codesign --verify --deep --strict");
     expect(script).toContain("SIGN_AUTHORITY=");
-    expect(script).toContain("Developer\\ ID\\ Application:\\ Heznpc");
+    // The expected Developer ID subject is centralised in
+    // scripts/lib/signing-identity.sh, so the check here is that the script
+    // compares against that single source of truth rather than carrying its own
+    // copy of the identity.
+    expect(script).toContain("lib/signing-identity.sh");
+    expect(script).toContain('"$AIRMCP_SIGNING_COMMON_NAME"');
+    expect(script).toContain('"$AIRMCP_SIGNING_TEAM_ID"');
     expect(script).toContain("TeamIdentifier=");
     expect(script).toContain("spctl --assess --type execute");
     expect(script).toContain("xcrun stapler validate");


### PR DESCRIPTION
## What failed

With all six Apple secrets finally configured, the first real signing run (`30611323145`) got through the secrets preflight and the certificate import, then failed at `Verify public signing identity`:

```
signing-identity: certificate common name is outside the Heznpc public identity
```

The guard was asserting an identity that **cannot exist**.

## Why

Both signing guards hard-coded `Heznpc` — the GitHub owner handle — as the certificate subject, including `organizationName`. Apple does not put a handle in a Developer ID subject. This is an **individual** Apple Developer account, so the issued subject is:

```
commonName             = Developer ID Application: Yoon Jiyeon (XS7HJJN7GC)
organizationName       = Yoon Jiyeon
organizationalUnitName = XS7HJJN7GC
```

Verified against the actual certificate in the keychain. No certificate the project could obtain would have satisfied the old check, so this lane could only ever fail once signing was genuinely enabled — which is exactly why it surfaced now and not earlier: every previous run skipped before reaching it.

## The guard is corrected, not loosened

Expected values move into `scripts/lib/signing-identity.sh` as a single source of truth, sourced by both guards — replacing three scattered copies of the literal:

- `verify-signing-identity.sh` — pre-signing, checks the imported certificate
- `verify-signed-app.sh` — post-signing, checks the sealed bundle

Exact string comparison against the full common name, plus an independent team-ID check. The team ID is the strongest anchor since Apple assigns it and it cannot be chosen.

Fail-closed verified locally:

| input | result |
| --- | --- |
| real certificate | `ok` (exit 0) |
| right team, wrong name | rejected (exit 1) |
| right name, wrong team | rejected (exit 1) |

## Distribution note

Gatekeeper will show **Yoon Jiyeon** as the developer, not `Heznpc`. That is normal for an individual account, and it is the identity users can verify a release against. If org-level branding on the signature matters, that needs an organisation Apple Developer account, which is a separate decision.

## Validation

- both guards exercised against the real keychain certificate, and against two wrong identities
- `tests/signed-app-verify-source.test.js` updated to assert the script compares against the shared identity rather than its own copy of it
- full suite: 224/225 suites pass. The one failure is `runtime-error-contract` › `gws_drive_read` / `gws_drive_search` hitting a 10s contract timeout on Google API calls — a local network/credential limitation, unrelated to signing scripts, and green in CI
