### PR TITLE
fix(cd): 중단된 배포 재개용 release_sha 디스패치 입력

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -11,6 +11,14 @@ on:
         options:
           - trusted-publishing
           - token
+      release_sha:
+        description: >-
+          Resume an interrupted publish of an already-released commit. Must be an
+          ancestor of main; if the version tag exists it must point at this commit.
+          Leave empty to publish the dispatched main HEAD (the normal path).
+        required: false
+        default: ''
+        type: string
 
 concurrency:
   group: deploy
@@ -31,14 +39,21 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          ref: ${{ github.sha }}
+          ref: ${{ inputs.release_sha || github.sha }}
           fetch-depth: 0
           fetch-tags: true
 
+      # release_sha exists for one situation: a release commit published the root
+      # package and then a later step failed, and by the time the fallback rerun
+      # is dispatched main has already advanced — so github.sha no longer matches
+      # the registry gitHead and the identity check can never pass. The resume
+      # path keeps both supply-chain invariants: the dispatch still comes from
+      # refs/heads/main, and the resumed commit must be an ancestor of that main.
       - name: Verify release source
         env:
           RELEASE_REF: ${{ github.ref }}
-          RELEASE_SHA: ${{ github.sha }}
+          WORKFLOW_SHA: ${{ github.sha }}
+          RELEASE_SHA: ${{ inputs.release_sha || github.sha }}
         run: |
           if [ "$RELEASE_REF" != "refs/heads/main" ]; then
             echo "::error::Publishing is allowed only from refs/heads/main, got $RELEASE_REF"
@@ -46,8 +61,15 @@ jobs:
           fi
           CHECKED_OUT_SHA="$(git rev-parse HEAD)"
           if [ "$CHECKED_OUT_SHA" != "$RELEASE_SHA" ]; then
-            echo "::error::Checked-out commit $CHECKED_OUT_SHA does not match workflow commit $RELEASE_SHA"
+            echo "::error::Checked-out commit $CHECKED_OUT_SHA does not match release commit $RELEASE_SHA"
             exit 1
+          fi
+          if [ "$RELEASE_SHA" != "$WORKFLOW_SHA" ]; then
+            if ! git merge-base --is-ancestor "$RELEASE_SHA" "$WORKFLOW_SHA"; then
+              echo "::error::release_sha $RELEASE_SHA is not an ancestor of the dispatched main commit $WORKFLOW_SHA"
+              exit 1
+            fi
+            echo "::notice::Resuming interrupted publish of $RELEASE_SHA (main is at $WORKFLOW_SHA)."
           fi
 
       - name: Extract package info
@@ -62,8 +84,12 @@ jobs:
       - name: Version guard
         run: |
           if git show-ref --tags --verify --quiet "refs/tags/v${{ steps.pkg.outputs.version }}"; then
-            echo "::error::Tag v${{ steps.pkg.outputs.version }} already exists. Bump the version first."
-            exit 1
+            TAG_SHA="$(git rev-parse "refs/tags/v${{ steps.pkg.outputs.version }}^{commit}")"
+            if [ "$TAG_SHA" != "$(git rev-parse HEAD)" ]; then
+              echo "::error::Tag v${{ steps.pkg.outputs.version }} already exists at $TAG_SHA, not at the release commit. Bump the version first."
+              exit 1
+            fi
+            echo "::notice::Tag v${{ steps.pkg.outputs.version }} already points at this commit — resuming an interrupted publish."
           fi
 
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v6
@@ -140,7 +166,7 @@ jobs:
       - name: Inspect root registry identity
         id: root-identity
         env:
-          AIRMCP_RELEASE_SHA: ${{ github.sha }}
+          AIRMCP_RELEASE_SHA: ${{ inputs.release_sha || github.sha }}
         run: node scripts/verify-publish-identity.mjs --allow-missing
 
       - name: Publish root with provenance
@@ -155,20 +181,20 @@ jobs:
 
       - name: Verify root registry identity
         env:
-          AIRMCP_RELEASE_SHA: ${{ github.sha }}
+          AIRMCP_RELEASE_SHA: ${{ inputs.release_sha || github.sha }}
         run: node scripts/verify-publish-identity.mjs --retry-seconds=600
 
       - name: Publish add-ons with provenance
         if: steps.npm-auth.outputs.mode == 'trusted-publishing'
         env:
-          AIRMCP_RELEASE_SHA: ${{ github.sha }}
+          AIRMCP_RELEASE_SHA: ${{ inputs.release_sha || github.sha }}
         run: |
           npm run addons:publish -- --publish --all --no-build --skip-verify
 
       - name: Publish add-ons with provenance (token fallback)
         if: steps.npm-auth.outputs.mode == 'token'
         env:
-          AIRMCP_RELEASE_SHA: ${{ github.sha }}
+          AIRMCP_RELEASE_SHA: ${{ inputs.release_sha || github.sha }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           npm run addons:publish -- --publish --all --no-build --skip-verify
@@ -177,7 +203,7 @@ jobs:
         uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v2.5.0
         with:
           tag_name: v${{ steps.pkg.outputs.version }}
-          target_commitish: ${{ github.sha }}
+          target_commitish: ${{ inputs.release_sha || github.sha }}
           name: v${{ steps.pkg.outputs.version }}
           generate_release_notes: true
           files: build/release-preflight/airmcp-${{ steps.pkg.outputs.version }}.mcpb
@@ -218,4 +244,4 @@ jobs:
       - name: Verify public release state
         env:
           GH_TOKEN: ${{ github.token }}
-        run: npm run release:verify -- --expected-sha=${{ github.sha }}
+        run: npm run release:verify -- --expected-sha=${{ inputs.release_sha || github.sha }}

--- a/tests/release-workflow-hardening.test.js
+++ b/tests/release-workflow-hardening.test.js
@@ -119,17 +119,26 @@ describe("release workflow source and identity hardening", () => {
   test("binds CD to main and the workflow SHA, then dispatches the signed lane explicitly", () => {
     expect(cd.jobs.publish.permissions.actions).toBe("write");
     const checkout = cd.jobs.publish.steps.find((step) => step.uses?.startsWith("actions/checkout@"));
-    expect(checkout.with.ref).toBe("${{ github.sha }}");
+    // release_sha lets a fallback dispatch resume a commit that already left
+    // main HEAD (e.g. after a prior publish attempt partially succeeded and a
+    // later commit landed on main before the rerun). It defaults to the plain
+    // dispatched SHA, so the no-input path is unchanged.
+    expect(checkout.with.ref).toBe("${{ inputs.release_sha || github.sha }}");
     expect(checkout.with["fetch-depth"]).toBe(0);
 
     const source = namedStep(cd, "publish", "Verify release source");
     expect(source.env.RELEASE_REF).toBe("${{ github.ref }}");
-    expect(source.env.RELEASE_SHA).toBe("${{ github.sha }}");
+    expect(source.env.WORKFLOW_SHA).toBe("${{ github.sha }}");
+    expect(source.env.RELEASE_SHA).toBe("${{ inputs.release_sha || github.sha }}");
     expect(source.run).toContain("refs/heads/main");
     expect(source.run).toContain("git rev-parse HEAD");
+    // The resume path must still prove provenance: release_sha has to be an
+    // ancestor of the main commit that dispatched the workflow, so someone
+    // can't smuggle in an arbitrary commit via the input.
+    expect(source.run).toContain("git merge-base --is-ancestor");
 
     const release = namedStep(cd, "publish", "Create GitHub Release");
-    expect(release.with.target_commitish).toBe("${{ github.sha }}");
+    expect(release.with.target_commitish).toBe("${{ inputs.release_sha || github.sha }}");
     const dispatch = namedStep(cd, "publish", "Dispatch signed app release");
     expect(dispatch.run).toContain("gh workflow run release-app.yml");
     expect(dispatch.run).toContain('--ref "$RELEASE_TAG"');
@@ -152,7 +161,7 @@ describe("release workflow source and identity hardening", () => {
     const inspect = namedStep(cd, "publish", "Inspect root registry identity");
     const verify = namedStep(cd, "publish", "Verify root registry identity");
     expect(inspect.run).toContain("verify-publish-identity.mjs --allow-missing");
-    expect(inspect.env.AIRMCP_RELEASE_SHA).toBe("${{ github.sha }}");
+    expect(inspect.env.AIRMCP_RELEASE_SHA).toBe("${{ inputs.release_sha || github.sha }}");
     expect(verify.run).toContain("verify-publish-identity.mjs --retry-seconds=60");
 
     for (const name of ["Publish root with provenance", "Publish root with provenance (token fallback)"]) {


### PR DESCRIPTION
## 배경 (v2.16.5 릴리스 실측)

릴리스 커밋이 루트 패키지를 배포한 뒤 애드온 단계에서 실패하면(이번: 애드온 4종이 npm trusted publisher 미등록이라 무인증 PUT → E404), main이 전진한 순간부터 복구가 불가능해집니다:

1. token 폴백 디스패치는 main HEAD에서 돌아 registry gitHead ≠ github.sha로 정체성 검증 실패
2. 태그에서 디스패치하면 "main에서만 배포" 가드에 차단
3. 태그가 이미 생성돼 있으면 Version guard가 모든 재실행을 차단

즉 파이프라인에 '중단된 배포 재개' 경로가 없습니다.

## 수정

`workflow_dispatch`에 선택 입력 `release_sha` 추가. 해당 커밋을 체크아웃·배포하되 공급망 불변식 둘 다 유지:
- 디스패치는 여전히 `refs/heads/main`에서만
- `release_sha`는 디스패치된 main HEAD의 조상이어야 함 (`merge-base --is-ancestor`)

Version guard는 기존 태그가 릴리스 커밋을 가리키면 재개로 간주하고 통과, 다른 커밋을 가리키면 기존대로 차단. `AIRMCP_RELEASE_SHA`·`target_commitish`·`release:verify` 전부 유효 릴리스 SHA를 따라감.

머지 후 `release_sha=37caebd…` + token 모드로 v2.16.5 배포를 재개합니다. 근본 원인(애드온 trusted publisher 미등록)은 npmjs.com 콘솔 등록으로 별도 해소 필요.