### PR TITLE
fix(system): add allow_sleep to release prevent_sleep before lid close

### DIFF
--- a/.github/AGENTS.md
+++ b/.github/AGENTS.md
@@ -83,7 +83,7 @@ tests/                    # Script generator tests
 
 ## Stats
 
-- **297 tools** across **32 modules** (+ dynamic shortcut tools at runtime)
+- **298 tools** across **32 modules** (+ dynamic shortcut tools at runtime)
 - **32 prompts** (per-module + cross-module + YAML skills)
 - **10 MCP resources** (Notes, Calendar, Reminders, Music, Mail, System, Context Snapshot)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`allow_sleep`** — `prevent_sleep` spawns a background `caffeinate -t <seconds>` (default 1h, max 24h) with no way to release it early. Bare `caffeinate` also blocks sleep triggered by closing the lid, not just idle timeout, so an active assertion left the Mac running (fans on, battery draining) with the lid shut until the timer expired, up to a full day later. `allow_sleep` kills the tracked `caffeinate` process immediately, restoring normal sleep behavior; it's a no-op when no assertion is active. `prevent_sleep`'s description now calls out the lid-close interaction.
+
 ## [2.16.4] - 2026-08-03
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ More workflow examples live in [docs/workflows.md](docs/workflows.md).
 AirMCP is designed to keep a large local capability surface usable without
 dumping the full catalog into every client context.
 
-The complete generated catalog currently contains 297 tools across 32 modules.
+The complete generated catalog currently contains 298 tools across 32 modules.
 Profiles and progressive exposure keep clients from loading it all at once.
 
 - **Profiles**: `starter`, `communications-safe`, `productivity`, `full`, or
@@ -201,7 +201,7 @@ do not use it as the first-success workflow. Broader diagnostics such as
 The complete generated tool manifest is in
 [docs/tool-manifest.json](docs/tool-manifest.json).
 
-Current generated surfaces: 233 App Intent action types, 85 Interactive Snippet views,
+Current generated surfaces: 234 App Intent action types, 86 Interactive Snippet views,
 14 AppEnum pickers, and an iOS-only provider with 8 read-only App Shortcuts that match the preview runtime. The sessionless discovery card uses MCP schema version
 2025-11-25.
 

--- a/app/Sources/AirMCPApp/Generated/AppCatalog.swift
+++ b/app/Sources/AirMCPApp/Generated/AppCatalog.swift
@@ -104,7 +104,7 @@ let allModules: [ModuleInfo] = [
     ModuleInfo(id: "music", icon: "music.note", toolCount: 17),
     ModuleInfo(id: "finder", icon: "folder", toolCount: 8),
     ModuleInfo(id: "safari", icon: "safari", toolCount: 12),
-    ModuleInfo(id: "system", icon: "gearshape", toolCount: 27),
+    ModuleInfo(id: "system", icon: "gearshape", toolCount: 28),
     ModuleInfo(id: "photos", icon: "photo", toolCount: 11),
     ModuleInfo(id: "shortcuts", icon: "command", toolCount: 11),
     ModuleInfo(id: "messages", icon: "bubble.left", toolCount: 6),

--- a/docs/REGISTRY_SUBMISSIONS.md
+++ b/docs/REGISTRY_SUBMISSIONS.md
@@ -57,7 +57,7 @@ When headline features change, walk this list before you touch any registry UI:
 
 - [ ] `npm run stats:sync` shows **no** remaining diffs (zero "sync:" lines)
 - [ ] `server.json` `version` matches `package.json` version
-- [ ] `server.json` `description` reflects current headline features (`.mcpb` one-click, OAuth 2.1, profiles, progressive tool exposure, 233 AppIntents, skills, memory, audit, inbound HTTP `allowNetwork`)
+- [ ] `server.json` `description` reflects current headline features (`.mcpb` one-click, OAuth 2.1, profiles, progressive tool exposure, 234 AppIntents, skills, memory, audit, inbound HTTP `allowNetwork`)
 - [ ] `README.md` Features block mirrors the description — catches the case where one was updated without the other
 - [ ] `docs/index.html` title, metadata, hero, and proof points lead with the governed Apple ecosystem runtime, distinguish current and roadmap platforms, and omit aggregate catalog counts
 - [ ] `CHANGELOG.md` `[Unreleased]` block names every user-visible change since the last registry ping

--- a/docs/TERMS_OF_SERVICE.md
+++ b/docs/TERMS_OF_SERVICE.md
@@ -19,7 +19,7 @@ AirMCP is open-source software released under the [MIT License](../LICENSE). The
 
 You are solely responsible for:
 
-- **AI agent actions.** AirMCP enables AI agents to perform actions on your Mac through 297 tools across 32 modules. Any action an AI agent takes through AirMCP is performed on your behalf and at your direction. You are responsible for the outcomes of those actions.
+- **AI agent actions.** AirMCP enables AI agents to perform actions on your Mac through 298 tools across 32 modules. Any action an AI agent takes through AirMCP is performed on your behalf and at your direction. You are responsible for the outcomes of those actions.
 - **Safety controls.** AirMCP provides a Human-in-the-Loop (HITL) approval system with configurable levels. It is your responsibility to configure an appropriate HITL level for your use case. Running AirMCP with HITL disabled means AI agents can execute sensitive or destructive actions without confirmation.
 - **HTTP mode security.** If you enable HTTP mode for remote access, you are responsible for securing it. This includes configuring token-based authentication, restricting network access, and ensuring the server is not exposed to untrusted networks.
 - **Legal compliance.** You must comply with all applicable local, state, national, and international laws when using AirMCP. This includes laws governing privacy, electronic communications, data protection, and computer access.

--- a/docs/environment.md
+++ b/docs/environment.md
@@ -16,7 +16,7 @@ If a variable accepts a path, `~` expands to `$HOME`. Booleans are `"true"` / `"
 | Use only selected module packs | `AIRMCP_MODULE_PACKS=core,productivity` |
 | Install and activate a module add-on | `npx airmcp modules enable productivity --install` |
 | Stage physical add-on package artifacts | `npm run addons:build` |
-| Send all 297 tools without compactDescription | `AIRMCP_COMPACT_TOOLS=false` + `AIRMCP_TOOL_EXPOSURE=full` |
+| Send all 298 tools without compactDescription | `AIRMCP_COMPACT_TOOLS=false` + `AIRMCP_TOOL_EXPOSURE=full` |
 | Require sessions before hidden tools can run | `AIRMCP_REQUIRE_TOOL_SESSION=true` |
 | Inspect or edit module add-ons | `npx airmcp modules` |
 | Increase audit-log signing strength for cross-host integrity | `AIRMCP_AUDIT_HMAC_KEY=<32+ random bytes>` |

--- a/docs/site/src/content/docs/architecture/overview.md
+++ b/docs/site/src/content/docs/architecture/overview.md
@@ -145,7 +145,7 @@ ok(data)   // { content: [{ type: "text", text: JSON.stringify(data) }] }
 err(msg)   // { content: [{ type: "text", text: msg }], isError: true }
 ```
 
-This ensures consistent error handling across all 297 tools.
+This ensures consistent error handling across all 298 tools.
 
 ## Directory Structure
 

--- a/docs/site/src/content/docs/modules/overview.md
+++ b/docs/site/src/content/docs/modules/overview.md
@@ -3,7 +3,7 @@ title: Module Overview
 description: All 32 AirMCP modules with tool counts and capabilities.
 ---
 
-AirMCP ships 32 modules that cover the Apple workspace. Each module registers a set of MCP tools that AI assistants can call. The full manifest contains 297 tools, while the default starter/progressive runtime exposes a smaller front door.
+AirMCP ships 32 modules that cover the Apple workspace. Each module registers a set of MCP tools that AI assistants can call. The full manifest contains 298 tools, while the default starter/progressive runtime exposes a smaller front door.
 
 Module packs are the activation boundary above modules. `npx airmcp modules enable productivity` or `AIRMCP_MODULE_PACKS=core,productivity` keeps core workspace tools and iWork active while reporting unavailable profile modules through `profile_status.modulesMissingPacks`. npm and MCPB releases are universal and already contain every standard JavaScript module; profiles and progressive exposure narrow the active context without making users assemble the product from packages. Scoped add-ons such as `@heznpc/airmcp-productivity` remain optional compatibility artifacts for `external-only` deployments.
 
@@ -22,7 +22,7 @@ The release gate boots clean-installed npm and MCPB artifacts in `full/full` mod
 | **Music** | 17 | Full Apple Music control. Playlists, playback, search, queue management. |
 | **Finder** | 8 | File system operations. Search, list directories, recent files, create directories, trash files. |
 | **Safari** | 12 | Tab management, bookmarks, reading list. Open/close tabs, get page content, execute JavaScript. |
-| **System** | 27 | Clipboard, volume, brightness, dark mode, Wi-Fi, Bluetooth, battery, running apps, windows, notifications. |
+| **System** | 28 | Clipboard, volume, brightness, dark mode, Wi-Fi, Bluetooth, battery, running apps, windows, notifications. |
 | **Photos** | 11 | Albums, search, favorites, photo info. Create albums, export photos. |
 | **Shortcuts** | 11 | List, search, run, create, delete, export, import, duplicate Siri Shortcuts. Plus dynamic per-shortcut tools. |
 | **Intelligence** | 13 | Apple Intelligence features (macOS 26+ only). Writing tools, image generation, summarization. |

--- a/docs/site/src/content/docs/modules/system.md
+++ b/docs/site/src/content/docs/modules/system.md
@@ -26,6 +26,7 @@ description: Clipboard, volume, brightness, dark mode, Wi-Fi, Bluetooth, battery
 | `toggle_focus_mode` | Toggle Do Not Disturb (Focus mode) on or off. | ❌ |
 | `system_sleep` | Put the Mac to sleep. | ❌ |
 | `prevent_sleep` | Prevent the Mac from sleeping for a specified duration using caffeinate. | ❌ |
+| `allow_sleep` | Cancel any active prevent_sleep assertion immediately, so the Mac can sleep normally again. | ❌ |
 | `system_power` | Shutdown or restart the Mac. Use with caution. | ❌ |
 | `launch_app` | Launch an application by name. Lightweight -- just activates the app. | ❌ |
 | `quit_app` | Quit a running application by name. May cause unsaved work to be lost. | ❌ |

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -1,6 +1,6 @@
 # AirMCP Skills Guide
 
-A practical guide for AI agents to effectively use AirMCP's 297 tools across 32 modules to orchestrate the Apple ecosystem via MCP.
+A practical guide for AI agents to effectively use AirMCP's 298 tools across 32 modules to orchestrate the Apple ecosystem via MCP.
 
 ## Overview
 
@@ -34,7 +34,7 @@ AirMCP bridges AI agents to native macOS applications through JXA (JavaScript fo
 | **safari** | Safari | `list_tabs`, `read_page_content`, `open_url`, `run_javascript`, `list_bookmarks`, `add_to_reading_list` | 12 |
 | **screen** | Screen Capture | `capture_screen`, `capture_window`, `capture_area`, `list_windows`, `record_screen` | 5 |
 | **shortcuts** | Shortcuts | `list_shortcuts`, `run_shortcut`, `get_shortcut_detail`, `search_shortcuts`, `export_shortcut` | 11 |
-| **system** | System | `get_clipboard`, `set_clipboard`, `show_notification`, `capture_screenshot`, `get_battery_status`, `toggle_dark_mode`, `system_sleep`, `prevent_sleep`, `system_power` | 27 |
+| **system** | System | `get_clipboard`, `set_clipboard`, `show_notification`, `capture_screenshot`, `get_battery_status`, `toggle_dark_mode`, `system_sleep`, `prevent_sleep`, `allow_sleep`, `system_power` | 28 |
 | **location** | Location | `get_current_location`, `get_location_status` | 2 |
 | **bluetooth** | Bluetooth | `bluetooth_scan`, `bluetooth_connect`, `bluetooth_disconnect`, `bluetooth_list_devices` | 4 |
 | **tv** | TV | `tv_list_playlists`, `tv_now_playing`, `tv_playback_control`, `tv_search`, `tv_play` | 6 |

--- a/docs/tool-manifest.json
+++ b/docs/tool-manifest.json
@@ -1,8 +1,8 @@
 {
   "generatedAt": "STABLE_PLACEHOLDER",
   "protocolVersion": "2025-11-25",
-  "toolCount": 297,
-  "eligibleCount": 290,
+  "toolCount": 298,
+  "eligibleCount": 291,
   "ineligibleCount": 7,
   "ineligibleByReason": {
     "object-param:recurrence": 2,
@@ -476,6 +476,38 @@
       "outputSchema": null,
       "annotations": {
         "readOnlyHint": true,
+        "destructiveHint": false,
+        "sensitiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false
+      },
+      "appIntentEligible": true,
+      "ineligibleReason": null
+    },
+    {
+      "name": "allow_sleep",
+      "title": "Allow Sleep",
+      "description": "Cancel any active prevent_sleep assertion immediately, so the Mac can sleep normally again (idle timeout or closing the lid). No-op if no assertion is active.",
+      "inputSchema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {}
+      },
+      "outputSchema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {
+          "cancelled": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "cancelled"
+        ],
+        "additionalProperties": false
+      },
+      "annotations": {
+        "readOnlyHint": false,
         "destructiveHint": false,
         "sensitiveHint": false,
         "idempotentHint": true,
@@ -9713,7 +9745,7 @@
     {
       "name": "prevent_sleep",
       "title": "Prevent Sleep",
-      "description": "Prevent the Mac from sleeping for a specified duration using caffeinate. The assertion is transient — it auto-releases when the timer elapses; no manual stop is required.",
+      "description": "Prevent the Mac from sleeping for a specified duration using caffeinate. The assertion auto-releases when the timer elapses, or immediately via allow_sleep. Note: this also blocks sleep triggered by closing the lid, not just idle timeout — call allow_sleep first if you're about to close the lid.",
       "inputSchema": {
         "$schema": "http://json-schema.org/draft-07/schema#",
         "type": "object",

--- a/llms.txt
+++ b/llms.txt
@@ -68,7 +68,7 @@ a step ran, not that the task is complete.
 - **Setup** (1 tools): setup_permissions
 - **Shortcuts** (10 tools): list_shortcuts, run_shortcut, search_shortcuts, get_shortcut_detail, create_shortcut, delete_shortcut, export_shortcut, import_shortcut, duplicate_shortcut, edit_shortcut
 - **speech** (3 tools): transcribe_audio, speech_availability, smart_clipboard
-- **System** (27 tools): get_clipboard, set_clipboard, get_volume, set_volume, toggle_dark_mode, get_frontmost_app, list_running_apps, get_screen_info, show_notification, capture_screenshot, get_wifi_status, toggle_wifi, list_bluetooth_devices, get_battery_status, get_brightness, set_brightness, toggle_focus_mode, system_sleep, prevent_sleep, system_power, launch_app, quit_app, is_app_running, list_all_windows, move_window, resize_window, minimize_window
+- **System** (28 tools): get_clipboard, set_clipboard, get_volume, set_volume, toggle_dark_mode, get_frontmost_app, list_running_apps, get_screen_info, show_notification, capture_screenshot, get_wifi_status, toggle_wifi, list_bluetooth_devices, get_battery_status, get_brightness, set_brightness, toggle_focus_mode, system_sleep, prevent_sleep, allow_sleep, system_power, launch_app, quit_app, is_app_running, list_all_windows, move_window, resize_window, minimize_window
 - **TV** (6 tools): tv_list_playlists, tv_list_tracks, tv_now_playing, tv_playback_control, tv_search, tv_play
 - **UI Automation** (10 tools): ui_open_app, ui_click, ui_type, ui_press_key, ui_scroll, ui_read, ui_accessibility_query, ui_perform_action, ui_traverse, ui_diff
 - **Weather** (3 tools): get_current_weather, get_daily_forecast, get_hourly_forecast

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "airmcp",
-  "version": "2.16.3",
+  "version": "2.16.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "airmcp",
-      "version": "2.16.3",
+      "version": "2.16.4",
       "license": "MIT",
       "os": [
         "darwin"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1685,9 +1685,9 @@
       }
     },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
-      "version": "3.15.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
-      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
+      "version": "3.15.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz",
+      "integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3399,9 +3399,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4533,9 +4533,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
-      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "funding": [
         {
           "type": "github",
@@ -4850,9 +4850,9 @@
       "license": "MIT"
     },
     "node_modules/glob/node_modules/brace-expansion": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
-      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4958,9 +4958,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.32",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.32.tgz",
-      "integrity": "sha512-XcuyW9qE2kJn07PkecMOBd5Vq/hMy7mmGw+idz1yblbg9N17ijJODrvPkn7/dwL3Kulj8LcRJ69DLOWf91dRUg==",
+      "version": "4.13.1",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.1.tgz",
+      "integrity": "sha512-kdJoFVv2xmayw6cY09H7AbMJMt8Jn5jdlEdXsP7AGBdF2DIptVlKlOLKXP41yPip4/a3yQPv9gVcJYI8YY04dw==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -5131,9 +5131,9 @@
       }
     },
     "node_modules/ip-address": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
-      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.5.0.tgz",
+      "integrity": "sha512-R5SnVLJmgYYvf2F2ZgwSBnelz5G4q5AxIC277GDfUaNbrZKNANcBC7RHqYYePlszf4kBolVkJauG0ZjHHFh55g==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"
@@ -5920,9 +5920,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
       "funding": [
         {
@@ -7344,9 +7344,9 @@
       "license": "MIT"
     },
     "node_modules/test-exclude/node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/scripts/count-stats.mjs
+++ b/scripts/count-stats.mjs
@@ -148,6 +148,7 @@ syncFile("README.md", [
   { pattern: /(\d+) Shortcuts\/AppIntents/g, value: appIntents },
   { pattern: /\*\*(\d+) Shortcuts \/ Siri AppIntents\*\*/, value: appIntents },
   { pattern: /Current generated surfaces: (\d+) Shortcuts \/ Siri AppIntents/g, value: appIntents },
+  { pattern: /(\d+) App Intent action types/g, value: appIntents },
   { pattern: /(\d+) Interactive Snippet views/g, value: snippetViews },
   { pattern: /and (\d+) AppEnum pickers/g, value: appEnums },
   { pattern: /(\d+) auto-generated AppIntents/g, value: appIntents },

--- a/src/system/tools.ts
+++ b/src/system/tools.ts
@@ -572,7 +572,7 @@ export function registerSystemTools(server: McpServer, _config: AirMcpConfig): v
     {
       title: "Prevent Sleep",
       description:
-        "Prevent the Mac from sleeping for a specified duration using caffeinate. The assertion is transient — it auto-releases when the timer elapses; no manual stop is required.",
+        "Prevent the Mac from sleeping for a specified duration using caffeinate. The assertion auto-releases when the timer elapses, or immediately via allow_sleep. Note: this also blocks sleep triggered by closing the lid, not just idle timeout — call allow_sleep first if you're about to close the lid.",
       inputSchema: {
         seconds: z
           .number()
@@ -607,6 +607,37 @@ export function registerSystemTools(server: McpServer, _config: AirMcpConfig): v
       } catch (e) {
         return errJxaFor("prevent sleep", e);
       }
+    },
+  );
+
+  server.registerTool(
+    "allow_sleep",
+    {
+      title: "Allow Sleep",
+      description:
+        "Cancel any active prevent_sleep assertion immediately, so the Mac can sleep normally again (idle timeout or closing the lid). No-op if no assertion is active.",
+      inputSchema: {},
+      outputSchema: {
+        cancelled: z.boolean(),
+      },
+      annotations: {
+        readOnlyHint: false,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: false,
+      },
+    },
+    async () => {
+      const cancelled = caffeinatePids.size > 0;
+      for (const pid of caffeinatePids) {
+        try {
+          process.kill(pid);
+        } catch {
+          /* already exited */
+        }
+      }
+      caffeinatePids.clear();
+      return okStructured({ cancelled });
     },
   );
 

--- a/swift/Sources/AirMCPKit/Generated/MCPIntents.swift
+++ b/swift/Sources/AirMCPKit/Generated/MCPIntents.swift
@@ -2,8 +2,8 @@
 //
 // Source: docs/tool-manifest.json
 // Generator: scripts/gen-swift-intents.mjs
-// RFC 0007 Phase A.2b.2 + A.4.1 — 233 auto-selected read-only
-// tools (85 with typed drift-guards + Interactive Snippet
+// RFC 0007 Phase A.2b.2 + A.4.1 — 234 auto-selected read-only
+// tools (86 with typed drift-guards + Interactive Snippet
 // SwiftUI views) + 8 AppShortcutsProvider entries.
 // Run `npm run gen:intents` to refresh after tool metadata changes.
 // CI guards against drift via `npm run gen:intents:check`.
@@ -51,6 +51,11 @@ public struct MCPAiPlanMetricsOutput: Codable, Sendable {
     public let expectedCoverageAvg: Double
     public let leakedForbiddenTotal: Double
     public let perCase: [PercaseItem]
+}
+
+// Output type for: allow_sleep
+public struct MCPAllowSleepOutput: Codable, Sendable {
+    public let cancelled: Bool
 }
 
 // Output type for: audit_summary
@@ -1699,6 +1704,34 @@ public struct AiStatusIntent: AppIntent {
             tool: "ai_status",
             args: [String: any Sendable]()
         )
+        return .result(value: result)
+    }
+}
+
+// Tool: allow_sleep
+public struct AllowSleepIntent: AppIntent {
+    nonisolated(unsafe) public static var title: LocalizedStringResource = "Allow Sleep"
+    nonisolated(unsafe) public static var description = IntentDescription("Cancel any active prevent_sleep assertion immediately, so the Mac can sleep normally again (idle timeout or closing the lid). No-op if no assertion is active.")
+    nonisolated(unsafe) public static var openAppWhenRun: Bool = false
+
+    public init() {}
+
+    @MainActor
+    public func perform() async throws -> some IntentResult & ReturnsValue<String> {
+        let result = try await MCPIntentRouter.shared.call(
+            tool: "allow_sleep",
+            args: [String: any Sendable]()
+        )
+        guard let data = result.data(using: .utf8) else {
+            throw MCPIntentError.toolCallFailed(tool: "allow_sleep", message: "empty result from router")
+        }
+        let decoded = try JSONDecoder().decode(MCPAllowSleepOutput.self, from: data)
+        #if canImport(SwiftUI) && compiler(>=6.3)
+        if #available(macOS 26, iOS 26, *) {
+            return .result(value: result, view: MCPAllowSleepSnippetView(data: decoded))
+        }
+        #endif
+        _ = decoded
         return .result(value: result)
     }
 }
@@ -5838,7 +5871,7 @@ public struct PodcastPlaybackControlIntent: AppIntent {
 // Tool: prevent_sleep
 public struct PreventSleepIntent: AppIntent {
     nonisolated(unsafe) public static var title: LocalizedStringResource = "Prevent Sleep"
-    nonisolated(unsafe) public static var description = IntentDescription("Prevent the Mac from sleeping for a specified duration using caffeinate. The assertion is transient — it auto-releases when the timer elapses; no manual stop is required.")
+    nonisolated(unsafe) public static var description = IntentDescription("Prevent the Mac from sleeping for a specified duration using caffeinate. The assertion auto-releases when the timer elapses, or immediately via allow_sleep. Note: this also blocks sleep triggered by closing the lid, not just idle timeout — call allow_sleep first if you're about to close the lid.")
     nonisolated(unsafe) public static var openAppWhenRun: Bool = false
 
     public init() {}
@@ -8343,6 +8376,25 @@ public struct MCPAiPlanMetricsSnippetView: View {
                 Text(row.name)
                     .font(.body)
                     .lineLimit(1)
+            }
+        }
+        .padding()
+    }
+}
+
+// Snippet view for: allow_sleep  (shape: scalar)
+@available(macOS 26, iOS 26, *)
+public struct MCPAllowSleepSnippetView: View {
+    public let data: MCPAllowSleepOutput
+    public init(data: MCPAllowSleepOutput) { self.data = data }
+    public var body: some View {
+        VStack(alignment: .leading, spacing: 2) {
+            HStack {
+                Text("Cancelled")
+                Spacer()
+                Text((data.cancelled ? "Yes" : "No"))
+                    .lineLimit(1)
+                    .truncationMode(.tail)
             }
         }
         .padding()

--- a/tests/output-schema-structured.test.js
+++ b/tests/output-schema-structured.test.js
@@ -140,6 +140,11 @@ const TOOL_FIXTURES = {
     args: {},
     mock: { name: 'Finder', bundleIdentifier: 'com.apple.finder', pid: 1 },
   },
+  allow_sleep: {
+    // Pure Node logic — no JXA/Swift/Automation call, so `mock` is unused.
+    args: {},
+    mock: {},
+  },
   // mail
   list_mailboxes: {
     args: {},

--- a/tests/system-tools.test.js
+++ b/tests/system-tools.test.js
@@ -37,7 +37,7 @@ describe('registerSystemTools', () => {
       'get_wifi_status', 'toggle_wifi', 'list_bluetooth_devices',
       'get_battery_status', 'get_brightness', 'set_brightness',
       'toggle_focus_mode',
-      'system_sleep', 'prevent_sleep', 'system_power',
+      'system_sleep', 'prevent_sleep', 'allow_sleep', 'system_power',
       'launch_app', 'quit_app', 'is_app_running',
       'list_all_windows', 'move_window', 'resize_window', 'minimize_window',
     ];
@@ -71,6 +71,40 @@ describe('registerSystemTools', () => {
       const tool = server._tools.get(name);
       expect(tool.opts.annotations.destructiveHint).toBe(true);
     }
+  });
+});
+
+// ── prevent_sleep / allow_sleep ──────────────────────────────────────
+
+describe('allow_sleep', () => {
+  beforeEach(() => {
+    mockRunJxa.mockReset();
+    mockRunAutomation.mockReset();
+  });
+
+  test('reports cancelled: false when no assertion is active', async () => {
+    const { server } = setup();
+
+    const result = await server.callTool('allow_sleep', {});
+
+    expect(result.isError).toBeUndefined();
+    expect(result.structuredContent).toEqual({ cancelled: false });
+  });
+
+  test('kills the tracked caffeinate process and reports cancelled: true', async () => {
+    const { server } = setup();
+    // Use a PID guaranteed not to correspond to a real process.
+    mockRunJxa.mockResolvedValue({ action: 'prevent_sleep', pid: 2147483647, seconds: 60 });
+    await server.callTool('prevent_sleep', { seconds: 60 });
+
+    const result = await server.callTool('allow_sleep', {});
+
+    expect(result.isError).toBeUndefined();
+    expect(result.structuredContent).toEqual({ cancelled: true });
+
+    // A second call is a no-op since the assertion was already cleared.
+    const second = await server.callTool('allow_sleep', {});
+    expect(second.structuredContent).toEqual({ cancelled: false });
   });
 });
 


### PR DESCRIPTION
## Summary
- `prevent_sleep` backgrounds a `caffeinate -t <seconds>` process for up to 24h with no way to cancel it early, and bare `caffeinate` also blocks sleep triggered by closing the lid (not just idle timeout) — so closing the lid left the Mac awake (fans on, battery draining) until the timer expired.
- Adds `allow_sleep`, which kills the tracked `caffeinate` process on demand and is a no-op when nothing is active.
- Regenerated `docs/tool-manifest.json`, the Swift `MCPIntents.swift` bridge, and doc tool counts (297 → 298); fixed a latent gap in `count-stats.mjs` where the README's "App Intent action types" line wasn't covered by any sync pattern.

## Test plan
- [x] `npm run build`
- [x] `npm test` (2906 tests passing, including new `allow_sleep` coverage in `tests/system-tools.test.js` and `tests/output-schema-structured.test.js`)
- [x] `npm run lint` / `npm run typecheck`
- [x] `npm run gen:manifest:check`, `npm run gen:intents:check`, `npm run stats:check`, `npm run llms:check`, `npm run tokens:check`