### PR TITLE
fix(audit): redact sensitive UI inputs

### DIFF
--- a/src/server/front-door-tools.ts
+++ b/src/server/front-door-tools.ts
@@ -32,6 +32,7 @@ import {
   writeModulePackConfig,
 } from "../shared/addon-operations.js";
 import { isPlainObject } from "../shared/validate.js";
+import { sanitizeToolArgs } from "../shared/audit.js";
 
 export interface MissingPackInstallHint {
   pack: ModulePackName;
@@ -502,7 +503,8 @@ export function registerFrontDoorTools(server: McpServer, options: RegisterFront
       annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: false },
     },
     async ({ tool, args }) => {
-      const preview = toolRegistry.previewCall(tool, (args ?? {}) as Record<string, unknown>);
+      const targetArgs = (args ?? {}) as Record<string, unknown>;
+      const preview = toolRegistry.previewCall(tool, targetArgs);
       const rate = getRateLimitStatus();
       const rateLimit = {
         emergencyStop: rate.emergencyStop,
@@ -535,7 +537,7 @@ export function registerFrontDoorTools(server: McpServer, options: RegisterFront
         wouldRequireApproval,
         hitlLevel: config.hitl.level,
         requiredScope: requiredScopeFor({ toolName: tool, isReadOnly: ann.readOnly, isDestructive: ann.destructive }),
-        auditPreview: { tool, status: "would-run", actor: "caller", args: preview.auditArgs ?? {} },
+        auditPreview: { tool, status: "would-run", actor: "caller", args: sanitizeToolArgs(tool, targetArgs) },
         rateLimit,
         sideEffect: "none — handler not invoked",
       });

--- a/src/shared/audit.ts
+++ b/src/shared/audit.ts
@@ -297,6 +297,38 @@ function isSensitiveTool(name: string): boolean {
   return SENSITIVE_TOOL_PATTERNS.some((re) => re.test(name));
 }
 
+/**
+ * Per-argument redaction for UI tools whose remaining arguments are useful
+ * audit context. These values can contain typed credentials or serialized UI
+ * state, but their names are intentionally generic and therefore do not match
+ * sanitizeArgs' secret-key patterns.
+ */
+const SENSITIVE_UI_ARGS: ReadonlyMap<string, ReadonlySet<string>> = new Map([
+  ["ui_type", new Set(["text"])],
+  ["ui_perform_action", new Set(["actionValue"])],
+  ["ui_diff", new Set(["beforeSnapshot"])],
+]);
+
+function redactSensitiveUiArgs(tool: string, args: Record<string, unknown>): Record<string, unknown> {
+  const sensitiveArgs = SENSITIVE_UI_ARGS.get(tool);
+  if (!sensitiveArgs) return args;
+
+  let changed = false;
+  const redacted: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(args)) {
+    if (sensitiveArgs.has(key) && value !== undefined && value !== null) {
+      redacted[key] = {
+        _redacted: "ui_input",
+        ...(typeof value === "string" ? { length: value.length } : {}),
+      };
+      changed = true;
+    } else {
+      redacted[key] = value;
+    }
+  }
+  return changed ? redacted : args;
+}
+
 let initialized = false;
 let buffer: string[] = [];
 let bufferBytes = 0;
@@ -342,7 +374,7 @@ export function auditLog(entry: AuditEntry): void {
   if (isSensitiveTool(entry.tool)) {
     sanitized = entry.args ? { _redacted: "sensitive_tool" } : undefined;
   } else if (entry.args) {
-    sanitized = sanitizeArgs(entry.args);
+    sanitized = sanitizeArgs(redactSensitiveUiArgs(entry.tool, entry.args));
   }
   // Auto-attach the active correlation ID when the caller didn't pass
   // one. Falls through to undefined for synthetic / pre-context callers

--- a/src/shared/audit.ts
+++ b/src/shared/audit.ts
@@ -304,8 +304,11 @@ function isSensitiveTool(name: string): boolean {
  * sanitizeArgs' secret-key patterns.
  */
 const SENSITIVE_UI_ARGS: ReadonlyMap<string, ReadonlySet<string>> = new Map([
+  ["ui_click", new Set(["text"])],
   ["ui_type", new Set(["text"])],
-  ["ui_perform_action", new Set(["actionValue"])],
+  ["ui_press_key", new Set(["key"])],
+  ["ui_accessibility_query", new Set(["title", "value", "description", "label"])],
+  ["ui_perform_action", new Set(["title", "value", "description", "label", "actionValue"])],
   ["ui_diff", new Set(["beforeSnapshot"])],
 ]);
 
@@ -327,6 +330,49 @@ function redactSensitiveUiArgs(tool: string, args: Record<string, unknown>): Rec
     }
   }
   return changed ? redacted : args;
+}
+
+const MAX_PREVIEW_ACTION_DEPTH = 3;
+
+function isArgsRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function sanitizeToolArgsAtDepth(
+  tool: string,
+  args: Record<string, unknown>,
+  previewDepth: number,
+): Record<string, unknown> {
+  if (isSensitiveTool(tool)) return { _redacted: "sensitive_tool" };
+
+  const sanitized = sanitizeArgs(redactSensitiveUiArgs(tool, args));
+  if (tool !== "preview_action" || !Object.hasOwn(args, "args")) return sanitized;
+
+  const targetTool = args.tool;
+  const targetArgs = args.args;
+  // `preview_action` is itself audited as a tool call. Its nested `args`
+  // describe the target tool, so generic key-only scrubbing is insufficient:
+  // `{ tool: "ui_type", args: { text: "..." } }` would otherwise seal the
+  // typed value into the HMAC chain. Invalid/malicious wrapper shapes and
+  // unbounded preview-of-preview recursion fail closed by dropping the entire
+  // nested payload.
+  const nested =
+    typeof targetTool === "string" &&
+    targetTool.length > 0 &&
+    isArgsRecord(targetArgs) &&
+    previewDepth < MAX_PREVIEW_ACTION_DEPTH
+      ? sanitizeToolArgsAtDepth(targetTool, targetArgs, previewDepth + 1)
+      : { _redacted: "preview_target_args" };
+  return { ...sanitized, args: nested };
+}
+
+/**
+ * Apply the exact tool-aware redaction policy used by both persisted audit
+ * rows and pre-hoc previews. Keeping this boundary shared prevents a preview
+ * from exposing data that the corresponding executed call would redact.
+ */
+export function sanitizeToolArgs(tool: string, args: Record<string, unknown>): Record<string, unknown> {
+  return sanitizeToolArgsAtDepth(tool, args, 0);
 }
 
 let initialized = false;
@@ -370,12 +416,7 @@ export function auditLog(entry: AuditEntry): void {
   if (auditDisabled) {
     maybeAttemptRecovery();
   }
-  let sanitized: Record<string, unknown> | undefined;
-  if (isSensitiveTool(entry.tool)) {
-    sanitized = entry.args ? { _redacted: "sensitive_tool" } : undefined;
-  } else if (entry.args) {
-    sanitized = sanitizeArgs(redactSensitiveUiArgs(entry.tool, entry.args));
-  }
+  const sanitized = entry.args ? sanitizeToolArgs(entry.tool, entry.args) : undefined;
   // Auto-attach the active correlation ID when the caller didn't pass
   // one. Falls through to undefined for synthetic / pre-context callers
   // (e.g. startup banner, direct test invocations).

--- a/src/shared/tool-registry.ts
+++ b/src/shared/tool-registry.ts
@@ -16,7 +16,7 @@
 
 import type { McpServer, AnyFn } from "./mcp.js";
 import { usageTracker } from "./usage-tracker.js";
-import { auditLog, readAuditEntries, sanitizeArgs } from "./audit.js";
+import { auditLog, readAuditEntries, sanitizeToolArgs } from "./audit.js";
 import { compactDescription } from "./tool-filter.js";
 import { withResultSizeHint } from "./result.js";
 import { log } from "./logger.js";
@@ -385,7 +385,7 @@ export class ToolRegistry {
       readOnly: entry.readOnly === true,
       sensitive: entry.sensitive === true,
     };
-    const auditArgs = sanitizeArgs(args);
+    const auditArgs = sanitizeToolArgs(name, args);
     try {
       validateToolArgs(name, entry.inputSchema, args);
       return { exists: true, exposed: entry.exposed, annotations, argsValid: true, auditArgs };

--- a/tests/audit-ui-redaction.test.js
+++ b/tests/audit-ui-redaction.test.js
@@ -1,0 +1,95 @@
+/** UI input values must be removed before a row is sealed into the HMAC audit
+ * chain. These tests inspect the actual JSONL bytes as well as the verified
+ * public history so a read-time-only redaction cannot satisfy the regression. */
+import { afterAll, beforeEach, describe, expect, test } from "@jest/globals";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const workDir = await mkdtemp(join(tmpdir(), "airmcp-audit-ui-redaction-"));
+process.env.AIRMCP_VECTOR_STORE_DIR = workDir;
+process.env.AIRMCP_AUDIT_HMAC_KEY = "audit-ui-redaction-key";
+process.env.AIRMCP_AUDIT_LOG = "true";
+
+const audit = await import("../dist/shared/audit.js");
+const auditPath = join(workDir, "audit.jsonl");
+
+async function writeRows(entries) {
+  for (const entry of entries) {
+    audit.auditLog({ timestamp: new Date().toISOString(), status: "ok", ...entry });
+  }
+  await audit._testFlush();
+  const raw = await readFile(auditPath, "utf8");
+  return {
+    raw,
+    rows: raw
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line)),
+  };
+}
+
+beforeEach(() => audit._testReset());
+
+afterAll(async () => {
+  audit._testReset();
+  await rm(workDir, { recursive: true, force: true });
+});
+
+describe("UI-input audit redaction", () => {
+  test("redacts sensitive UI values before sealing while preserving benign context", async () => {
+    const secrets = {
+      ui_type: "hunter2 secret passphrase",
+      ui_perform_action: "s3cr3t-value",
+      ui_diff: "SECRET-SNAPSHOT-1234",
+    };
+    const { raw, rows } = await writeRows([
+      { tool: "ui_type", args: { text: secrets.ui_type, appName: "Notes", locator: "AXTextField:Body" } },
+      {
+        tool: "ui_perform_action",
+        args: {
+          role: "AXTextField",
+          title: "Password",
+          action: "setValue",
+          actionValue: secrets.ui_perform_action,
+        },
+      },
+      {
+        tool: "ui_diff",
+        args: { beforeSnapshot: [{ role: "AXStaticText", value: secrets.ui_diff }], app: "Notes" },
+      },
+    ]);
+
+    for (const secret of Object.values(secrets)) expect(raw).not.toContain(secret);
+
+    const byTool = Object.fromEntries(rows.map((row) => [row.tool, row]));
+    expect(byTool.ui_type.args).toEqual({
+      text: { _redacted: "ui_input", length: secrets.ui_type.length },
+      appName: "Notes",
+      locator: "AXTextField:Body",
+    });
+    expect(byTool.ui_perform_action.args).toEqual({
+      role: "AXTextField",
+      title: "Password",
+      action: "setValue",
+      actionValue: { _redacted: "ui_input", length: secrets.ui_perform_action.length },
+    });
+    expect(byTool.ui_diff.args).toEqual({
+      beforeSnapshot: { _redacted: "ui_input" },
+      app: "Notes",
+    });
+
+    for (const row of rows) {
+      expect(row._prev).toMatch(/^[0-9a-f]{64}$/);
+      expect(row._hmac).toMatch(/^[0-9a-f]{64}$/);
+    }
+    const summary = await audit.summarizeAuditEntries({ since: "2020-01-01T00:00:00Z" });
+    expect(summary.verified).toBe(true);
+    expect(summary.total).toBe(3);
+  });
+
+  test("does not redact the same generic key on unrelated tools", async () => {
+    const { rows } = await writeRows([{ tool: "create_note", args: { title: "Groceries", text: "milk and eggs" } }]);
+    expect(rows.at(-1).args).toEqual({ title: "Groceries", text: "milk and eggs" });
+  });
+});

--- a/tests/audit-ui-redaction.test.js
+++ b/tests/audit-ui-redaction.test.js
@@ -1,15 +1,19 @@
 /** UI input values must be removed before a row is sealed into the HMAC audit
  * chain. These tests inspect the actual JSONL bytes as well as the verified
  * public history so a read-time-only redaction cannot satisfy the regression. */
-import { afterAll, beforeEach, describe, expect, test } from "@jest/globals";
+import { afterAll, beforeEach, describe, expect, jest, test } from "@jest/globals";
 import { mkdtemp, readFile, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { createMockServer } from "./helpers/mock-server.js";
+import { createMockConfig } from "./helpers/mock-config.js";
 
 const workDir = await mkdtemp(join(tmpdir(), "airmcp-audit-ui-redaction-"));
 process.env.AIRMCP_VECTOR_STORE_DIR = workDir;
 process.env.AIRMCP_AUDIT_HMAC_KEY = "audit-ui-redaction-key";
 process.env.AIRMCP_AUDIT_LOG = "true";
+process.env.AIRMCP_USAGE_TRACKING = "false";
+process.env.AIRMCP_EMERGENCY_STOP_PATH = join(workDir, "emergency-stop");
 
 const audit = await import("../dist/shared/audit.js");
 const auditPath = join(workDir, "audit.jsonl");
@@ -39,24 +43,61 @@ afterAll(async () => {
 describe("UI-input audit redaction", () => {
   test("redacts sensitive UI values before sealing while preserving benign context", async () => {
     const secrets = {
-      ui_type: "hunter2 secret passphrase",
-      ui_perform_action: "s3cr3t-value",
-      ui_diff: "SECRET-SNAPSHOT-1234",
+      typeText: "TYPE-SECRET-hunter2",
+      clickText: "CLICK-SECRET-account-name",
+      pressKey: "PRESS-KEY-SECRET",
+      queryTitle: "QUERY-TITLE-SECRET",
+      queryValue: "QUERY-VALUE-SECRET",
+      queryDescription: "QUERY-DESCRIPTION-SECRET",
+      queryLabel: "QUERY-LABEL-SECRET",
+      actionTitle: "ACTION-TITLE-SECRET",
+      actionValueLocator: "ACTION-LOCATOR-VALUE-SECRET",
+      actionDescription: "ACTION-DESCRIPTION-SECRET",
+      actionLabel: "ACTION-LABEL-SECRET",
+      actionInput: "ACTION-INPUT-SECRET",
+      beforeSnapshot: "SNAPSHOT-SECRET-1234",
     };
     const { raw, rows } = await writeRows([
-      { tool: "ui_type", args: { text: secrets.ui_type, appName: "Notes", locator: "AXTextField:Body" } },
+      { tool: "ui_type", args: { text: secrets.typeText, appName: "Notes" } },
+      {
+        tool: "ui_click",
+        args: { text: secrets.clickText, appName: "Safari", x: 42, y: 84, role: "AXButton", index: 2 },
+      },
+      {
+        tool: "ui_press_key",
+        args: { key: secrets.pressKey, modifiers: ["command", "shift"], appName: "Notes" },
+      },
+      {
+        tool: "ui_accessibility_query",
+        args: {
+          app: "Safari",
+          role: "AXTextField",
+          title: secrets.queryTitle,
+          value: secrets.queryValue,
+          description: secrets.queryDescription,
+          label: secrets.queryLabel,
+          identifier: "account-field",
+          maxResults: 5,
+        },
+      },
       {
         tool: "ui_perform_action",
         args: {
+          app: "Notes",
           role: "AXTextField",
-          title: "Password",
+          title: secrets.actionTitle,
+          value: secrets.actionValueLocator,
+          description: secrets.actionDescription,
+          label: secrets.actionLabel,
+          identifier: "body-field",
           action: "setValue",
-          actionValue: secrets.ui_perform_action,
+          actionValue: secrets.actionInput,
+          index: 1,
         },
       },
       {
         tool: "ui_diff",
-        args: { beforeSnapshot: [{ role: "AXStaticText", value: secrets.ui_diff }], app: "Notes" },
+        args: { beforeSnapshot: secrets.beforeSnapshot, app: "Notes" },
       },
     ]);
 
@@ -64,18 +105,46 @@ describe("UI-input audit redaction", () => {
 
     const byTool = Object.fromEntries(rows.map((row) => [row.tool, row]));
     expect(byTool.ui_type.args).toEqual({
-      text: { _redacted: "ui_input", length: secrets.ui_type.length },
+      text: { _redacted: "ui_input", length: secrets.typeText.length },
       appName: "Notes",
-      locator: "AXTextField:Body",
+    });
+    expect(byTool.ui_click.args).toEqual({
+      text: { _redacted: "ui_input", length: secrets.clickText.length },
+      appName: "Safari",
+      x: 42,
+      y: 84,
+      role: "AXButton",
+      index: 2,
+    });
+    expect(byTool.ui_press_key.args).toEqual({
+      key: { _redacted: "ui_input", length: secrets.pressKey.length },
+      modifiers: ["command", "shift"],
+      appName: "Notes",
+    });
+    expect(byTool.ui_accessibility_query.args).toEqual({
+      app: "Safari",
+      role: "AXTextField",
+      title: { _redacted: "ui_input", length: secrets.queryTitle.length },
+      value: { _redacted: "ui_input", length: secrets.queryValue.length },
+      description: { _redacted: "ui_input", length: secrets.queryDescription.length },
+      label: { _redacted: "ui_input", length: secrets.queryLabel.length },
+      identifier: "account-field",
+      maxResults: 5,
     });
     expect(byTool.ui_perform_action.args).toEqual({
+      app: "Notes",
       role: "AXTextField",
-      title: "Password",
+      title: { _redacted: "ui_input", length: secrets.actionTitle.length },
+      value: { _redacted: "ui_input", length: secrets.actionValueLocator.length },
+      description: { _redacted: "ui_input", length: secrets.actionDescription.length },
+      label: { _redacted: "ui_input", length: secrets.actionLabel.length },
+      identifier: "body-field",
       action: "setValue",
-      actionValue: { _redacted: "ui_input", length: secrets.ui_perform_action.length },
+      actionValue: { _redacted: "ui_input", length: secrets.actionInput.length },
+      index: 1,
     });
     expect(byTool.ui_diff.args).toEqual({
-      beforeSnapshot: { _redacted: "ui_input" },
+      beforeSnapshot: { _redacted: "ui_input", length: secrets.beforeSnapshot.length },
       app: "Notes",
     });
 
@@ -85,11 +154,171 @@ describe("UI-input audit redaction", () => {
     }
     const summary = await audit.summarizeAuditEntries({ since: "2020-01-01T00:00:00Z" });
     expect(summary.verified).toBe(true);
-    expect(summary.total).toBe(3);
+    expect(summary.total).toBe(6);
   });
 
   test("does not redact the same generic key on unrelated tools", async () => {
     const { rows } = await writeRows([{ tool: "create_note", args: { title: "Groceries", text: "milk and eggs" } }]);
     expect(rows.at(-1).args).toEqual({ title: "Groceries", text: "milk and eggs" });
+  });
+
+  test("preview_action redacts its response and nested sealed rows with the same policy", async () => {
+    const { createToolRegistry } = await import("../dist/shared/tool-registry.js");
+    const { registerFrontDoorTools } = await import("../dist/server/front-door-tools.js");
+    const server = createMockServer();
+    const registry = createToolRegistry();
+    registry.installOn(server);
+    const targetHandler = jest.fn(async () => ({ content: [] }));
+
+    const cases = [
+      {
+        tool: "ui_type",
+        args: { text: "PREVIEW-TYPE-SECRET", appName: "Notes" },
+        expected: { text: { _redacted: "ui_input", length: 19 }, appName: "Notes" },
+      },
+      {
+        tool: "ui_click",
+        args: { text: "PREVIEW-CLICK-SECRET", appName: "Safari", role: "AXButton", index: 3 },
+        expected: {
+          text: { _redacted: "ui_input", length: 20 },
+          appName: "Safari",
+          role: "AXButton",
+          index: 3,
+        },
+      },
+      {
+        tool: "ui_press_key",
+        args: { key: "PREVIEW-PRESS-KEY-SECRET", modifiers: ["command"], appName: "Notes" },
+        expected: {
+          key: { _redacted: "ui_input", length: 24 },
+          modifiers: ["command"],
+          appName: "Notes",
+        },
+      },
+      {
+        tool: "ui_accessibility_query",
+        args: {
+          app: "Safari",
+          role: "AXTextField",
+          title: "PREVIEW-QUERY-TITLE-SECRET",
+          value: "PREVIEW-QUERY-VALUE-SECRET",
+          description: "PREVIEW-QUERY-DESCRIPTION-SECRET",
+          label: "PREVIEW-QUERY-LABEL-SECRET",
+          identifier: "login-field",
+        },
+        expected: {
+          app: "Safari",
+          role: "AXTextField",
+          title: { _redacted: "ui_input", length: 26 },
+          value: { _redacted: "ui_input", length: 26 },
+          description: { _redacted: "ui_input", length: 32 },
+          label: { _redacted: "ui_input", length: 26 },
+          identifier: "login-field",
+        },
+      },
+      {
+        tool: "ui_perform_action",
+        args: {
+          app: "Notes",
+          role: "AXTextField",
+          title: "PREVIEW-ACTION-TITLE-SECRET",
+          value: "PREVIEW-ACTION-VALUE-SECRET",
+          description: "PREVIEW-ACTION-DESCRIPTION-SECRET",
+          label: "PREVIEW-ACTION-LABEL-SECRET",
+          identifier: "body-field",
+          action: "setValue",
+          actionValue: "PREVIEW-ACTION-INPUT-SECRET",
+          index: 1,
+        },
+        expected: {
+          app: "Notes",
+          role: "AXTextField",
+          title: { _redacted: "ui_input", length: 27 },
+          value: { _redacted: "ui_input", length: 27 },
+          description: { _redacted: "ui_input", length: 33 },
+          label: { _redacted: "ui_input", length: 27 },
+          identifier: "body-field",
+          action: "setValue",
+          actionValue: { _redacted: "ui_input", length: 27 },
+          index: 1,
+        },
+      },
+      {
+        tool: "ui_diff",
+        args: { beforeSnapshot: "PREVIEW-SNAPSHOT-SECRET", app: "Notes" },
+        expected: { beforeSnapshot: { _redacted: "ui_input", length: 23 }, app: "Notes" },
+      },
+    ];
+
+    for (const { tool } of cases) {
+      server.registerTool(
+        tool,
+        { title: tool, description: "redaction probe", inputSchema: {}, annotations: {} },
+        targetHandler,
+      );
+    }
+    const config = createMockConfig();
+    registerFrontDoorTools(server, {
+      toolRegistry: registry,
+      config,
+      harness: {
+        name: "compatible",
+        requireSessionForHiddenTools: false,
+        maxSessionTools: 64,
+        defaultSessionTtlSeconds: 900,
+        maxSessionTtlSeconds: 3600,
+        discoveryDescriptionMode: "summary",
+      },
+      version: "2.16.5-test",
+      enabledModules: ["ui"],
+      disabledModules: [],
+      modulePacksAvailable: ["core"],
+      modulePackInstallStatuses: [],
+      modulePackInstallIssues: [],
+      modulesMissingPacks: [],
+      missingAddonPackageModules: [],
+      missingPackInstallHints: [],
+      buildWorkflowReadiness: () => [],
+    });
+
+    const secrets = cases.flatMap(({ args }) =>
+      Object.entries(args)
+        .filter(([key]) =>
+          ["text", "key", "title", "value", "description", "label", "actionValue", "beforeSnapshot"].includes(key),
+        )
+        .map(([, value]) => value),
+    );
+    for (const previewCase of cases) {
+      const result = await server.callTool("preview_action", { tool: previewCase.tool, args: previewCase.args });
+      expect(result.structuredContent.auditPreview.args).toEqual(previewCase.expected);
+      for (const secret of secrets) expect(JSON.stringify(result)).not.toContain(secret);
+    }
+    expect(targetHandler).not.toHaveBeenCalled();
+
+    await audit._testFlush();
+    const raw = await readFile(auditPath, "utf8");
+    for (const secret of secrets) expect(raw).not.toContain(secret);
+    const rows = raw
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line));
+    const previewRows = rows.filter((row) => row.tool === "preview_action").slice(-cases.length);
+    expect(previewRows).toHaveLength(cases.length);
+    for (const [index, row] of previewRows.entries()) {
+      expect(row.args).toEqual({ tool: cases[index].tool, args: cases[index].expected });
+      expect(row._prev).toMatch(/^[0-9a-f]{64}$/);
+      expect(row._hmac).toMatch(/^[0-9a-f]{64}$/);
+    }
+    const summary = await audit.summarizeAuditEntries({ since: "2020-01-01T00:00:00Z" });
+    expect(summary.verified).toBe(true);
+  });
+
+  test("preview_action malformed nested args fail closed before sealing", async () => {
+    const secret = "MALFORMED-PREVIEW-SECRET";
+    const { raw, rows } = await writeRows([{ tool: "preview_action", args: { tool: 42, args: { text: secret } } }]);
+    expect(raw).not.toContain(secret);
+    expect(rows.at(-1).args).toEqual({ tool: 42, args: { _redacted: "preview_target_args" } });
+    const summary = await audit.summarizeAuditEntries({ since: "2020-01-01T00:00:00Z" });
+    expect(summary.verified).toBe(true);
   });
 });

--- a/tests/preview-action.test.js
+++ b/tests/preview-action.test.js
@@ -13,12 +13,13 @@ import { z } from "zod";
 jest.unstable_mockModule("../dist/shared/usage-tracker.js", () => ({
   usageTracker: { record: jest.fn() },
 }));
+const sanitizeToolArgsMock = jest.fn((_tool, args) => ({ ...args, _scrubbed: true }));
 jest.unstable_mockModule("../dist/shared/audit.js", () => ({
   auditLog: jest.fn(),
   readAuditEntries: jest.fn(),
   // Real previewCall scrubs args; a marker-wrapping passthrough lets the test
-  // prove auditArgs came from sanitizeArgs without importing the real scrubber.
-  sanitizeArgs: jest.fn((a) => ({ ...a, _scrubbed: true })),
+  // prove auditArgs came from the tool-aware scrubber without importing it.
+  sanitizeToolArgs: sanitizeToolArgsMock,
 }));
 jest.unstable_mockModule("../dist/shared/tool-filter.js", () => ({
   compactDescription: jest.fn((d) => (d ? d.substring(0, 80) : d)),
@@ -67,6 +68,7 @@ describe("ToolRegistry.previewCall", () => {
     expect(preview.annotations).toEqual({ destructive: true, readOnly: false, sensitive: false });
     expect(preview.argsValid).toBe(true);
     expect(preview.auditArgs).toEqual({ id: "abc", _scrubbed: true });
+    expect(sanitizeToolArgsMock).toHaveBeenCalledWith("delete_thing", { id: "abc" });
     // The load-bearing guarantee: the handler was never called.
     expect(handlerSpy).not.toHaveBeenCalled();
   });

--- a/tests/tool-registry-scope-gate.test.js
+++ b/tests/tool-registry-scope-gate.test.js
@@ -21,7 +21,7 @@ jest.unstable_mockModule('../dist/shared/usage-tracker.js', () => ({
 jest.unstable_mockModule('../dist/shared/audit.js', () => ({
   auditLog: auditLogMock,
   readAuditEntries: jest.fn(),
-  sanitizeArgs: jest.fn((a) => a),
+  sanitizeToolArgs: jest.fn((_tool, args) => args),
 }));
 jest.unstable_mockModule('../dist/shared/tool-filter.js', () => ({
   compactDescription: (d) => (d ? d.substring(0, 80) : d),

--- a/tests/tool-registry.test.js
+++ b/tests/tool-registry.test.js
@@ -10,9 +10,9 @@ const readAuditEntriesMock = jest.fn();
 jest.unstable_mockModule("../dist/shared/audit.js", () => ({
   auditLog: auditLogMock,
   readAuditEntries: readAuditEntriesMock,
-  // previewCall() PII-scrubs args via sanitizeArgs; a passthrough is enough
+  // previewCall() PII-scrubs args via sanitizeToolArgs; a passthrough is enough
   // for registry unit tests that don't assert on the scrubbing itself.
-  sanitizeArgs: jest.fn((a) => a),
+  sanitizeToolArgs: jest.fn((_tool, args) => args),
 }));
 jest.unstable_mockModule("../dist/shared/tool-filter.js", () => ({
   compactDescription: jest.fn((d) => (d ? d.substring(0, 80) : d)),


### PR DESCRIPTION
## Summary

Uses one tool-aware sanitizer for persisted audit rows, ToolRegistry previews, and the preview_action response. Redacts content-bearing UI inputs before they can reach a response or the HMAC-sealed JSONL chain:

- ui_type.text
- ui_click.text
- ui_press_key.key
- ui_accessibility_query.title/value/description/label
- ui_perform_action.title/value/description/label/actionValue
- ui_diff.beforeSnapshot

Preserves structural context such as app/appName, identifier, role, action, index, coordinates, and modifiers. The audited preview_action wrapper now recursively sanitizes its nested target args with a depth cap; malformed nested payloads fail closed.

## Linked Issue

Recovered internal security finding; no public issue.

## Type of Change

- [ ] New feature (new tool, module, or prompt)
- [x] Bug fix
- [ ] Refactoring (no behavior change)
- [ ] Documentation
- [ ] CI/CD or build configuration

## Checklist

- [x] npm run lint passes
- [x] npm run typecheck passes
- [x] npm run build succeeds
- [x] Focused audit/preview suites pass: 52 tests
- [x] Registry and governance dependency suites pass: 176 tests across 11 suites
- [ ] Full local npm test remains affected by pre-existing Node/Jest global failures in unrelated HTTP/runtime suites; GitHub CI is authoritative
- [x] User input escaping is not applicable; no JXA added
- [x] Tool annotations are not applicable; no tool added
- [x] README/docs are not applicable; no public contract changed

## QA Reports

### Read-Only Smoke Test

Not run: this change is isolated to audit serialization and does not invoke Apple applications.

### CRUD Roundtrip Test

Not run: no CRUD tool behavior changed.

### Modules Affected

- [x] ui
- [x] audit
- [x] Shared / Infrastructure

### Manual Testing

The regression invokes real preview_action handlers against UI target tools without executing those target handlers. It asserts that both the structured response and the actual audit.jsonl bytes contain no sensitive plaintext, verifies preserved structural context, checks every _prev/_hmac envelope, and validates the complete chain through summarizeAuditEntries(). Direct audit rows and malformed nested preview payloads are covered as well.
