### PR TITLE
fix(test): 테스트 스폰 서버의 감사 로그를 실 HOME에서 격리

### DIFF
--- a/scripts/lib/clean-boot-env.mjs
+++ b/scripts/lib/clean-boot-env.mjs
@@ -56,5 +56,15 @@ export function cleanBootEnv(base = process.env) {
   // Suspenders: usage-tracker.ts also refuses disk persistence whenever
   // AIRMCP_TEST_MODE=1 without an explicit AIRMCP_USAGE_PROFILE_PATH.
   env.AIRMCP_USAGE_TRACKING = "false";
+  // Same leak, different file: the audit log lives under PATHS.VECTOR_STORE
+  // (default ~/.airmcp), so a cleanBootEnv-spawned server audit-logs into the
+  // developer's REAL ~/.airmcp/audit.jsonl. cli-connect.test.js deliberately
+  // sends an unauthenticated request to assert a 401 — every full-suite run
+  // was appending one __auth_failure row to the real audit chain, which then
+  // read as an unattributable production auth incident (2026-08: 13 loopback
+  // 401s traced back to exactly this before the redirect existed).
+  // Per-parent-process dir: parallel jest workers each isolate their spawns,
+  // and the multiprocess audit lock handles siblings sharing one dir.
+  env.AIRMCP_VECTOR_STORE_DIR = join(tmpdir(), `airmcp-test-state-${process.pid}`);
   return env;
 }

--- a/tests/clean-boot-env.test.js
+++ b/tests/clean-boot-env.test.js
@@ -1,0 +1,56 @@
+/**
+ * cleanBootEnv — state isolation contract for test-spawned real servers.
+ *
+ * cleanBootEnv() is the shared child env for every harness that boots the
+ * REAL server binary (smoke/validate gates, cli-connect, codex/connect-clients
+ * CLI tests). Those children inherit the real HOME, so every stateful default
+ * path must be explicitly redirected or the suite leaks into developer state:
+ *   - ~/.airmcp/profile.json (usage stats) — leaked until 2.16.4, now gated
+ *     by AIRMCP_USAGE_TRACKING=false;
+ *   - ~/.airmcp/audit.jsonl (HMAC-chained audit log) — leaked until this
+ *     test's redirect existed: cli-connect asserts a deliberate 401 against a
+ *     spawned server, and each full-suite run appended one __auth_failure row
+ *     to the real audit chain, indistinguishable from a production incident
+ *     (2026-08: 13 loopback 401s were chased as an unattributable prober
+ *     before being traced here).
+ *
+ * If a new stateful default path is added under PATHS.*, it belongs in
+ * cleanBootEnv and in these assertions.
+ */
+import { describe, test, expect } from "@jest/globals";
+import { homedir, tmpdir } from "node:os";
+import { join } from "node:path";
+import { cleanBootEnv } from "../scripts/lib/clean-boot-env.mjs";
+
+describe("cleanBootEnv state isolation", () => {
+  test("strips inherited AIRMCP_* and locks the default-surface contract", () => {
+    const env = cleanBootEnv({
+      HOME: homedir(),
+      AIRMCP_FULL: "true",
+      AIRMCP_VECTOR_STORE_DIR: join(homedir(), ".airmcp"),
+      AIRMCP_HTTP_TOKEN: "leaked",
+    });
+    expect(env.AIRMCP_FULL).toBeUndefined();
+    expect(env.AIRMCP_HTTP_TOKEN).toBeUndefined();
+    expect(env.AIRMCP_TEST_MODE).toBe("1");
+    expect(env.AIRMCP_PROFILE).toBe("starter");
+    expect(env.AIRMCP_TOOL_EXPOSURE).toBe("progressive");
+    expect(env.HOME).toBe(homedir());
+  });
+
+  test("usage tracking is disabled and audit state is redirected off the real HOME", () => {
+    const env = cleanBootEnv();
+    expect(env.AIRMCP_USAGE_TRACKING).toBe("false");
+
+    const stateDir = env.AIRMCP_VECTOR_STORE_DIR;
+    expect(stateDir).toBeDefined();
+    // The audit log (and every other PATHS.VECTOR_STORE file) must land in a
+    // scratch dir, never in the developer's real ~/.airmcp.
+    expect(stateDir.startsWith(tmpdir())).toBe(true);
+    expect(stateDir.startsWith(join(homedir(), ".airmcp"))).toBe(false);
+  });
+
+  test("state dir is stable within a process so sibling spawns share one audit chain", () => {
+    expect(cleanBootEnv().AIRMCP_VECTOR_STORE_DIR).toBe(cleanBootEnv().AIRMCP_VECTOR_STORE_DIR);
+  });
+});


### PR DESCRIPTION
## 배경 — 미상 무토큰 401의 정체

일주일간 실 감사 로그에 쌓인 loopback 401 13건(`__auth_failure`, ip 127.0.0.1, path /mcp)은 외부 프로버도, 토큰 어긋난 클라이언트도 아니었습니다. v2.16.5에 넣은 계측이 첫 발생에서 `reason: missing_token, userAgent: node`를 찍어줬고, 추적 결과:

- `cleanBootEnv()`는 config 격리 + usage tracking 비활성은 했지만 **PATHS.VECTOR_STORE(기본 ~/.airmcp)는 격리하지 않음**
- cli-connect.test.js가 실서버를 임시 포트에 띄우고 **의도적으로** 무토큰 요청을 보내 401을 검증
- 그 스폰된 서버가 실 `~/.airmcp/audit.jsonl`에 `__auth_failure`를 기록 → 전체 스위트 1회당 1건

2.16.4에서 고친 profile.json 오염과 같은 클래스의 잔재입니다(파일만 다름).

## 수정

`cleanBootEnv`가 `AIRMCP_VECTOR_STORE_DIR`를 부모 프로세스별 스크래치 디렉터리로 지정. 신규 tests/clean-boot-env.test.js가 격리 계약(AIRMCP_* 제거, usage tracking off, 상태 디렉터리 tmpdir 하위·실 ~/.airmcp 밖)을 고정.

## 검증 (양방향)

- 수정 후 cli-connect 실행 → 의도된 401이 스크래치 audit.jsonl에 정확히 1건 기록
- 실 감사 로그에는 새 행 없음 (마지막 401 = 수정 전 재현 실행분)
- cleanBootEnv 소비 테스트 5개 스위트 25개 전부 통과