### PR TITLE
fix(audit): migrate mixed-version legacy chains, disclose unverified rows, isolate tests from the real usage profile

### DIFF
--- a/docs/tool-manifest.json
+++ b/docs/tool-manifest.json
@@ -809,6 +809,31 @@
           },
           "auditDisabled": {
             "type": "boolean"
+          },
+          "unverifiedTailRows": {
+            "type": "number"
+          },
+          "unsignedLegacyRows": {
+            "type": "number"
+          },
+          "quarantined": {
+            "type": "object",
+            "properties": {
+              "files": {
+                "type": "number"
+              },
+              "rows": {
+                "type": "number"
+              }
+            },
+            "required": [
+              "files",
+              "rows"
+            ],
+            "additionalProperties": false
+          },
+          "legacyMixedBreak": {
+            "type": "boolean"
           }
         },
         "required": [
@@ -820,7 +845,11 @@
           "topTools",
           "byActor",
           "verified",
-          "auditDisabled"
+          "auditDisabled",
+          "unverifiedTailRows",
+          "unsignedLegacyRows",
+          "quarantined",
+          "legacyMixedBreak"
         ],
         "additionalProperties": false
       },

--- a/scripts/clean-profile-residue.mjs
+++ b/scripts/clean-profile-residue.mjs
@@ -1,0 +1,95 @@
+#!/usr/bin/env node
+/**
+ * Remove test-fixture residue from a usage profile (~/.airmcp/profile.json).
+ *
+ * Historical test/harness runs that escaped disk isolation left fixture tool
+ * names (tool_a, tool_b, foo, test_tool, tool_0…) inside a real user
+ * profile's `frequency` / `sequences` / `hourly` maps, and the tracker's
+ * merge-on-load cycle preserves them forever. Source-side isolation now
+ * prevents new leaks (usage-tracker.ts test-mode guard + clean-boot-env);
+ * this script cleans up profiles contaminated before that fix.
+ *
+ * Usage:
+ *   node scripts/clean-profile-residue.mjs [path] [--apply]
+ *
+ *   path     profile to clean (default: ~/.airmcp/profile.json, or
+ *            $AIRMCP_USAGE_PROFILE_PATH when set)
+ *   --apply  actually rewrite the file (atomic tmp+rename). Without it the
+ *            script is a dry run: it only prints what would be removed.
+ *
+ * Exit codes: 0 = clean or cleaned, 1 = usage / IO / parse error.
+ */
+import { readFileSync, writeFileSync, renameSync, statSync } from "node:fs";
+import { homedir } from "node:os";
+import { join, dirname, basename } from "node:path";
+
+// Fixture names used by the repo's own tests and harnesses. `tool_<simple>`
+// deliberately requires a single [a-z0-9] run after the underscore so real
+// tools like `tool_session_status` (extra underscore) can never match.
+const RESIDUE_RE = /^(tool_[a-z0-9]+|test_tool|foo)$/;
+const isResidue = (name) => RESIDUE_RE.test(name);
+const sequenceHasResidue = (key) => key.split(" → ").some((part) => isResidue(part.trim()));
+
+const args = process.argv.slice(2);
+const apply = args.includes("--apply");
+const positional = args.filter((a) => a !== "--apply");
+if (positional.length > 1) {
+  console.error("usage: node scripts/clean-profile-residue.mjs [path] [--apply]");
+  process.exit(1);
+}
+const profilePath =
+  positional[0] ?? process.env.AIRMCP_USAGE_PROFILE_PATH ?? join(homedir(), ".airmcp", "profile.json");
+
+let profile;
+try {
+  profile = JSON.parse(readFileSync(profilePath, "utf-8"));
+} catch (err) {
+  console.error(`cannot read profile at ${profilePath}: ${err?.message ?? err}`);
+  process.exit(1);
+}
+
+const removed = { frequency: [], sequences: [], hourly: [] };
+for (const key of Object.keys(profile.frequency ?? {})) {
+  if (isResidue(key)) {
+    removed.frequency.push(`${key} (${profile.frequency[key]})`);
+    delete profile.frequency[key];
+  }
+}
+for (const key of Object.keys(profile.sequences ?? {})) {
+  if (sequenceHasResidue(key)) {
+    removed.sequences.push(`${key} (${profile.sequences[key]})`);
+    delete profile.sequences[key];
+  }
+}
+for (const key of Object.keys(profile.hourly ?? {})) {
+  if (isResidue(key)) {
+    removed.hourly.push(key);
+    delete profile.hourly[key];
+  }
+}
+
+const totalRemoved = removed.frequency.length + removed.sequences.length + removed.hourly.length;
+if (totalRemoved === 0) {
+  console.log(`${profilePath}: no test residue found — nothing to do`);
+  process.exit(0);
+}
+
+console.log(`${profilePath}: ${apply ? "removing" : "would remove (dry run — pass --apply)"}`);
+for (const [section, keys] of Object.entries(removed)) {
+  for (const key of keys) console.log(`  ${section}: ${key}`);
+}
+
+if (apply) {
+  const mode = (() => {
+    try {
+      return statSync(profilePath).mode & 0o777;
+    } catch {
+      return 0o600;
+    }
+  })();
+  // Atomic same-directory replacement so a crash can never leave a torn file.
+  const tempPath = join(dirname(profilePath), `.${basename(profilePath)}.clean.${process.pid}.tmp`);
+  writeFileSync(tempPath, JSON.stringify(profile, null, 2), { encoding: "utf-8", mode });
+  renameSync(tempPath, profilePath);
+  console.log(`cleaned ${totalRemoved} residue entr${totalRemoved === 1 ? "y" : "ies"}`);
+}

--- a/scripts/lib/clean-boot-env.mjs
+++ b/scripts/lib/clean-boot-env.mjs
@@ -50,5 +50,11 @@ export function cleanBootEnv(base = process.env) {
   env.AIRMCP_CONFIG_PATH = ABSENT_CONFIG;
   env.AIRMCP_PROFILE = "starter";
   env.AIRMCP_TOOL_EXPOSURE = "progressive";
+  // These gates inherit the REAL HOME (node/npx need it), so any tool call
+  // they make would otherwise be recorded into the developer's real
+  // ~/.airmcp/profile.json usage stats. Belt: disable tracking outright.
+  // Suspenders: usage-tracker.ts also refuses disk persistence whenever
+  // AIRMCP_TEST_MODE=1 without an explicit AIRMCP_USAGE_PROFILE_PATH.
+  env.AIRMCP_USAGE_TRACKING = "false";
   return env;
 }

--- a/src/audit/tools.ts
+++ b/src/audit/tools.ts
@@ -147,6 +147,19 @@ export function registerAuditTools(server: McpServer, _config: AirMcpConfig): vo
         // flush failures). Surfaced so a doctor / health check can flag a gap
         // in coverage rather than reading silence as "nothing happened".
         auditDisabled: z.boolean(),
+        // Coverage disclosure — a broken chain must never silently shrink the
+        // summary. unverifiedTailRows = rows after a chain break that exist on
+        // disk but are not in `total`; unsignedLegacyRows = pre-HMAC rows
+        // still active; quarantined = audit.legacy-untrusted.* snapshot files
+        // (full pre-surgery file images, so rows may overlap the active
+        // chain's surviving prefix).
+        unverifiedTailRows: z.number(),
+        unsignedLegacyRows: z.number(),
+        quarantined: z.object({ files: z.number(), rows: z.number() }),
+        // True when the break is provably key-holder mixed-version history
+        // (old build / concurrent fork) rather than tampering; an upgraded
+        // server quarantines it automatically on its next flush.
+        legacyMixedBreak: z.boolean(),
       },
       annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: false },
     },

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -661,11 +661,23 @@ export async function runDoctor(): Promise<void> {
         ok("Audit HMAC chain", `verified across ${summary.scannedFiles} file(s), ${summary.total} entries`);
       } else if (summary.verifiedFirstBreak) {
         const b = summary.verifiedFirstBreak;
-        bad(
-          "Audit HMAC chain",
-          `break at ${b.file}:${b.lineIndex} (${b.reason}) — possible tampering or corruption. ` +
-            `Inspect the surrounding lines, then call audit_summary to see the full break window.`,
-        );
+        if (summary.legacyMixedBreak) {
+          // Key-holder-written rows under an older chain contract (pre-seq
+          // build or two builds appending concurrently) — not tampering. The
+          // server quarantines this automatically on its next flush.
+          meh(
+            "Audit HMAC chain",
+            `mixed-version legacy history at ${b.file}:${b.lineIndex} (${b.reason}) — ` +
+              `${summary.unverifiedTailRows} unverified row(s) will be quarantined byte-exact on the server's next ` +
+              `audit flush and the chain resumes. If this recurs, an outdated AirMCP build is still writing to this store.`,
+          );
+        } else {
+          bad(
+            "Audit HMAC chain",
+            `break at ${b.file}:${b.lineIndex} (${b.reason}) — possible tampering or corruption. ` +
+              `Inspect the surrounding lines, then call audit_summary to see the full break window.`,
+          );
+        }
       } else {
         meh("Audit HMAC chain", "no chained entries on disk yet");
       }

--- a/src/shared/audit.ts
+++ b/src/shared/audit.ts
@@ -906,7 +906,7 @@ async function flushOneBatch(): Promise<boolean> {
   // Swap before waiting for the OS lock. New events remain ordered in the
   // fresh buffer and the outer queue seals them before its callers return.
   const toFlush = buffer;
-  const toFlushBytes = bufferBytes;
+  let toFlushBytes = bufferBytes;
   buffer = [];
   bufferBytes = 0;
   let appended = false;
@@ -928,6 +928,40 @@ async function flushOneBatch(): Promise<boolean> {
       // failure — re-derive the truth from a full scan before failing closed.
       clearChainTrust();
       disk = await scanAuditChain();
+    }
+    if (!disk.appendable && disk.legacyMixedBreak && !legacyMixedMigrationAttempted) {
+      // Provably key-holder-written history under an older chain contract
+      // (see migrateLegacyMixedHistory). Quarantine it once instead of letting
+      // every flush fail until audit authority is permanently revoked.
+      legacyMixedMigrationAttempted = true;
+      const brokenAt = disk.firstBreak!;
+      const stats = await migrateLegacyMixedHistory(disk);
+      clearChainTrust();
+      disk = await scanAuditChain();
+      if (!disk.appendable) {
+        const detail = disk.firstBreak
+          ? `${disk.firstBreak.file}:${disk.firstBreak.lineIndex} ${disk.firstBreak.reason}`
+          : "unknown integrity failure";
+        throw new Error(`Audit legacy-mixed migration did not restore an appendable chain (${detail})`);
+      }
+      // Seal a self-describing marker as the first post-migration row so the
+      // migration itself is on the tamper-evident record.
+      const marker = JSON.stringify({
+        timestamp: new Date().toISOString(),
+        kind: "tool",
+        tool: "__audit_chain_migration",
+        status: "ok",
+        args: {
+          reason: "legacy_mixed_history",
+          firstAnomaly: `${brokenAt.file}:${brokenAt.lineIndex}`,
+          anomalyReason: brokenAt.reason,
+          quarantinedFiles: stats.quarantinedFiles,
+          quarantinedRows: stats.quarantinedRows,
+          resumedFromHead: stats.previousHead,
+        },
+      });
+      toFlush.unshift(marker);
+      toFlushBytes += Buffer.byteLength(marker, "utf8");
     }
     if (!disk.appendable) {
       const detail = disk.firstBreak
@@ -1143,12 +1177,14 @@ function sortActiveAuditFiles(files: string[]): string[] {
     });
 }
 
+const LEGACY_QUARANTINE_PREFIX = "audit.legacy-untrusted.";
+
 async function createLegacyQuarantineLink(sourcePath: string, sourceName: string): Promise<string> {
   for (let attempt = 0; attempt < 8; attempt++) {
     // This prefix deliberately does not match either active rotation pattern.
     // A hard link preserves the exact original bytes before any active file is
     // unlinked or rewritten, and fails instead of overwriting a collision.
-    const targetPath = join(AUDIT_DIR, `audit.legacy-untrusted.${Date.now()}.${randomUUID()}.${sourceName}`);
+    const targetPath = join(AUDIT_DIR, `${LEGACY_QUARANTINE_PREFIX}${Date.now()}.${randomUUID()}.${sourceName}`);
     try {
       await link(sourcePath, targetPath);
       // Hard links share an inode, so this simultaneously repairs a
@@ -1271,6 +1307,130 @@ async function quarantineUnsignedLegacyPrefix(): Promise<void> {
   }
 }
 
+interface LegacyMixedMigrationStats {
+  quarantinedFiles: number;
+  quarantinedRows: number;
+  /** Chain head of the strict verified prefix that stays active. */
+  previousHead: string;
+  previousSeq: number;
+}
+
+/** At most one legacy-mixed migration per process. A chain that breaks AGAIN
+ * after a successful migration means a pre-contract writer is still appending
+ * concurrently (or the store is genuinely damaged); repeating the quarantine
+ * would just shuttle that writer's rows into quarantine forever, so the second
+ * break keeps the original hard fail-closed behavior and the operator log
+ * points at the stale co-installed build. */
+let legacyMixedMigrationAttempted = false;
+
+/**
+ * One-shot migration for mixed-version signed history (RFC: audit chain epoch
+ * migration).
+ *
+ * Real stores upgraded across several AirMCP releases can contain signed rows
+ * written by builds with DIFFERENT chain contracts: pre-`seq` rows appended
+ * after a sequenced era, a `seq` era restarting at 0, or two concurrently
+ * installed builds forking the chain off the same parent. Every such row still
+ * carries a valid HMAC under the store key — it is provably key-holder output,
+ * not tampering — but the strict scanner rejects it, which previously made
+ * every flush fail and (after MAX_FLUSH_FAILURES) permanently revoked audit
+ * logging with no migration path.
+ *
+ * Policy implemented here, symmetric with the unsigned-legacy quarantine:
+ *   - The strict verified prefix (everything before the first anomaly) stays
+ *     active and trusted; the checkpoint is re-anchored to its tail.
+ *   - Everything from the first anomaly onward is preserved byte-exact behind
+ *     the same `audit.legacy-untrusted.*` quarantine boundary (hard link
+ *     first, then rewrite/unlink), so no history is destroyed — it is just
+ *     never again part of the trusted verdict.
+ *   - The first row sealed after migration is a self-describing
+ *     `__audit_chain_migration` marker recording what was quarantined and the
+ *     quarantined head hmac, so the migration itself is tamper-evident.
+ *
+ * Caller must hold the audit writer lock and must only call this when the
+ * scan reported `legacyMixedBreak` (tamper-shaped breaks never reach here).
+ */
+async function migrateLegacyMixedHistory(scan: AuditChainScanResult): Promise<LegacyMixedMigrationStats> {
+  const brk = scan.firstBreak;
+  if (!brk || brk.lineIndex < 0) {
+    throw new Error("Audit legacy-mixed migration requires a row-level break location");
+  }
+  const files = sortActiveAuditFiles(await readdir(AUDIT_DIR));
+  const breakFileIdx = files.indexOf(brk.file);
+  if (breakFileIdx < 0) {
+    throw new Error(`Audit legacy-mixed migration could not find the break file (${brk.file})`);
+  }
+
+  let quarantinedFiles = 0;
+  let quarantinedRows = 0;
+  for (let i = breakFileIdx; i < files.length; i++) {
+    const file = files[i]!;
+    const sourcePath = join(AUDIT_DIR, file);
+    const raw = await readFile(sourcePath, "utf-8");
+    const allLines = raw.split("\n");
+    // Line indexes from the scanner refer to positions in the raw split, so
+    // slice on the raw array and only then drop blank lines.
+    const keepIdx = i === breakFileIdx ? brk.lineIndex : 0;
+    const kept = allLines.slice(0, keepIdx).filter((l) => l.length > 0);
+    const dropped = allLines.slice(keepIdx).filter((l) => l.length > 0);
+    if (dropped.length === 0) continue;
+
+    // Preserve the exact original bytes before any rewrite or unlink.
+    await createLegacyQuarantineLink(sourcePath, file);
+    quarantinedFiles++;
+    quarantinedRows += dropped.length;
+    if (kept.length === 0) {
+      await unlink(sourcePath);
+      await syncAuditDirectory();
+      continue;
+    }
+    const tempPath = join(AUDIT_DIR, `audit.legacy-rewrite.${process.pid}.${randomUUID()}.tmp`);
+    try {
+      await writeFile(tempPath, kept.join("\n") + "\n", { encoding: "utf-8", mode: 0o600, flag: "wx" });
+      // Same durability barrier as writeCheckpoint: seal the rewritten bytes
+      // and the directory entry before the old name disappears.
+      await syncPath(tempPath);
+      await rename(tempPath, sourcePath);
+      await syncAuditDirectory();
+    } finally {
+      await unlink(tempPath).catch(() => {});
+    }
+  }
+
+  // Re-anchor the truncation checkpoint to the surviving strict tail. When the
+  // surviving prefix has no sequenced rows the checkpoint must be absent —
+  // leaving the old (higher) anchor in place would read as truncation forever.
+  if (scan.chainLastSeq >= 0) {
+    if (!(await writeCheckpoint(scan.chainLastSeq, scan.chainHeadHmac))) {
+      throw new Error("Audit legacy-mixed migration could not re-anchor the checkpoint");
+    }
+  } else {
+    try {
+      await unlink(CHECKPOINT_PATH);
+      await syncAuditDirectory();
+    } catch (err) {
+      if (!isFsError(err, "ENOENT")) throw err;
+    }
+  }
+
+  log.warn("audit: mixed-version signed history quarantined behind an untrusted boundary", {
+    firstAnomaly: `${brk.file}:${brk.lineIndex} (${brk.reason})`,
+    files: quarantinedFiles,
+    rows: quarantinedRows,
+    keptVerifiedRows: scan.entries.length,
+    note:
+      "rows were HMAC-valid but written under an older chain contract (pre-seq build or concurrent fork); " +
+      "if this recurs, an outdated AirMCP build is still writing to this store — remove it",
+  });
+
+  return {
+    quarantinedFiles,
+    quarantinedRows,
+    previousHead: scan.chainHeadHmac,
+    previousSeq: scan.chainLastSeq,
+  };
+}
+
 async function nextRotatedAuditPath(tailSeq: number): Promise<string> {
   const files = await readdir(AUDIT_DIR);
   let maxTimestamp = -1;
@@ -1381,6 +1541,7 @@ export function _testReset(): string[] {
   warnedHostKey = false;
   observedCheckpointFloor = null;
   verifiedChainTrust = null;
+  legacyMixedMigrationAttempted = false;
   return snapshot;
 }
 
@@ -1495,6 +1656,20 @@ interface AuditChainScanResult {
   signedShapeEncountered: boolean;
   chainHeadHmac: string;
   chainLastSeq: number;
+  /** Non-empty rows at/after `firstBreak` that were read but never verified.
+   * Zero on an intact chain. Surfaced so summaries can DISCLOSE the size of
+   * the unverified remainder instead of silently shrinking `total`. */
+  unverifiedTailRows: number;
+  /** The break row is a well-formed sealed row whose own HMAC verifies under
+   * this store's key AND whose `_prev` points at history this scan already
+   * verified (the running head or an earlier verified row). Only a key-holding
+   * AirMCP writer can produce such a row, so the break is mixed-version legacy
+   * history — an older build that predates the `seq` contract, or two builds
+   * appending concurrently (a fork) — not byte tampering. Eligible for the
+   * one-shot legacy-mixed quarantine migration at flush time. Byte edits,
+   * unsigned insertions, forged envelopes, and every checkpoint break keep
+   * this false and remain hard fail-closed. */
+  legacyMixedBreak: boolean;
 }
 
 function asAuditEntry(entry: Record<string, unknown>): AuditEntry | null {
@@ -1552,6 +1727,7 @@ async function scanAuditChain(trust: ChainTrust | null = null): Promise<AuditCha
   const entries: AuditEntry[] = [];
   const legacyEntries: AuditEntry[] = [];
   const seenFiles = new Set<string>();
+  const seenHmacs = new Set<string>();
   let prev: string = HMAC_GENESIS;
   let chainStarted = false;
   let signedShapeEncountered = false;
@@ -1561,36 +1737,79 @@ async function scanAuditChain(trust: ChainTrust | null = null): Promise<AuditCha
   let legacyFirst: { file: string; lineIndex: number } | undefined;
   const checkpoint = await readCheckpoint();
   let checkpointHmacAtSeq: string | undefined;
+  let firstBreak: { file: string; lineIndex: number; reason: AuditChainBreakReason } | undefined;
+  let legacyMixedBreak = false;
+  let unverifiedTailRows = 0;
 
-  const broken = (file: string, lineIndex: number, reason: AuditChainBreakReason): AuditChainScanResult => ({
+  const brokenResult = (): AuditChainScanResult => ({
     entries,
     legacyEntries,
     scannedFiles: seenFiles.size,
     verified: false,
-    firstBreak: { file, lineIndex, reason },
+    firstBreak,
     appendable: false,
     chainStarted,
     signedShapeEncountered,
     chainHeadHmac,
     chainLastSeq,
+    unverifiedTailRows,
+    legacyMixedBreak,
   });
 
+  /** Was the break row itself written by a key holder chaining onto history
+   * this scan already verified? See `legacyMixedBreak` on the result type. */
+  const classifyLegacyMixed = (line: string, entry: Record<string, unknown> | null): boolean => {
+    if (!entry) return false;
+    const hmacField = entry._hmac;
+    const prevField = entry._prev;
+    if (typeof hmacField !== "string" || typeof prevField !== "string") return false;
+    if (!/^[0-9a-f]{64}$/.test(hmacField) || !/^[0-9a-f]{64}$/.test(prevField)) return false;
+    const body = exactSignedBody(line, prevField, hmacField);
+    if (!body) return false;
+    if (computeHmac(prevField, body) !== hmacField) return false;
+    return prevField === (chainStarted ? prev : HMAC_GENESIS) || seenHmacs.has(prevField);
+  };
+
   for await (const item of readAllAuditLinesIndexed()) {
-    if ("readFailure" in item) return broken(item.readFailure, -1, "malformed");
+    if ("readFailure" in item) {
+      // A whole file (or the directory) could not be read at all. There is no
+      // way to even count the remainder, so stop the walk here.
+      firstBreak ??= { file: item.readFailure, lineIndex: -1, reason: "malformed" };
+      break;
+    }
     const { line, file, lineIndex } = item;
     seenFiles.add(file);
+    if (firstBreak) {
+      // Verification is over, but keep draining so the unverified remainder is
+      // DISCLOSED by size instead of silently vanishing from every summary.
+      unverifiedTailRows++;
+      continue;
+    }
+
+    // Local helper: record the first break at this row, classify it, and count
+    // the row itself into the unverified tail.
+    const breakHere = (reason: AuditChainBreakReason, entry: Record<string, unknown> | null): void => {
+      firstBreak = { file, lineIndex, reason };
+      legacyMixedBreak = (reason === "malformed" || reason === "prev_mismatch") && classifyLegacyMixed(line, entry);
+      unverifiedTailRows = 1;
+    };
+
     let entry: Record<string, unknown>;
     try {
       entry = JSON.parse(line) as Record<string, unknown>;
     } catch {
-      return broken(file, lineIndex, "malformed");
+      breakHere("malformed", null);
+      continue;
     }
 
     const hasHmac = Object.prototype.hasOwnProperty.call(entry, "_hmac");
     const hasPrev = Object.prototype.hasOwnProperty.call(entry, "_prev");
     if (!hasHmac && !hasPrev) {
       const legacyEntry = asAuditEntry(entry);
-      if (chainStarted || !legacyEntry) return broken(file, lineIndex, "malformed");
+      if (chainStarted || !legacyEntry) {
+        breakHere("malformed", entry);
+        continue;
+      }
       legacyFirst ??= { file, lineIndex };
       legacyEntries.push(legacyEntry);
       continue;
@@ -1607,11 +1826,15 @@ async function scanAuditChain(trust: ChainTrust | null = null): Promise<AuditCha
       !/^[0-9a-f]{64}$/.test(hmacField) ||
       !/^[0-9a-f]{64}$/.test(prevField)
     ) {
-      return broken(file, lineIndex, "malformed");
+      breakHere("malformed", entry);
+      continue;
     }
 
     const expectedPrev = chainStarted ? prev : HMAC_GENESIS;
-    if (prevField !== expectedPrev) return broken(file, lineIndex, "prev_mismatch");
+    if (prevField !== expectedPrev) {
+      breakHere("prev_mismatch", entry);
+      continue;
+    }
 
     const rawSeq = entry.seq;
     const trustCovers =
@@ -1621,30 +1844,51 @@ async function scanAuditChain(trust: ChainTrust | null = null): Promise<AuditCha
       // skip only the HMAC recomputation. The anchor row must still carry the
       // exact hmac we recorded — any splice or history replacement breaks
       // either this comparison or the structural checks around it.
-      if (rawSeq === trust.seq && hmacField !== trust.hmac) return broken(file, lineIndex, "hmac_mismatch");
+      if (rawSeq === trust.seq && hmacField !== trust.hmac) {
+        breakHere("hmac_mismatch", entry);
+        continue;
+      }
     } else {
       // Verify the literal bytes sealed by the writer. Reconstructing from the
       // parsed object would normalize duplicate keys, escape spellings, and
       // whitespace, allowing a raw JSONL edit to keep `verified: true`.
       const signedBody = exactSignedBody(line, prevField, hmacField);
-      if (!signedBody) return broken(file, lineIndex, "malformed");
+      if (!signedBody) {
+        breakHere("malformed", entry);
+        continue;
+      }
       const expected = computeHmac(prevField, signedBody);
-      if (expected !== hmacField) return broken(file, lineIndex, "hmac_mismatch");
+      if (expected !== hmacField) {
+        breakHere("hmac_mismatch", entry);
+        continue;
+      }
     }
 
     const decoded = asAuditEntry(entry);
-    if (!decoded) return broken(file, lineIndex, "malformed");
+    if (!decoded) {
+      breakHere("malformed", entry);
+      continue;
+    }
 
     const seqField = entry.seq;
     if (seqField === undefined) {
       // Once the signed sequence starts it is part of every subsequent signed
       // body. Omitting it would evade the truncation checkpoint's ordering.
-      if (seqStarted) return broken(file, lineIndex, "malformed");
+      if (seqStarted) {
+        breakHere("malformed", entry);
+        continue;
+      }
     } else {
-      if (!Number.isInteger(seqField) || (seqField as number) < 0) return broken(file, lineIndex, "malformed");
+      if (!Number.isInteger(seqField) || (seqField as number) < 0) {
+        breakHere("malformed", entry);
+        continue;
+      }
       const seq = seqField as number;
       const expectedSeq = seqStarted ? chainLastSeq + 1 : 0;
-      if (seq !== expectedSeq) return broken(file, lineIndex, "malformed");
+      if (seq !== expectedSeq) {
+        breakHere("malformed", entry);
+        continue;
+      }
       seqStarted = true;
       chainLastSeq = seq;
       if (checkpoint.kind === "valid" && checkpoint.seq === seq) checkpointHmacAtSeq = hmacField;
@@ -1652,9 +1896,17 @@ async function scanAuditChain(trust: ChainTrust | null = null): Promise<AuditCha
 
     entries.push(decoded);
     prev = hmacField;
+    seenHmacs.add(hmacField);
     chainStarted = true;
     chainHeadHmac = hmacField;
   }
+
+  if (firstBreak) return brokenResult();
+
+  const broken = (file: string, lineIndex: number, reason: AuditChainBreakReason): AuditChainScanResult => {
+    firstBreak = { file, lineIndex, reason };
+    return brokenResult();
+  };
 
   // The checkpoint is atomically replaced. Missing/malformed state after a
   // sequenced chain exists is therefore a fail-closed integrity gap rather
@@ -1700,6 +1952,8 @@ async function scanAuditChain(trust: ChainTrust | null = null): Promise<AuditCha
       signedShapeEncountered,
       chainHeadHmac,
       chainLastSeq,
+      unverifiedTailRows: 0,
+      legacyMixedBreak: false,
     };
   }
 
@@ -1713,6 +1967,8 @@ async function scanAuditChain(trust: ChainTrust | null = null): Promise<AuditCha
     signedShapeEncountered,
     chainHeadHmac,
     chainLastSeq,
+    unverifiedTailRows: 0,
+    legacyMixedBreak: false,
   };
 }
 
@@ -1791,6 +2047,49 @@ export interface AuditSummary {
    *  too many failures). Auto-recovery kicks in after the backoff window;
    *  the field surfaces the state so a doctor / health check can flag it. */
   auditDisabled: boolean;
+  /** Rows at/after the first chain break that exist on disk but could not be
+   *  verified — and are therefore NOT inside `total`. Always disclosed (0 on
+   *  an intact chain) so a broken chain can never silently shrink the summary.
+   *  Unlike `total` these disclosure counters are window-independent: they
+   *  describe the whole store, not the `since` slice. */
+  unverifiedTailRows: number;
+  /** Unsigned pre-HMAC rows still in the active store. Inspectable via
+   *  audit_log on a legacy-only store, but never part of the trusted total. */
+  unsignedLegacyRows: number;
+  /** Byte-exact preserved history behind the `audit.legacy-untrusted.*`
+   *  quarantine boundary (unsigned pre-HMAC rows and mixed-version signed
+   *  rows). Counted so quarantined history stays visible in every summary
+   *  instead of disappearing without a trace. Quarantine files are FULL
+   *  pre-surgery snapshots of the affected file, so `rows` counts snapshot
+   *  lines and can overlap rows that also survived into the active chain. */
+  quarantined: { files: number; rows: number };
+  /** The current chain break looks like mixed-version key-holder history (see
+   *  scan classification) rather than tampering; the next flush of an upgraded
+   *  server will quarantine it automatically. */
+  legacyMixedBreak: boolean;
+}
+
+/** Count quarantined legacy history so summaries can disclose it. */
+async function collectQuarantineStats(): Promise<{ files: number; rows: number }> {
+  let names: string[];
+  try {
+    names = await readdir(AUDIT_DIR);
+  } catch {
+    return { files: 0, rows: 0 };
+  }
+  let files = 0;
+  let rows = 0;
+  for (const name of names) {
+    if (!name.startsWith(LEGACY_QUARANTINE_PREFIX)) continue;
+    files++;
+    try {
+      const raw = await readFile(join(AUDIT_DIR, name), "utf-8");
+      rows += raw.split("\n").filter(Boolean).length;
+    } catch {
+      // Unreadable quarantine file: still disclosed as a file.
+    }
+  }
+  return { files, rows };
 }
 
 /** Aggregate statistics over the HMAC-verified prefix only. */
@@ -1832,6 +2131,7 @@ export async function summarizeAuditEntries(opts: { since?: string; topN?: numbe
     .map(([actor, v]) => ({ actor, count: v.count, errors: v.errors }))
     .sort((a, b) => b.count - a.count);
   const total = page.entries.length;
+  const quarantined = await collectQuarantineStats();
   return {
     since: sinceIso,
     total,
@@ -1843,6 +2143,10 @@ export async function summarizeAuditEntries(opts: { since?: string; topN?: numbe
     verified: chainResult.verified,
     verifiedFirstBreak: chainResult.firstBreak,
     auditDisabled,
+    unverifiedTailRows: chainResult.unverifiedTailRows,
+    unsignedLegacyRows: chainResult.legacyEntries.length,
+    quarantined,
+    legacyMixedBreak: chainResult.legacyMixedBreak,
   };
 }
 

--- a/src/shared/usage-tracker.ts
+++ b/src/shared/usage-tracker.ts
@@ -20,6 +20,22 @@ interface UsageProfile {
 const FLUSH_INTERVAL = 60_000; // flush to disk every 60s
 const MAX_SEQUENCE_ENTRIES = 500;
 
+/**
+ * Test-mode disk isolation (defense in depth).
+ *
+ * A test or harness process (NODE_ENV=test, or a gate booted with
+ * AIRMCP_TEST_MODE=1 such as smoke-mcp / mcp-validate) that did NOT
+ * explicitly point AIRMCP_USAGE_PROFILE_PATH at its own scratch file must
+ * never read or write the resolved profile path — on a dev box that path is
+ * the developer's real ~/.airmcp/profile.json. This closed a real incident:
+ * fixture tool names (tool_a / tool_b / foo / test_tool) leaked into a real
+ * user profile's frequency/hourly stats and then persisted forever through
+ * the merge-on-load cycle. Captured at import time to match how PATHS
+ * resolves the profile path.
+ */
+const PERSISTENCE_BLOCKED =
+  (process.env.NODE_ENV === "test" || process.env.AIRMCP_TEST_MODE === "1") && !process.env.AIRMCP_USAGE_PROFILE_PATH;
+
 class UsageTracker {
   private lastTool: string | null = null;
   private profile: UsageProfile | null = null;
@@ -106,6 +122,10 @@ class UsageTracker {
 
   /** Flush to disk immediately (async). Waits for disk load to complete first. */
   async flush(): Promise<void> {
+    if (PERSISTENCE_BLOCKED) {
+      this.dirty = false;
+      return;
+    }
     if (this.loaded) await this.loaded;
     if (!this.dirty || !this.profile) return;
     this.profile.updatedAt = new Date().toISOString();
@@ -122,6 +142,10 @@ class UsageTracker {
 
   /** Synchronous flush for process exit handler. Skips if disk load still in-flight to avoid partial writes. */
   flushSync(): void {
+    if (PERSISTENCE_BLOCKED) {
+      this.dirty = false;
+      return;
+    }
     if (this.loaded || !this.dirty || !this.profile) return;
     this.profile.updatedAt = new Date().toISOString();
     try {
@@ -159,6 +183,10 @@ class UsageTracker {
 
   private loadSync(): void {
     this.profile = { version: 1, frequency: {}, sequences: {}, hourly: {}, updatedAt: "" };
+    // Reading is blocked too: merging the developer's real profile into a
+    // test-mode process both leaks personal usage data into test output and
+    // makes suites flaky on the host's history.
+    if (PERSISTENCE_BLOCKED) return;
     this.loaded = this.loadFromDisk()
       .catch((e) => {
         // loadFromDisk swallows ENOENT (expected on first run); everything else

--- a/swift/Sources/AirMCPKit/Generated/MCPIntents.swift
+++ b/swift/Sources/AirMCPKit/Generated/MCPIntents.swift
@@ -70,6 +70,10 @@ public struct MCPAuditSummaryOutput: Codable, Sendable {
         public let lineIndex: Double
         public let reason: String
     }
+    public struct Quarantined: Codable, Sendable {
+        public let files: Double
+        public let rows: Double
+    }
 
     public let since: String
     public let total: Double
@@ -81,6 +85,10 @@ public struct MCPAuditSummaryOutput: Codable, Sendable {
     public let verified: Bool
     public let verifiedFirstBreak: Verifiedfirstbreak?
     public let auditDisabled: Bool
+    public let unverifiedTailRows: Double
+    public let unsignedLegacyRows: Double
+    public let quarantined: Quarantined
+    public let legacyMixedBreak: Bool
 }
 
 // Output type for: describe_tool
@@ -8415,6 +8423,34 @@ public struct MCPAuditSummarySnippetView: View {
                 Text("Audit Disabled")
                 Spacer()
                 Text((data.auditDisabled ? "Yes" : "No"))
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+            }
+            HStack {
+                Text("Unverified Tail Rows")
+                Spacer()
+                Text(data.unverifiedTailRows.formatted())
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+            }
+            HStack {
+                Text("Unsigned Legacy Rows")
+                Spacer()
+                Text(data.unsignedLegacyRows.formatted())
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+            }
+            HStack {
+                Text("Quarantined")
+                Spacer()
+                Text(String(describing: data.quarantined))
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+            }
+            HStack {
+                Text("Legacy Mixed Break")
+                Spacer()
+                Text((data.legacyMixedBreak ? "Yes" : "No"))
                     .lineLimit(1)
                     .truncationMode(.tail)
             }

--- a/tests/audit-legacy-mixed-migration.test.js
+++ b/tests/audit-legacy-mixed-migration.test.js
@@ -1,0 +1,274 @@
+/**
+ * Legacy-mixed chain migration + summary honesty regression tests.
+ *
+ * Reproduces the real-store failure shape found on 2026-08-03: a single
+ * audit.jsonl written by SEVERAL AirMCP builds over time —
+ *   [unsigned pre-HMAC rows] → [signed rows without seq] → [seq era 0..N] →
+ *   [signed rows without seq again] → [seq era restarting at 0] →
+ *   [a fork: two rows chaining off the same parent]
+ * — plus a checkpoint anchored at the fork branch's tail. Every signed row's
+ * HMAC verifies under the store key (provably key-holder output), but the
+ * strict scanner rejects the history at the first seq anomaly, which used to
+ * make EVERY flush fail until audit authority was permanently revoked
+ * (auditDisabled), while audit_summary silently under-counted the store.
+ *
+ * Asserts the two fixes:
+ *   1. Summary honesty — a broken chain DISCLOSES the unverified remainder
+ *      (unverifiedTailRows / unsignedLegacyRows / quarantined) and classifies
+ *      the break (legacyMixedBreak) instead of silently shrinking `total`.
+ *   2. One-shot migration — the next flush quarantines the mixed history
+ *      byte-exact behind audit.legacy-untrusted.*, re-anchors the checkpoint
+ *      to the surviving strict prefix, seals a self-describing
+ *      __audit_chain_migration marker, and resumes a verified chain.
+ *   3. Tampering is NEVER migrated — byte edits and unknown-parent reroots
+ *      keep the original hard fail-closed behavior.
+ */
+import { describe, test, expect, beforeEach, afterAll } from "@jest/globals";
+import { mkdtemp, rm, readFile, writeFile, readdir } from "node:fs/promises";
+import { createHmac } from "node:crypto";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const workDir = await mkdtemp(join(tmpdir(), "airmcp-legacy-mixed-"));
+process.env.AIRMCP_VECTOR_STORE_DIR = workDir;
+process.env.AIRMCP_AUDIT_HMAC_KEY = "legacy-mixed-fixture-key";
+
+afterAll(async () => {
+  await rm(workDir, { recursive: true, force: true }).catch(() => {});
+});
+
+const { auditLog, _testReset, _testFlush, _testGetState, readAuditEntries, summarizeAuditEntries } = await import(
+  "../dist/shared/audit.js"
+);
+
+const KEY = "legacy-mixed-fixture-key";
+const GENESIS = "0".repeat(64);
+const AUDIT_PATH = join(workDir, "audit.jsonl");
+const CHECKPOINT_PATH = join(workDir, "audit.checkpoint");
+const SINCE_EPOCH = { since: "2020-01-01T00:00:00.000Z" };
+
+function hmacOf(prev, body) {
+  return createHmac("sha256", KEY).update(prev).update("\0").update(body).digest("hex");
+}
+
+/** Replicates the writer's sealed-row byte format exactly. */
+function seal(prev, bodyObj) {
+  const body = JSON.stringify(bodyObj);
+  const hmac = hmacOf(prev, body);
+  return { line: body.slice(0, -1) + `,"_prev":"${prev}","_hmac":"${hmac}"}`, hmac };
+}
+
+function checkpointLine(seq, hmac) {
+  const mac = hmacOf("airmcp-audit-checkpoint-v1", `${seq}:${hmac}`);
+  return JSON.stringify({ seq, hmac, mac }) + "\n";
+}
+
+function entry(tool, timestamp, extra = {}) {
+  return { timestamp, tool, args: { fixture: true }, status: "ok", ...extra };
+}
+
+async function wipeDir() {
+  const files = await readdir(workDir).catch(() => []);
+  for (const f of files) await rm(join(workDir, f), { force: true }).catch(() => {});
+}
+
+/**
+ * Build the mixed-version store. Layout (0-based line index):
+ *   0-1   unsigned pre-HMAC rows
+ *   2-3   signed, no seq (pre-seq build)
+ *   4-5   signed, seq 0..1 (sequenced build)
+ *   6-7   signed, no seq again  ← FIRST ANOMALY at index 6
+ *   8-9   signed, seq restarting 0..1
+ *   10    signed, no seq, forked off row 9
+ *   11-12 signed, seq 2..3, ALSO forked off row 9 (checkpoint branch)
+ * Checkpoint anchors {seq:3, hmac(row 12)}.
+ */
+async function buildMixedStore() {
+  const lines = [];
+  lines.push(JSON.stringify(entry("launch_app", "2026-04-30T10:00:00.000Z")));
+  lines.push(JSON.stringify(entry("get_frontmost_app", "2026-04-30T10:01:00.000Z")));
+  const s0 = seal(GENESIS, entry("list_notes", "2026-05-01T10:00:00.000Z"));
+  const s1 = seal(s0.hmac, entry("read_note", "2026-05-01T10:01:00.000Z"));
+  const q0 = seal(s1.hmac, entry("__auth_failure", "2026-06-22T10:00:00.000Z", { seq: 0 }));
+  const q1 = seal(q0.hmac, entry("summarize_context", "2026-06-22T10:01:00.000Z", { seq: 1 }));
+  const m0 = seal(q1.hmac, entry("search_reminders", "2026-06-23T10:00:00.000Z"));
+  const m1 = seal(m0.hmac, entry("search_notes", "2026-06-23T10:01:00.000Z"));
+  const r0 = seal(m1.hmac, entry("semantic_status", "2026-07-09T10:00:00.000Z", { seq: 0 }));
+  const r1 = seal(r0.hmac, entry("recent_files", "2026-07-09T10:01:00.000Z", { seq: 1 }));
+  const f0 = seal(r1.hmac, entry("recent_files", "2026-07-10T10:00:00.000Z"));
+  const f1 = seal(r1.hmac, entry("summarize_context", "2026-07-10T11:00:00.000Z", { seq: 2 }));
+  const f2 = seal(f1.hmac, entry("skill_inbox-triage", "2026-07-10T11:01:00.000Z", { seq: 3 }));
+  for (const row of [s0, s1, q0, q1, m0, m1, r0, r1, f0, f1, f2]) lines.push(row.line);
+  await writeFile(AUDIT_PATH, lines.join("\n") + "\n", "utf-8");
+  await writeFile(CHECKPOINT_PATH, checkpointLine(3, f2.hmac), "utf-8");
+  return { lines, strictHead: q1.hmac };
+}
+
+async function quarantineFiles() {
+  const files = await readdir(workDir);
+  return files.filter((f) => f.startsWith("audit.legacy-untrusted."));
+}
+
+describe("mixed-version legacy history", () => {
+  beforeEach(async () => {
+    _testReset();
+    await wipeDir();
+  });
+
+  test("summary DISCLOSES the broken remainder instead of silently shrinking total", async () => {
+    await buildMixedStore();
+    const summary = await summarizeAuditEntries(SINCE_EPOCH);
+
+    expect(summary.verified).toBe(false);
+    expect(summary.firstBreak ?? summary.verifiedFirstBreak).toEqual({
+      file: "audit.jsonl",
+      lineIndex: 6,
+      reason: "malformed",
+    });
+    // Strict verified prefix only (rows 2-5) …
+    expect(summary.total).toBe(4);
+    // … but the remainder is disclosed, never dropped in silence.
+    expect(summary.unverifiedTailRows).toBe(7);
+    expect(summary.unsignedLegacyRows).toBe(2);
+    expect(summary.quarantined).toEqual({ files: 0, rows: 0 });
+    // And the break is classified as key-holder mixed-version history.
+    expect(summary.legacyMixedBreak).toBe(true);
+    expect(summary.auditDisabled).toBe(false);
+  });
+
+  test("next flush migrates: quarantines mixed history byte-exact, re-anchors checkpoint, resumes verified chain", async () => {
+    const { lines } = await buildMixedStore();
+
+    auditLog(entry("create_note", "2026-08-03T09:00:00.000Z"));
+    await _testFlush();
+
+    // Flush succeeded — audit authority retained, nothing requeued.
+    const state = _testGetState();
+    expect(state.auditDisabled).toBe(false);
+    expect(state.bufferLength).toBe(0);
+    expect(state.consecutiveFlushFailures).toBe(0);
+
+    // Active file: strict prefix (rows 2-5) + migration marker + new row.
+    const active = (await readFile(AUDIT_PATH, "utf-8")).trimEnd().split("\n");
+    expect(active.slice(0, 4)).toEqual(lines.slice(2, 6));
+    expect(active).toHaveLength(6);
+    const marker = JSON.parse(active[4]);
+    expect(marker.tool).toBe("__audit_chain_migration");
+    expect(marker.seq).toBe(2);
+    expect(marker.args.reason).toBe("legacy_mixed_history");
+    expect(marker.args.quarantinedRows).toBe(7);
+    expect(marker.args.firstAnomaly).toBe("audit.jsonl:6");
+    const sealed = JSON.parse(active[5]);
+    expect(sealed.tool).toBe("create_note");
+    expect(sealed.seq).toBe(3);
+
+    // Checkpoint re-anchored to the new tail.
+    const ck = JSON.parse(await readFile(CHECKPOINT_PATH, "utf-8"));
+    expect(ck.seq).toBe(3);
+    expect(ck.hmac).toBe(sealed._hmac);
+
+    // Quarantine preserved every removed row byte-exact: the mixed tail
+    // (rows 6-12, inside the full original file image) and the unsigned
+    // prefix (rows 0-1).
+    const qFiles = await quarantineFiles();
+    expect(qFiles).toHaveLength(2);
+    const contents = await Promise.all(qFiles.map((f) => readFile(join(workDir, f), "utf-8")));
+    const allQuarantined = contents.join("");
+    for (const line of [...lines.slice(0, 2), ...lines.slice(6)]) {
+      expect(allQuarantined).toContain(line);
+    }
+
+    // The resumed chain verifies end-to-end and the summary is honest.
+    const read = await readAuditEntries(SINCE_EPOCH);
+    expect(read.verified).toBe(true);
+    expect(read.total).toBe(6);
+    const summary = await summarizeAuditEntries(SINCE_EPOCH);
+    expect(summary.verified).toBe(true);
+    expect(summary.total).toBe(6);
+    expect(summary.unverifiedTailRows).toBe(0);
+    expect(summary.unsignedLegacyRows).toBe(0);
+    // Quarantine files are FULL pre-surgery snapshots: the mixed-history
+    // snapshot holds the original 13-line file, the unsigned-prefix snapshot
+    // holds the 6-line rewrite that preceded the second surgery.
+    expect(summary.quarantined).toEqual({ files: 2, rows: 19 });
+    expect(summary.legacyMixedBreak).toBe(false);
+  });
+
+  test("a second break in the same process fails closed (no migration loop)", async () => {
+    await buildMixedStore();
+    auditLog(entry("create_note", "2026-08-03T09:00:00.000Z"));
+    await _testFlush();
+    expect(_testGetState().auditDisabled).toBe(false);
+
+    // A stale pre-contract build appends another seq-less (but key-sealed)
+    // row onto the migrated chain.
+    const active = (await readFile(AUDIT_PATH, "utf-8")).trimEnd().split("\n");
+    const tail = JSON.parse(active[active.length - 1]);
+    const stale = seal(tail._hmac, entry("recent_files", "2026-08-03T10:00:00.000Z"));
+    await writeFile(AUDIT_PATH, active.join("\n") + "\n" + stale.line + "\n", "utf-8");
+
+    auditLog(entry("list_notes", "2026-08-03T10:01:00.000Z"));
+    await _testFlush();
+
+    // No second migration: the batch is requeued as a flush failure and the
+    // stale row is still on disk, not quarantined again.
+    const state = _testGetState();
+    expect(state.consecutiveFlushFailures).toBeGreaterThan(0);
+    expect(state.bufferLength).toBe(1);
+    const after = (await readFile(AUDIT_PATH, "utf-8")).trimEnd().split("\n");
+    expect(after[after.length - 1]).toBe(stale.line);
+    expect((await quarantineFiles()).length).toBe(2); // unchanged from the first migration
+  });
+});
+
+describe("tampering is never treated as legacy history", () => {
+  beforeEach(async () => {
+    _testReset();
+    await wipeDir();
+    for (let i = 0; i < 5; i++) {
+      auditLog(entry(`tool_${i}`, `2026-08-01T00:00:0${i}.000Z`));
+    }
+    await _testFlush();
+  });
+
+  test("body edit mid-chain → hmac_mismatch, no migration, flush fails closed", async () => {
+    const lines = (await readFile(AUDIT_PATH, "utf-8")).trimEnd().split("\n");
+    const middle = JSON.parse(lines[2]);
+    middle.tool = "tampered_tool";
+    lines[2] = JSON.stringify(middle);
+    await writeFile(AUDIT_PATH, lines.join("\n") + "\n", "utf-8");
+
+    // Fresh-process semantics: the in-process chain-trust anchor deliberately
+    // skips re-verifying bodies of rows this process already sealed (see
+    // verifiedChainTrust); a body edit is caught by every FULL verification.
+    _testReset();
+
+    const summary = await summarizeAuditEntries(SINCE_EPOCH);
+    expect(summary.verified).toBe(false);
+    expect(summary.verifiedFirstBreak.reason).toBe("hmac_mismatch");
+    expect(summary.legacyMixedBreak).toBe(false);
+    // The unverified remainder (edited row + everything after) is disclosed.
+    expect(summary.unverifiedTailRows).toBe(3);
+
+    auditLog(entry("create_note", "2026-08-03T09:00:00.000Z"));
+    await _testFlush();
+    expect(_testGetState().consecutiveFlushFailures).toBeGreaterThan(0);
+    expect(await (async () => (await readdir(workDir)).filter((f) => f.startsWith("audit.legacy-untrusted.")))()).toEqual(
+      [],
+    );
+  });
+
+  test("key-sealed row rerooted to an unknown parent → prev_mismatch, not migratable", async () => {
+    const lines = (await readFile(AUDIT_PATH, "utf-8")).trimEnd().split("\n");
+    // Self-consistent seal (valid HMAC under the real key) but chained to a
+    // parent this store has never seen — a splice, not a fork.
+    const forged = seal("f".repeat(64), entry("forged_row", "2026-08-02T00:00:00.000Z"));
+    lines[3] = forged.line;
+    await writeFile(AUDIT_PATH, lines.join("\n") + "\n", "utf-8");
+
+    const summary = await summarizeAuditEntries(SINCE_EPOCH);
+    expect(summary.verified).toBe(false);
+    expect(summary.verifiedFirstBreak.reason).toBe("prev_mismatch");
+    expect(summary.legacyMixedBreak).toBe(false);
+  });
+});

--- a/tests/clean-profile-residue.test.js
+++ b/tests/clean-profile-residue.test.js
@@ -1,0 +1,71 @@
+/**
+ * scripts/clean-profile-residue.mjs — removes historical test-fixture residue
+ * (tool_a / tool_b / foo / test_tool / tool_<n>) from a usage profile without
+ * touching real tool stats. Dry-run by default; --apply rewrites atomically.
+ */
+import { describe, test, expect, beforeEach, afterAll } from "@jest/globals";
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import { mkdtempSync, writeFileSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const run = promisify(execFile);
+const SCRIPT = join(process.cwd(), "scripts", "clean-profile-residue.mjs");
+const SCRATCH = mkdtempSync(join(tmpdir(), "airmcp-clean-profile-"));
+const PROFILE = join(SCRATCH, "profile.json");
+
+const CONTAMINATED = {
+  version: 1,
+  frequency: {
+    create_note: 42,
+    tool_session_status: 3, // real tool that must survive the tool_* pattern
+    tool_a: 6,
+    tool_b: 3,
+    foo: 1,
+    test_tool: 1,
+  },
+  sequences: {
+    "create_note → list_notes": 7,
+    "tool_a → tool_b": 5,
+    "tool_b → today_events": 1,
+  },
+  hourly: {
+    create_note: new Array(24).fill(1),
+    tool_a: new Array(24).fill(0),
+  },
+  updatedAt: "2026-08-03T00:00:00.000Z",
+};
+
+beforeEach(() => {
+  writeFileSync(PROFILE, JSON.stringify(CONTAMINATED, null, 2), "utf-8");
+});
+
+afterAll(() => {
+  rmSync(SCRATCH, { recursive: true, force: true });
+});
+
+describe("clean-profile-residue script", () => {
+  test("dry run reports residue but leaves the file untouched", async () => {
+    const { stdout } = await run(process.execPath, [SCRIPT, PROFILE]);
+    expect(stdout).toContain("dry run");
+    expect(stdout).toContain("tool_a");
+    expect(JSON.parse(readFileSync(PROFILE, "utf-8"))).toEqual(CONTAMINATED);
+  });
+
+  test("--apply removes residue from every section and keeps real tools", async () => {
+    await run(process.execPath, [SCRIPT, PROFILE, "--apply"]);
+    const cleaned = JSON.parse(readFileSync(PROFILE, "utf-8"));
+
+    expect(cleaned.frequency).toEqual({ create_note: 42, tool_session_status: 3 });
+    expect(cleaned.sequences).toEqual({ "create_note → list_notes": 7 });
+    expect(Object.keys(cleaned.hourly)).toEqual(["create_note"]);
+    expect(cleaned.updatedAt).toBe(CONTAMINATED.updatedAt);
+  });
+
+  test("a clean profile is a no-op exit 0", async () => {
+    await run(process.execPath, [SCRIPT, PROFILE, "--apply"]);
+    const { stdout } = await run(process.execPath, [SCRIPT, PROFILE, "--apply"]);
+    expect(stdout).toContain("no test residue");
+  });
+});

--- a/tests/usage-tracker-isolation.test.js
+++ b/tests/usage-tracker-isolation.test.js
@@ -1,0 +1,68 @@
+/**
+ * UsageTracker test-mode disk isolation (defense in depth).
+ *
+ * Real incident: fixture tool names (tool_a / tool_b / foo / test_tool)
+ * leaked into a real user's ~/.airmcp/profile.json frequency/hourly stats and
+ * then persisted forever through the tracker's merge-on-load cycle. The
+ * jest-level fake HOME (tests/helpers/isolate-home.cjs) already guards jest
+ * workers, but harness gates booted with AIRMCP_TEST_MODE=1 inherit the REAL
+ * HOME — so the tracker itself must refuse to touch the resolved profile path
+ * whenever it runs in test mode WITHOUT an explicit
+ * AIRMCP_USAGE_PROFILE_PATH override.
+ *
+ * This suite deliberately does NOT set AIRMCP_USAGE_PROFILE_PATH (unlike
+ * usage-tracker.test.js, which covers the persistence-enabled branch).
+ */
+import { describe, test, expect, beforeAll, afterAll } from "@jest/globals";
+import { mkdirSync, writeFileSync, readFileSync } from "node:fs";
+import { dirname } from "node:path";
+
+// Must be unset BEFORE import — the guard is captured at module load, same as
+// PATHS. NODE_ENV=test is set by jest itself.
+delete process.env.AIRMCP_USAGE_PROFILE_PATH;
+
+const { usageTracker } = await import("../dist/shared/usage-tracker.js");
+const { PATHS } = await import("../dist/shared/constants.js");
+
+// A stand-in for the developer's real profile at the resolved default path
+// (inside the suite's fake HOME, so this file is disposable either way).
+const PRE_EXISTING = JSON.stringify(
+  {
+    version: 1,
+    frequency: { create_note: 42 },
+    sequences: { "create_note → list_notes": 7 },
+    hourly: { create_note: new Array(24).fill(0) },
+    updatedAt: "2026-01-01T00:00:00.000Z",
+  },
+  null,
+  2,
+);
+
+beforeAll(() => {
+  mkdirSync(dirname(PATHS.USAGE_PROFILE), { recursive: true });
+  writeFileSync(PATHS.USAGE_PROFILE, PRE_EXISTING, "utf-8");
+  usageTracker._resetForTests();
+});
+
+afterAll(() => {
+  usageTracker.stop();
+});
+
+describe("UsageTracker — test-mode isolation without explicit profile path", () => {
+  test("record + flush + flushSync never rewrite the default profile path", async () => {
+    usageTracker.record("tool_a");
+    usageTracker.record("tool_b");
+    await usageTracker.flush();
+    usageTracker.flushSync();
+
+    expect(readFileSync(PATHS.USAGE_PROFILE, "utf-8")).toBe(PRE_EXISTING);
+  });
+
+  test("the pre-existing profile is not merged into test-mode memory", () => {
+    // Only this session's records are visible — the 42 create_note calls from
+    // the on-disk profile must NOT leak into stats.
+    const stats = usageTracker.getStats();
+    expect(stats.totalCalls).toBe(2);
+    expect(stats.topTools.find((t) => t.tool === "create_note")).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Field report (2026-08-03, real store)

A production `~/.airmcp` store written across several AirMCP releases exhibited five audit-pipeline defects at once:

1. **`auditDisabled: true` on the running server** — every 30s flush failed the pre-append chain integrity check, and after `MAX_FLUSH_FAILURES` (5) the server revoked its own audit authority. The 5-minute recovery window re-enabled it, only to fail again immediately: effectively permanent.
2. **"No HMAC fields" was an observation artifact** — 141 of the 145 rows ARE signed; `audit_log` strips chain internals (`seq`/`_prev`/`_hmac`) at the tool boundary by design, so sampled rows looked unsigned. Only rows 0–3 (2026-04-30, pre-HMAC build) are genuinely unsigned.
3. **Checkpoint "frozen" at `seq: 8`** — it was actually in sync with the tail (line 144, `seq: 8`, matching hmac + valid MAC); the scan just never reached checkpoint validation because it broke at line 96 first.
4. **`total: 92` / `firstBreak` at `lineIndex: 96 "malformed"`** — line 96 is a signed, HMAC-valid row *without* `seq` appearing after a sequenced era (`seq` 0–14 at lines 81–95). The strict scanner treats a missing `seq` after sequence-start as `malformed`, stops, and the summary silently reported only the 92 verified prefix rows (lines 4–95) — 53 rows vanished without disclosure.
5. **Test residue in the real `profile.json`** (`tool_a` 6, `tool_b` 3, `foo` 1, `test_tool` 1) — preserved forever by the tracker's merge-on-load cycle.

Root cause of 1/3/4: the store contains **mixed-version key-holder history** — pre-`seq` builds appending after sequenced eras, a `seq` era restarting at 0 (line 135), and a genuine fork (lines 142 and 143 both chain off line 141's hmac: two concurrently installed builds). Every one of those rows verifies under the store key — provably written by AirMCP, not tampering — but the current contract rejects them with no migration path, bricking audit logging permanently.

## Fix

**`fix(audit)` — one-shot legacy-mixed migration + summary honesty**
- `scanAuditChain` classifies a break as `legacyMixedBreak` only when the breaking row is self-sealed under the store key **and** chains to already-verified history (running head or an earlier verified row's hmac). Byte edits (`hmac_mismatch`), forged envelopes, unknown-parent reroots, unsigned insertions, and every checkpoint break remain hard fail-closed.
- On such a break, the next flush performs a **one-shot migration** (symmetric with the existing unsigned-legacy quarantine): the strict verified prefix stays active and trusted; everything from the first anomaly is preserved **byte-exact** behind the existing `audit.legacy-untrusted.*` boundary; the checkpoint is re-anchored to the surviving tail; a self-describing `__audit_chain_migration` marker (quarantine stats + resumed head hmac) is sealed as the first post-migration row. A second break in the same process fails closed — no quarantine loops while a stale co-installed build keeps writing.
- `audit_summary` never omits in silence anymore: new `unverifiedTailRows`, `unsignedLegacyRows`, `quarantined {files, rows}` and `legacyMixedBreak` fields (tool outputSchema updated). `doctor --deep` now distinguishes mixed-version history (with the auto-migration guidance) from tampering.

**`fix(intelligence)` — usage-profile test isolation + cleanup**
- `usage-tracker.ts` refuses to read *or* write the resolved profile path whenever `NODE_ENV=test` or `AIRMCP_TEST_MODE=1` without an explicit `AIRMCP_USAGE_PROFILE_PATH` — this closes the remaining leak: harness gates boot via `cleanBootEnv` with `AIRMCP_TEST_MODE=1` but the **real** HOME.
- `cleanBootEnv` additionally sets `AIRMCP_USAGE_TRACKING=false` for the three boot gates.
- New `scripts/clean-profile-residue.mjs` removes historical residue from an already-contaminated profile (dry-run by default, `--apply` rewrites atomically; the `tool_<n>` pattern cannot match real tools like `tool_session_status`).

## Verification

- Full suite: **228 suites / 2903 tests pass** (`npm test`), typecheck + eslint clean.
- New regression suites: `tests/audit-legacy-mixed-migration.test.js` (reproduces the exact real-store shape incl. the fork; asserts disclosure, migration, checkpoint re-anchor, byte-exact quarantine, second-break fail-closed, and that tampering is never migrated), `tests/usage-tracker-isolation.test.js`, `tests/clean-profile-residue.test.js`.
- Ran the built module against a **copy** of the affected real store: `BEFORE total:92, break audit.jsonl:96 malformed, legacyMixedBreak:true, unverifiedTailRows:49, unsignedLegacyRows:4` → one flush → `verified:true, seq resumed at 15/16, auditDisabled:false`, both quarantine snapshots present, checkpoint re-anchored.

## Operator notes (affected stores)

No manual surgery needed: upgrade + restart the server; the first flush migrates automatically (worst case the 5-minute recovery window lifts `auditDisabled` on its own). If the break recurs, an outdated AirMCP build is still writing to the store — remove it. Profile cleanup: `node scripts/clean-profile-residue.mjs` (dry run), then `--apply`.