### PR TITLE
공증을 App Store Connect API 키로 인증할 수 있게

### DIFF
--- a/scripts/notarize-app.sh
+++ b/scripts/notarize-app.sh
@@ -201,6 +201,31 @@ SUBMISSION_ID="$(printf '%s' "$SUBMIT_OUTPUT" | node -e '
 # team, certificate subject, or raw messages into the public Actions log.
 if [ "$SUBMIT_EXIT" -ne 0 ] || [ "$NOTARY_STATUS" != "Accepted" ]; then
   echo "notarize-app: notarization failed; raw account, certificate, and submission metadata is suppressed" >&2
+
+  # Two failures land here and they need completely different fixes:
+  #
+  #   a) Apple accepted the submission and rejected the binary. There is a
+  #      submission ID, and the sanitized issue log below says what to change.
+  #   b) notarytool never created a submission — credentials were refused, the
+  #      Apple ID does not belong to the team, or the Program License Agreement
+  #      is unaccepted. No submission ID exists, so the log path cannot run.
+  #
+  # Case (b) previously printed the suppression notice and nothing else, leaving
+  # an operator with a red release and no way to tell a bad app-specific password
+  # from a rejected binary. Classify it without echoing notarytool's raw output,
+  # which carries the account and team.
+  if ! [[ "$SUBMISSION_ID" =~ ^[0-9A-Fa-f-]{36}$ ]]; then
+    echo "notarize-app: Apple never accepted the submission, so this is a credential or account" >&2
+    echo "notarize-app: problem rather than a rejected build. Check, in this order:" >&2
+    echo "notarize-app:   1. APPLE_ID_PASSWORD must be an APP-SPECIFIC password from" >&2
+    echo "notarize-app:      appleid.apple.com (format xxxx-xxxx-xxxx-xxxx), not the Apple ID login password" >&2
+    echo "notarize-app:   2. APPLE_ID must be the Apple ID that belongs to the team in APPLE_TEAM_ID" >&2
+    echo "notarize-app:   3. the Apple Developer Program License Agreement must be accepted at" >&2
+    echo "notarize-app:      developer.apple.com — notarytool refuses before submitting while it is pending" >&2
+    echo "notarize-app: verify locally with: xcrun notarytool history --apple-id <id> --team-id <team> --password <app-specific>" >&2
+    exit 2
+  fi
+
   if [[ "$SUBMISSION_ID" =~ ^[0-9A-Fa-f-]{36}$ ]]; then
     set +e
     NOTARY_LOG="$(

--- a/scripts/notarize-app.sh
+++ b/scripts/notarize-app.sh
@@ -8,10 +8,23 @@
 #   APPLE_DEVELOPER_ID          — Developer ID Application certificate
 #                                 common name, e.g. "Developer ID Application:
 #                                 Heznpc (TEAMID)"
-#   APPLE_ID                    — Apple ID email for notarytool
-#   APPLE_ID_PASSWORD           — app-specific password
-#                                 (appleid.apple.com → sign-in and security)
-#   APPLE_TEAM_ID               — 10-char team ID
+#
+# Notarization credentials — supply exactly ONE of the three sets below.
+# They are tried in this order, most robust first:
+#
+#   1. App Store Connect API key (preferred; no 2FA, one key for the whole team)
+#      APPLE_API_KEY_PATH       — path to AuthKey_<KEYID>.p8
+#      APPLE_API_KEY_ID         — 10-char key ID
+#      APPLE_API_ISSUER_ID      — issuer UUID
+#
+#   2. Stored keychain profile (preferred for local runs)
+#      NOTARY_KEYCHAIN_PROFILE  — profile name saved by
+#                                 `xcrun notarytool store-credentials`
+#
+#   3. Apple ID + app-specific password (legacy; breaks on 2FA changes)
+#      APPLE_ID                 — Apple ID email
+#      APPLE_ID_PASSWORD        — app-specific password
+#      APPLE_TEAM_ID            — 10-char team ID
 #
 # Optional environment:
 #   APP_BUNDLE_PATH             — default: AirMCP.app (relative to repo root)
@@ -51,10 +64,33 @@ need_var() {
 }
 need_var APPLE_DEVELOPER_ID
 
+# ── Resolve notarytool credentials ───────────────────────────────────
+# Built once here so `submit` and the failure-path `log` call can never
+# authenticate two different ways. NOTARY_AUTH_KIND drives the diagnostics
+# printed when Apple refuses the credentials outright.
+NOTARY_AUTH=()
+NOTARY_AUTH_KIND=""
 if [ "${SKIP_NOTARIZATION:-}" != "1" ]; then
-  need_var APPLE_ID
-  need_var APPLE_ID_PASSWORD
-  need_var APPLE_TEAM_ID
+  if [ -n "${APPLE_API_KEY_PATH:-}" ] || [ -n "${APPLE_API_KEY_ID:-}" ] || [ -n "${APPLE_API_ISSUER_ID:-}" ]; then
+    need_var APPLE_API_KEY_PATH
+    need_var APPLE_API_KEY_ID
+    need_var APPLE_API_ISSUER_ID
+    if [ ! -f "$APPLE_API_KEY_PATH" ]; then
+      echo "notarize-app: APPLE_API_KEY_PATH points at no file" >&2
+      exit 1
+    fi
+    NOTARY_AUTH=(--key "$APPLE_API_KEY_PATH" --key-id "$APPLE_API_KEY_ID" --issuer "$APPLE_API_ISSUER_ID")
+    NOTARY_AUTH_KIND="api-key"
+  elif [ -n "${NOTARY_KEYCHAIN_PROFILE:-}" ]; then
+    NOTARY_AUTH=(--keychain-profile "$NOTARY_KEYCHAIN_PROFILE")
+    NOTARY_AUTH_KIND="keychain-profile"
+  else
+    need_var APPLE_ID
+    need_var APPLE_ID_PASSWORD
+    need_var APPLE_TEAM_ID
+    NOTARY_AUTH=(--apple-id "$APPLE_ID" --password "$APPLE_ID_PASSWORD" --team-id "$APPLE_TEAM_ID")
+    NOTARY_AUTH_KIND="apple-id"
+  fi
 fi
 
 # The certificate subject is public in every distributed binary. Refuse to
@@ -171,9 +207,7 @@ echo "notarize-app: submitting to Apple (this takes 2-10 minutes) …"
 set +e
 SUBMIT_OUTPUT="$(
   xcrun notarytool submit "$ZIP_PATH" \
-    --apple-id "$APPLE_ID" \
-    --password "$APPLE_ID_PASSWORD" \
-    --team-id "$APPLE_TEAM_ID" \
+    "${NOTARY_AUTH[@]}" \
     --wait \
     --output-format json 2>&1
 )"
@@ -217,12 +251,27 @@ if [ "$SUBMIT_EXIT" -ne 0 ] || [ "$NOTARY_STATUS" != "Accepted" ]; then
   if ! [[ "$SUBMISSION_ID" =~ ^[0-9A-Fa-f-]{36}$ ]]; then
     echo "notarize-app: Apple never accepted the submission, so this is a credential or account" >&2
     echo "notarize-app: problem rather than a rejected build. Check, in this order:" >&2
-    echo "notarize-app:   1. APPLE_ID_PASSWORD must be an APP-SPECIFIC password from" >&2
-    echo "notarize-app:      appleid.apple.com (format xxxx-xxxx-xxxx-xxxx), not the Apple ID login password" >&2
-    echo "notarize-app:   2. APPLE_ID must be the Apple ID that belongs to the team in APPLE_TEAM_ID" >&2
-    echo "notarize-app:   3. the Apple Developer Program License Agreement must be accepted at" >&2
-    echo "notarize-app:      developer.apple.com — notarytool refuses before submitting while it is pending" >&2
-    echo "notarize-app: verify locally with: xcrun notarytool history --apple-id <id> --team-id <team> --password <app-specific>" >&2
+    case "$NOTARY_AUTH_KIND" in
+      api-key)
+        echo "notarize-app:   1. APPLE_API_KEY_ID and APPLE_API_ISSUER_ID must belong to the same key" >&2
+        echo "notarize-app:      as the .p8 at APPLE_API_KEY_PATH — a mismatched pair is refused" >&2
+        echo "notarize-app:   2. the key needs the Admin (or App Manager) role in App Store Connect" >&2
+        echo "notarize-app:   3. a revoked key keeps its .p8 file but stops authenticating" >&2
+        ;;
+      keychain-profile)
+        echo "notarize-app:   1. NOTARY_KEYCHAIN_PROFILE must name a profile saved by" >&2
+        echo "notarize-app:      'xcrun notarytool store-credentials' on THIS machine and keychain" >&2
+        echo "notarize-app:   2. a locked login keychain makes the stored profile unreadable" >&2
+        ;;
+      *)
+        echo "notarize-app:   1. APPLE_ID_PASSWORD must be an APP-SPECIFIC password from" >&2
+        echo "notarize-app:      appleid.apple.com (format xxxx-xxxx-xxxx-xxxx), not the Apple ID login password" >&2
+        echo "notarize-app:   2. APPLE_ID must be the Apple ID that belongs to the team in APPLE_TEAM_ID" >&2
+        ;;
+    esac
+    echo "notarize-app:   the Apple Developer Program License Agreement must also be accepted at" >&2
+    echo "notarize-app:   developer.apple.com — notarytool refuses before submitting while it is pending" >&2
+    echo "notarize-app: verify the same credentials locally with: xcrun notarytool history <same auth flags>" >&2
     exit 2
   fi
 
@@ -230,9 +279,7 @@ if [ "$SUBMIT_EXIT" -ne 0 ] || [ "$NOTARY_STATUS" != "Accepted" ]; then
     set +e
     NOTARY_LOG="$(
       xcrun notarytool log "$SUBMISSION_ID" \
-        --apple-id "$APPLE_ID" \
-        --password "$APPLE_ID_PASSWORD" \
-        --team-id "$APPLE_TEAM_ID" \
+        "${NOTARY_AUTH[@]}" \
         --output-format json 2>/dev/null
     )"
     LOG_EXIT=$?


### PR DESCRIPTION
## 왜

`notarize-app.sh`가 `APPLE_ID` + `APPLE_ID_PASSWORD`로만 인증합니다. 앱 암호는 Apple이 주는 자격증명 중 가장 잘 깨집니다 — Apple ID마다 따로 발급되고, 계정의 2FA 상태가 바뀌면 죽고, 죽으면 사람이 손으로 재발급해서 GitHub 시크릿에 다시 넣어야 합니다.

## 무엇

인증 방식 두 개를 추가하고, 설정된 것 중 첫 번째를 자동으로 씁니다.

1. `APPLE_API_KEY_PATH` / `APPLE_API_KEY_ID` / `APPLE_API_ISSUER_ID` — 팀 단위 App Store Connect 키. 키 하나가 팀의 모든 앱을 커버하고, 만료가 없고, 2FA와 무관합니다. CI가 써야 할 방식입니다.
2. `NOTARY_KEYCHAIN_PROFILE` — `notarytool store-credentials`로 저장한 프로파일. 로컬 실행에서 환경변수에 비밀값을 두지 않아도 됩니다.
3. Apple ID + 앱 암호 — 기존 그대로, 폴백.

## 설계상 주의한 점

플래그를 `NOTARY_AUTH` 배열로 **한 번만** 해석합니다. `submit`과 실패 경로의 `log` 호출이 서로 다른 신원으로 인증하면, 로그를 다른 계정으로 조회해서 조용히 빈 결과를 받습니다.

자격증명 거부 진단도 사용한 방식별로 갈랐습니다. `.p8`로 인증한 사람에게 앱 암호를 확인하라고 하는 건 도움이 안 되는 정도가 아니라 오답입니다.

## 검증

`bash -n` 통과, `shellcheck -S error` 클린.

## 참고

이 브랜치는 `fix/notarize-credential-diagnostics`(커밋 518f3d4) 위에 올라가 있습니다. 그 커밋이 아직 main에 없어서 이 PR에 함께 들어갑니다.