### PR TITLE
fix(release): sign the embedded Node runtime with JIT entitlements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Signed app's embedded Node runtime crashed on launch** — `notarize-app.sh` signed the bundled Node binary with the hardened runtime and no entitlements. V8 needs writable-then-executable JIT pages, which the hardened runtime forbids by default, so the re-signed binary died with SIGTRAP before `main()`: the bundle signed, notarized, and stapled cleanly while its embedded server could never start. Found on the first real signed run of v2.16.3, where `verify-bundle-structure.sh` caught it by executing the bundled runtime — after Apple had already accepted the broken artifact. The Node binary is now signed with `allow-jit` and `allow-unsigned-executable-memory` from `scripts/lib/node-runtime-entitlements.plist`; the Swift bridge stays on the default entitlement set.
+
 ## [2.16.3] - 2026-07-31
 
 ### Fixed

--- a/scripts/lib/node-runtime-entitlements.plist
+++ b/scripts/lib/node-runtime-entitlements.plist
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <!-- V8 allocates writable-then-executable JIT pages. Under the hardened
+       runtime both keys are required for the embedded Node binary to run at
+       all: without them the process dies with SIGTRAP before main(), so the
+       bundled server can never start. AirMcpBridge (Swift, no JIT) must NOT
+       receive these — grant them only to the Node runtime. -->
+  <key>com.apple.security.cs.allow-jit</key><true/>
+  <key>com.apple.security.cs.allow-unsigned-executable-memory</key><true/>
+</dict>
+</plist>

--- a/scripts/notarize-app.sh
+++ b/scripts/notarize-app.sh
@@ -93,6 +93,20 @@ done
 # The self-contained app embeds executable Node and Swift bridge binaries.
 # They are nested code and must receive the same Developer ID + hardened
 # runtime treatment before the outer bundle is signed.
+#
+# The Node binary additionally needs JIT entitlements: V8 requires
+# writable-then-executable pages, which the hardened runtime forbids by
+# default. Signing node without them produces a bundle that signs, notarizes,
+# and staples cleanly but whose embedded runtime dies with SIGTRAP before
+# main() — verify-bundle-structure.sh catches this because it executes the
+# bundled runtime, but only after a wasted notarization round-trip. The
+# Swift bridge performs no JIT and must stay on the default (stricter)
+# entitlement set.
+NODE_RUNTIME_ENTITLEMENTS="$SCRIPT_DIR/lib/node-runtime-entitlements.plist"
+if [ ! -f "$NODE_RUNTIME_ENTITLEMENTS" ]; then
+  echo "notarize-app: node runtime entitlements file missing" >&2
+  exit 1
+fi
 for nested in \
   "$APP_BUNDLE/Contents/Resources/airmcp/runtime/bin/node" \
   "$APP_BUNDLE/Contents/Resources/airmcp/bin/AirMcpBridge"; do
@@ -101,7 +115,11 @@ for nested in \
     exit 1
   fi
   echo "  signing embedded executable"
-  if ! codesign --force --options=runtime --timestamp \
+  NESTED_SIGN_ARGS=(--force --options=runtime --timestamp)
+  if [ "$(basename "$nested")" = "node" ]; then
+    NESTED_SIGN_ARGS+=(--entitlements "$NODE_RUNTIME_ENTITLEMENTS")
+  fi
+  if ! codesign "${NESTED_SIGN_ARGS[@]}" \
     --sign "$APPLE_DEVELOPER_ID" \
     "$nested" >/dev/null 2>&1; then
     echo "notarize-app: embedded executable signing failed" >&2


### PR DESCRIPTION
## Problem

The signed app lane produces a bundle whose embedded Node runtime cannot execute. `notarize-app.sh` re-signs the bundled Node binary with `--options=runtime` and no entitlements; V8 needs writable-then-executable JIT pages, which the hardened runtime forbids, so the binary dies with SIGTRAP before `main()`.

The failure is invisible to the signing pipeline itself: the bundle **signs, notarizes (Accepted), and staples cleanly** — Apple validates the signature, not runnability. It surfaced on the first real signed run of v2.16.3, when `verify-bundle-structure.sh` executed the bundled runtime (`node dist/index.js --version`) and the process died with exit 133.

## Fix

- New `scripts/lib/node-runtime-entitlements.plist` with `com.apple.security.cs.allow-jit` + `com.apple.security.cs.allow-unsigned-executable-memory`, applied only to the Node binary in the nested-signing loop.
- `AirMcpBridge` (Swift, no JIT) deliberately stays on the default entitlement set.

## Verification

Applied the same re-sign to the v2.16.3 bundle locally: embedded node executes, `verify-bundle-structure.sh` passes, re-notarization Accepted, `verify-signed-app.sh` full guard passes, Gatekeeper assessment `accepted / Notarized Developer ID`.