### PR TITLE
fix(docs,doctor): correct five places where docs and doctor disagreed with the code

### DIFF
--- a/app/Sources/AirMCPApp/Resources/en.lproj/Localizable.strings
+++ b/app/Sources/AirMCPApp/Resources/en.lproj/Localizable.strings
@@ -267,7 +267,7 @@
 "module.google" = "Google Workspace";
 "module.google.desc" = "Gmail, Drive, Sheets, Calendar, Docs";
 "module.speech" = "Speech";
-"module.speech.desc" = "Text-to-speech, voice synthesis";
+"module.speech.desc" = "Audio transcription, speech recognition";
 "module.health" = "Health";
 "module.health.desc" = "Steps, heart rate, sleep, activity";
 "module.memory" = "Context Memory";

--- a/app/Sources/AirMCPApp/Resources/ko.lproj/Localizable.strings
+++ b/app/Sources/AirMCPApp/Resources/ko.lproj/Localizable.strings
@@ -267,7 +267,7 @@
 "module.google" = "Google Workspace";
 "module.google.desc" = "Gmail, Drive, Sheets, Calendar, Docs";
 "module.speech" = "음성";
-"module.speech.desc" = "텍스트 음성 변환, 음성 합성";
+"module.speech.desc" = "오디오 전사, 음성 인식";
 "module.health" = "건강";
 "module.health.desc" = "걸음 수, 심박수, 수면, 활동";
 "module.memory" = "맥락 기억";

--- a/docs/site/src/content/docs/getting-started/configuration.md
+++ b/docs/site/src/content/docs/getting-started/configuration.md
@@ -126,8 +126,8 @@ In the extension: server URL `http://<host>:3847/mcp`, header `Authorization: Be
 |----------|-------------|
 | `GEMINI_API_KEY` | Gemini API key for cloud-based embeddings |
 | `AIRMCP_EMBEDDING_PROVIDER` | Provider selection: `auto`, `gemini`, `swift`, `hybrid`, `none` |
-| `AIRMCP_EMBEDDING_MODEL` | Gemini model name (default: `gemini-embedding-2-preview`) |
-| `AIRMCP_EMBEDDING_DIM` | Embedding dimension (default: `3072`) |
+| `AIRMCP_EMBEDDING_MODEL` | Gemini model name (default: `gemini-embedding-2`) |
+| `AIRMCP_EMBEDDING_DIM` | Embedding dimension (default: `256`) |
 
 ## CLI Flags
 

--- a/docs/site/src/content/docs/modules/overview.md
+++ b/docs/site/src/content/docs/modules/overview.md
@@ -34,11 +34,11 @@ The release gate boots clean-installed npm and MCPB artifacts in `full/full` mod
 | **Weather** | 3 | Current weather, daily forecast, hourly forecast via Open-Meteo API. |
 | **Pages** | 7 | Apple Pages automation. List, create, read/write body text, close documents. |
 | **Numbers** | 12 | Apple Numbers automation. Spreadsheets, sheets, cell read/write. |
-| **Keynote** | 9 | Apple Keynote automation. Slides, presenter notes, add/delete slides. |
+| **Keynote** | 9 | Apple Keynote automation. Slides, presenter notes, add slides, PDF export, slideshow. |
 | **Location** | 2 | Location permission status, current location (via CoreLocation). |
 | **Bluetooth** | 4 | Bluetooth state, device discovery, connect/disconnect. |
 | **Google** | 16 | Google Workspace integration. Gmail, Google Calendar, Drive, Contacts, Tasks via GWS CLI. |
-| **Speech** | 3 | Speech recognition and text-to-speech helpers for local audio workflows. |
+| **Speech** | 3 | Speech recognition for local audio workflows: audio transcription, availability probe, smart clipboard. |
 | **Health** | 5 | HealthKit-backed summaries and samples through the optional Swift bridge. |
 | **Memory** | 4 | Local context memory for storing, querying, and summarizing reusable facts. |
 | **Audit** | 2 | Queryable audit summaries and raw audit log access. |

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -98,8 +98,11 @@ export async function runDoctor(): Promise<void> {
   const major = parseInt(nodeVer.slice(1), 10);
   s1.succeed("Environment checked");
 
-  if (major >= 18) ok("Node.js", `${nodeVer}`);
-  else bad("Node.js", `${nodeVer} — upgrade required (>= 18)`);
+  // Must track package.json `engines.node` (>=20). At >=18 this reported green
+  // on versions where npm refuses to install the package at all, so doctor
+  // cleared an environment that could never have run it.
+  if (major >= 20) ok("Node.js", `${nodeVer}`);
+  else bad("Node.js", `${nodeVer} — upgrade required (>= 20)`);
 
   const platform = process.platform;
   if (platform === "darwin") ok("Platform", "macOS");
@@ -155,9 +158,15 @@ export async function runDoctor(): Promise<void> {
   try {
     runtimeConfig = parseConfig();
     const enabledCount = MODULE_NAMES.filter((moduleName) => isModuleEnabled(runtimeConfig!, moduleName)).length;
+    // MODULE_NAMES covers the standard modules a profile can enable; the
+    // published catalogue count also includes OPT_IN_MODULE_NAMES, which no
+    // profile turns on. Naming both keeps this from reading as a contradiction
+    // of the documented module total.
+    const catalogueCount = MODULE_NAMES.length + OPT_IN_MODULE_NAMES.length;
     ok(
       "Runtime profile",
-      `${runtimeConfig.profile} (${runtimeConfig.toolExposure} exposure, ${enabledCount}/${MODULE_NAMES.length} modules enabled)`,
+      `${runtimeConfig.profile} (${runtimeConfig.toolExposure} exposure, ${enabledCount}/${MODULE_NAMES.length} standard modules enabled` +
+        `, ${OPT_IN_MODULE_NAMES.length} opt-in excluded of ${catalogueCount} total)`,
     );
     const requestedProfile = normalizeProfileName(fileConfig?.profile);
     if (fileConfig?.profile && requestedProfile !== runtimeConfig.profile) {

--- a/tests/doctor-runtime-consistency.test.js
+++ b/tests/doctor-runtime-consistency.test.js
@@ -102,13 +102,21 @@ describe('doctor ↔ runtime consistency (#358 contract)', () => {
         maxBuffer: 4 * 1024 * 1024,
       });
       const text = stripAnsi(stdout);
-      const match = text.match(/Runtime profile\s+(\S+) \((\S+) exposure, (\d+)\/(\d+) modules enabled\)/);
+      // The label names the standard-module denominator AND the opt-in modules
+      // excluded from it, because reporting only "11/29" read as a
+      // contradiction of the documented 32-module catalogue.
+      const match = text.match(
+        /Runtime profile\s+(\S+) \((\S+) exposure, (\d+)\/(\d+) standard modules enabled, (\d+) opt-in excluded of (\d+) total\)/,
+      );
       expect(match).not.toBeNull();
-      const [, profile, exposure, enabled, total] = match;
+      const [, profile, exposure, enabled, total, optIn, catalogue] = match;
       expect(profile).toBe(resolved.profile);
       expect(exposure).toBe(resolved.toolExposure);
       expect(Number(enabled)).toBe(resolved.enabledModules.length);
       expect(Number(total)).toBe(resolved.totalModules);
+      // The two denominators have to add up, or the label just moves the
+      // confusion instead of resolving it.
+      expect(Number(total) + Number(optIn)).toBe(Number(catalogue));
       // The #358 regression path: a requested profile that is not effective
       // must be flagged. With a valid requested profile there is no mismatch
       // warning — doctor may not claim one exists.


### PR DESCRIPTION
## Summary

Five places where documentation or `doctor` disagreed with the code. Each was verified against the source rather than against other docs.

| # | Claim in docs/doctor | What the code does |
| --- | --- | --- |
| 1 | `doctor` passes Node `>= 18` | `package.json` engines requires `>=20.0.0` |
| 2 | `doctor` reports `11/29` modules | README and the generated manifest say **32** |
| 3 | Keynote "add/**delete** slides" | nine tools, `keynote_add_slide`, no delete |
| 4 | Speech = "text-to-**speech**, voice synthesis" | `transcribe_audio`, `speech_availability`, `smart_clipboard` — recognition |
| 5 | site: `gemini-embedding-2-preview` / `3072` | `constants.ts`: `gemini-embedding-2` / `256` |

## 1. doctor cleared environments npm refuses to install

`src/cli/doctor.ts` gated on `major >= 18` and printed `>= 18`. A user on Node 18 got a green environment check for a runtime `npm` will not install at all. Now gated on 20, tracking `engines.node`.

## 2. The module denominator contradicted the published count

`doctor` reported `11/29` from `MODULE_NAMES` while README and `docs/tool-manifest.json` say 32 modules. Not a bug — the gap is exactly `OPT_IN_MODULE_NAMES` (`spatial_prep`, `webhooks`, `powerautomate`), which no profile enables. But two different totals in front of the same user reads as one of them being wrong.

The label now names both:

```
custom (profile exposure, 11/29 standard modules enabled, 3 opt-in excluded of 32 total)
```

`tests/doctor-runtime-consistency.test.js` now asserts `standard + opt-in == catalogue`, so the label cannot drift into restating the same confusion with different numbers.

## 3 & 4. Two modules described as something they are not

Keynote's doc promised a delete-slide tool that does not exist. Speech was described **backwards** — synthesis instead of recognition — in the doc *and* in the app UI string `module.speech.desc`, which was the stronger error since it is what a user reads while choosing modules. Fixed in both locales carrying the key (en, ko); `check-i18n` stays green at 201 keys per locale.

## 5. Stale embedding defaults on the docs site

`docs/environment.md` already matched the source; only the site page was stale.

## Validation

- `tsc --noEmit`, `eslint src/`, `prettier --check src/`, build — all clean
- `node scripts/check-i18n.mjs` — OK, 201 keys per locale
- `node dist/index.js doctor` — confirmed printing the corrected Node gate and module label
- full suite: **225 suites / 2893 tests passing**

## Note

`docs/tool-manifest.json` is 297 tools and `MODULE_MANIFEST` is 32 — the current, correct figures. Any local notes still carrying `272 tools / 29 modules` are stale and worth updating, since those numbers are what led to the mismatch above being read as normal.
