### PR TITLE
fix(podcasts): keep removed module gated on future macOS

### DIFF
--- a/docs/direction.md
+++ b/docs/direction.md
@@ -119,7 +119,7 @@ rate limits, OAuth scopes, and local controls govern Apple workspace actions.
 | 클라이언트 연결 | 명시적 opt-in (Claude Desktop, Claude Code, Codex, Cursor, Windsurf) |
 | 검증 | 계약 기반 Jest·Swift·실제 npm/MCPB/app 산출물 게이트 |
 
-¹ podcasts 모듈은 macOS 26+에서 `brokenOn: [26]` 게이트로 등록 스킵 (Apple이 Podcasts JXA 딕셔너리 제거). v3.0.0에서 드랍 예정.
+¹ podcasts 모듈은 Apple의 Podcasts JXA 딕셔너리 영구 제거로 `maxMacosVersion: 25`를 선언하며, macOS 26 및 이후 버전에서 등록을 건너뛴다. v3.0.0에서 드랍 예정.
 
 ---
 

--- a/docs/site/src/content/docs/modules/podcasts.md
+++ b/docs/site/src/content/docs/modules/podcasts.md
@@ -5,8 +5,10 @@ description: Podcast shows, episodes, playback control, and episode search.
 
 :::caution[Deprecated on macOS 26+]
 Apple removed the entire Podcasts JXA scripting dictionary in macOS 26 (Tahoe).
-All six Podcasts tools are **skipped at module registration** on macOS 26+
-(see `compatibility.brokenOn: [26]` in [`src/shared/modules.ts`](https://github.com/heznpc/AirMCP/blob/main/src/shared/modules.ts)).
+Because this is a permanent removal rather than a one-release regression, all
+six Podcasts tools are **skipped at module registration** on macOS 26 and every
+later release (see `compatibility.maxMacosVersion: 25` in
+[`src/shared/modules.ts`](https://github.com/heznpc/AirMCP/blob/main/src/shared/modules.ts)).
 They remain available on macOS ≤ 25 hosts.
 
 - **Deprecated since:** v2.11.0

--- a/src/shared/modules.ts
+++ b/src/shared/modules.ts
@@ -85,10 +85,11 @@ export const MODULE_MANIFEST: ReadonlyArray<ModuleManifestEntry> = [
     compatibility: {
       // Apple removed the entire Podcasts JXA scripting dictionary in
       // macOS 26. All 6 tools fail at runtime; the module is still
-      // registered for ≤25 hosts. RFC 0004 doctor surfaces this so a
-      // user on 26 isn't left guessing why podcasts_* always errors.
+      // registered for ≤25 hosts. The upper bound intentionally covers
+      // macOS 26 and every later release: unlike `brokenOn`, this removal is
+      // permanent rather than a regression isolated to one OS version.
       status: "deprecated",
-      brokenOn: [26],
+      maxMacosVersion: 25,
       deprecation: {
         since: "2.11.0",
         removeAt: "3.0.0",

--- a/tests/compatibility-env.test.js
+++ b/tests/compatibility-env.test.js
@@ -125,3 +125,34 @@ describe('safari module — breakage is tool-scoped, not module-scoped', () => {
     expect(decision.decision).toBe('register');
   });
 });
+
+describe('podcasts module — removed after macOS 25', () => {
+  test('macOS 25 remains supported while surfacing the existing deprecation', async () => {
+    const { MODULE_MANIFEST } = await import('../dist/shared/modules.js');
+    const podcasts = MODULE_MANIFEST.find((m) => m.name === 'podcasts');
+    expect(podcasts).toBeDefined();
+    expect(podcasts.compatibility?.maxMacosVersion).toBe(25);
+    expect(podcasts.compatibility?.brokenOn ?? []).not.toContain(26);
+
+    const decision = resolveModuleCompatibility('podcasts', podcasts.compatibility, {
+      osVersion: 25,
+      cpu: 'arm64',
+      healthkitAvailable: true,
+    });
+    expect(decision.decision).toBe('register-with-deprecation');
+  });
+
+  test.each([26, 27, 99])('macOS %i and later releases stay unavailable', async (osVersion) => {
+    const { MODULE_MANIFEST } = await import('../dist/shared/modules.js');
+    const podcasts = MODULE_MANIFEST.find((m) => m.name === 'podcasts');
+    expect(podcasts).toBeDefined();
+
+    const decision = resolveModuleCompatibility('podcasts', podcasts.compatibility, {
+      osVersion,
+      cpu: 'arm64',
+      healthkitAvailable: true,
+    });
+    expect(decision.decision).toBe('skip-unsupported');
+    expect(decision.reason).toBe(`podcasts was removed after macOS 25 (detected ${osVersion})`);
+  });
+});


### PR DESCRIPTION
## Summary

Replace the Podcasts module’s exact `brokenOn: [26]` declaration with `maxMacosVersion: 25`, so the permanently removed JXA surface stays unavailable on macOS 26, 27, and future releases. Add manifest-driven boundary coverage for macOS 25, 26, 27, and a future major version, and align the public module/direction docs with that permanent version gate.

## Linked Issue

None — follow-up from the local compatibility audit.

## Type of Change

- [x] Bug fix
- [x] Documentation

## Checklist

- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
- [x] `npm run build` succeeds
- [x] `npm test` passes in CI
- [x] Astro documentation build succeeds (34 pages)
- [x] User input escaping is not applicable; no script inputs changed
- [x] Tool annotations are unchanged
- [x] Public docs describe `maxMacosVersion: 25` and the permanent macOS 26+ removal

### Modules Affected

- [x] `podcasts`
- [x] Shared / Infrastructure

### Manual Testing

The compatibility resolver was exercised with macOS majors 25, 26, 27, and 99. macOS 25 registers with the existing deprecation warning; all later versions return `skip-unsupported` with the declared maximum-version reason.

The local full-suite run reached 2,941/2,942 before an unrelated Google Workspace runtime-contract timeout; the isolated compatibility/runtime-registration suite passed 48/48, and the complete GitHub Actions CI suite passed.