### PR TITLE
fix(finder): prevent silent Spotlight and directory failures

### DIFF
--- a/docs/tool-manifest.json
+++ b/docs/tool-manifest.json
@@ -11152,6 +11152,7 @@
         "properties": {
           "folder": {
             "description": "Folder to search (default: home)",
+            "default": "~",
             "type": "string",
             "minLength": 1,
             "maxLength": 4096
@@ -12090,6 +12091,7 @@
           },
           "folder": {
             "description": "Folder to search in (default: home)",
+            "default": "~",
             "type": "string",
             "minLength": 1,
             "maxLength": 4096

--- a/src/finder/scripts.ts
+++ b/src/finder/scripts.ts
@@ -197,7 +197,7 @@ export function recentFilesScript(folder: string, days: number, limit: number): 
     const app = Application.currentApplication();
     app.includeStandardAdditions = true;
     const dateStr = new Date(Date.now() - ${d} * 86400000).toISOString().split('T')[0];
-    const results = app.doShellScript('mdfind -onlyin "${escJxaShell(folder)}" "kMDItemContentModificationDate >= $time.iso(' + dateStr + ')" | head -${n}');
+    const results = app.doShellScript('mdfind -onlyin "${escJxaShell(folder)}" "kMDItemContentModificationDate >= \\\\$time.iso(' + dateStr + ')" | head -${n}');
     const paths = results.split(/[\\r\\n]+/).filter(p => p.length > 0);
     const result = paths.map(p => ({path: p, name: p.split('/').pop()}));
     JSON.stringify({total: paths.length, files: result});

--- a/src/finder/scripts.ts
+++ b/src/finder/scripts.ts
@@ -120,6 +120,20 @@ function assertSafePath(p: string): void {
 // Included in scripts that handle runtime-dynamic paths (e.g. mdfind/ls output).
 const JXA_SHELL_ESC_FN = `function _esc(s){return s.replace(/\\\\/g,'\\\\\\\\').replace(/"/g,'\\\\"').replace(/\\$/g,'\\\\$').replace(/\\\`/g,'\\\\\\\`');}`;
 
+// Run the producer to completion before limiting its output. A direct
+// `producer | head` reports head's status instead of the producer's, while
+// pipefail makes a healthy producer look failed when head closes the pipe.
+// The temporary file preserves both the producer status and the output cap.
+// Check the directory explicitly because mdfind reports rc 0 + no output for a
+// missing `-onlyin` path, which is indistinguishable from a real empty result.
+function checkedLimitShellPrefix(directory: string): string {
+  return String.raw`test -d "${escJxaShell(directory)}" || exit $?; airmcp_tmp=$(/usr/bin/mktemp -t airmcp-finder) || exit $?; trap \'/bin/rm -f "$airmcp_tmp"\' 0; `;
+}
+
+function checkedLimitShellSuffix(limit: number): string {
+  return String.raw` >"$airmcp_tmp"; airmcp_producer_status=$?; [ "$airmcp_producer_status" -eq 0 ] || exit "$airmcp_producer_status"; /usr/bin/head -n ${limit} "$airmcp_tmp"`;
+}
+
 export function searchFilesScript(folder: string, query: string, limit: number): string {
   assertSafePath(folder);
   const n = safeInt(limit);
@@ -127,7 +141,7 @@ export function searchFilesScript(folder: string, query: string, limit: number):
     const app = Application.currentApplication();
     app.includeStandardAdditions = true;
     ${JXA_SHELL_ESC_FN}
-    const results = app.doShellScript('mdfind -onlyin "${escJxaShell(folder)}" "${escJxaShell(query)}" | head -${n}');
+    const results = app.doShellScript('${checkedLimitShellPrefix(folder)}mdfind -onlyin "${escJxaShell(folder)}" "${escJxaShell(query)}"${checkedLimitShellSuffix(n)}');
     const paths = results.split(/[\\r\\n]+/).filter(p => p.length > 0);
     const result = paths.map(p => {
       try {
@@ -197,7 +211,10 @@ export function recentFilesScript(folder: string, days: number, limit: number): 
     const app = Application.currentApplication();
     app.includeStandardAdditions = true;
     const dateStr = new Date(Date.now() - ${d} * 86400000).toISOString().split('T')[0];
-    const results = app.doShellScript('mdfind -onlyin "${escJxaShell(folder)}" "kMDItemContentModificationDate >= \\\\$time.iso(' + dateStr + ')" | head -${n}');
+    // Prefix the Spotlight time token with a literal shell backslash. Building
+    // that character explicitly avoids losing it to this generated JXA string.
+    const query = 'kMDItemContentModificationDate >= ' + String.fromCharCode(92) + '$time.iso(' + dateStr + ')';
+    const results = app.doShellScript('${checkedLimitShellPrefix(folder)}mdfind -onlyin "${escJxaShell(folder)}" "' + query + '"${checkedLimitShellSuffix(n)}');
     const paths = results.split(/[\\r\\n]+/).filter(p => p.length > 0);
     const result = paths.map(p => ({path: p, name: p.split('/').pop()}));
     JSON.stringify({total: paths.length, files: result});
@@ -211,7 +228,7 @@ export function listDirectoryScript(path: string, limit: number): string {
     const app = Application.currentApplication();
     app.includeStandardAdditions = true;
     ${JXA_SHELL_ESC_FN}
-    const output = app.doShellScript('ls -1 "${escJxaShell(path)}" | head -${n}');
+    const output = app.doShellScript('${checkedLimitShellPrefix(path)}ls -1 "${escJxaShell(path)}"${checkedLimitShellSuffix(n)}');
     const fileNames = output.split(/[\\r\\n]+/).filter(n => n.length > 0);
     const result = fileNames.map(name => {
       try {

--- a/src/finder/tools.ts
+++ b/src/finder/tools.ts
@@ -31,6 +31,10 @@ export function registerFinderTools(server: McpServer, _config: AirMcpConfig): v
       description: "Search files using Spotlight (mdfind). Searches file names and content.",
       inputSchema: {
         query: z.string().max(500).describe("Search query (Spotlight syntax)"),
+        // Zod 4 `.default()` returns its value without running the inner
+        // transform, which would leave the handler with the literal `~`.
+        // `.prefault()` feeds the default through zFilePath so it resolves to
+        // HOME exactly like an explicitly supplied `~` does.
         folder: zFilePath.prefault("~").describe("Folder to search in (default: home)"),
         limit: z.number().int().min(1).max(200).optional().default(50).describe("Max results (default: 50)"),
       },

--- a/src/finder/tools.ts
+++ b/src/finder/tools.ts
@@ -31,7 +31,7 @@ export function registerFinderTools(server: McpServer, _config: AirMcpConfig): v
       description: "Search files using Spotlight (mdfind). Searches file names and content.",
       inputSchema: {
         query: z.string().max(500).describe("Search query (Spotlight syntax)"),
-        folder: zFilePath.optional().default("~").describe("Folder to search in (default: home)"),
+        folder: zFilePath.prefault("~").describe("Folder to search in (default: home)"),
         limit: z.number().int().min(1).max(200).optional().default(50).describe("Max results (default: 50)"),
       },
       outputSchema: {
@@ -123,7 +123,7 @@ export function registerFinderTools(server: McpServer, _config: AirMcpConfig): v
       title: "Recent Files",
       description: "Find recently modified files in a folder using Spotlight.",
       inputSchema: {
-        folder: zFilePath.optional().default("~").describe("Folder to search (default: home)"),
+        folder: zFilePath.prefault("~").describe("Folder to search (default: home)"),
         days: z.number().int().min(1).max(365).optional().default(7).describe("Modified within N days (default: 7)"),
         limit: z.number().int().min(1).max(200).optional().default(30).describe("Max results (default: 30)"),
       },

--- a/swift/Sources/AirMCPKit/Generated/MCPIntents.swift
+++ b/swift/Sources/AirMCPKit/Generated/MCPIntents.swift
@@ -6266,8 +6266,8 @@ public struct RecentFilesIntent: AppIntent {
 
     public init() {}
 
-    @Parameter(title: "Folder to search (default: home)")
-    public var folder: String?
+    @Parameter(title: "Folder to search (default: home)", default: "~")
+    public var folder: String
 
     @Parameter(title: "Modified within N days (default: 7)", default: 7, inclusiveRange: (1, 365))
     public var days: Int
@@ -6277,13 +6277,9 @@ public struct RecentFilesIntent: AppIntent {
 
     @MainActor
     public func perform() async throws -> some IntentResult & ReturnsValue<String> {
-        var args: [String: any Sendable] = [:]
-        if let v = folder { args["folder"] = v }
-        args["days"] = days
-        args["limit"] = limit
         let result = try await MCPIntentRouter.shared.call(
             tool: "recent_files",
-            args: args
+            args: ["folder": folder, "days": days, "limit": limit]
         )
         guard let data = result.data(using: .utf8) else {
             throw MCPIntentError.toolCallFailed(tool: "recent_files", message: "empty result from router")
@@ -6593,21 +6589,17 @@ public struct SearchFilesIntent: AppIntent {
     @Parameter(title: "Search query (Spotlight syntax)")
     public var query: String
 
-    @Parameter(title: "Folder to search in (default: home)")
-    public var folder: String?
+    @Parameter(title: "Folder to search in (default: home)", default: "~")
+    public var folder: String
 
     @Parameter(title: "Max results (default: 50)", default: 50, inclusiveRange: (1, 200))
     public var limit: Int
 
     @MainActor
     public func perform() async throws -> some IntentResult & ReturnsValue<String> {
-        var args: [String: any Sendable] = [:]
-        args["query"] = query
-        if let v = folder { args["folder"] = v }
-        args["limit"] = limit
         let result = try await MCPIntentRouter.shared.call(
             tool: "search_files",
-            args: args
+            args: ["query": query, "folder": folder, "limit": limit]
         )
         guard let data = result.data(using: .utf8) else {
             throw MCPIntentError.toolCallFailed(tool: "search_files", message: "empty result from router")

--- a/tests/finder-scripts.test.js
+++ b/tests/finder-scripts.test.js
@@ -1,4 +1,9 @@
 import { describe, test, expect } from '@jest/globals';
+import { execFileSync } from 'node:child_process';
+import { chmodSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import vm from 'node:vm';
 import {
   searchFilesScript,
   getFileInfoScript,
@@ -33,6 +38,40 @@ describe('finder script generators', () => {
     expect(script).toContain('mdfind');
     expect(script).toContain('kMDItemContentModificationDate');
     expect(script).toContain('30');
+  });
+
+  test('recentFilesScript preserves the Spotlight $time token through JXA and the shell', () => {
+    const script = recentFilesScript('/Users/test', 7, 30);
+    let command = '';
+    const app = {
+      includeStandardAdditions: false,
+      doShellScript(value) {
+        command = value;
+        return '';
+      },
+    };
+
+    vm.runInNewContext(`(function(){${script}})()`, {
+      Application: { currentApplication: () => app },
+    });
+
+    expect(command).toMatch(/kMDItemContentModificationDate >= \\\$time\.iso\(\d{4}-\d{2}-\d{2}\)/);
+
+    const binDir = mkdtempSync(join(tmpdir(), 'airmcp-finder-test-'));
+    try {
+      const fakeMdfind = join(binDir, 'mdfind');
+      writeFileSync(fakeMdfind, '#!/bin/sh\nprintf "%s\\n" "$3"\n');
+      chmodSync(fakeMdfind, 0o755);
+      const output = execFileSync('/bin/sh', ['-c', command], {
+        encoding: 'utf8',
+        env: { ...process.env, PATH: `${binDir}:${process.env.PATH ?? ''}`, time: 'EXPANDED_BY_SHELL' },
+      }).trim();
+
+      expect(output).toMatch(/^kMDItemContentModificationDate >= \$time\.iso\(\d{4}-\d{2}-\d{2}\)$/);
+      expect(output).not.toContain('EXPANDED_BY_SHELL');
+    } finally {
+      rmSync(binDir, { recursive: true, force: true });
+    }
   });
 });
 

--- a/tests/finder-scripts.test.js
+++ b/tests/finder-scripts.test.js
@@ -1,88 +1,225 @@
-import { describe, test, expect } from '@jest/globals';
-import { execFileSync } from 'node:child_process';
-import { chmodSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
-import { tmpdir } from 'node:os';
-import { join } from 'node:path';
-import vm from 'node:vm';
+import { describe, test, expect } from "@jest/globals";
+import vm from "node:vm";
+import { execFileSync, spawnSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import {
   searchFilesScript,
   getFileInfoScript,
   setTagsScript,
   recentFilesScript,
-} from '../dist/finder/scripts.js';
+  listDirectoryScript,
+} from "../dist/finder/scripts.js";
 
-describe('finder script generators', () => {
-  test('searchFilesScript uses mdfind', () => {
-    const script = searchFilesScript('~', 'report', 50);
-    expect(script).toContain('mdfind');
-    expect(script).toContain('report');
-    expect(script).toContain('50');
+function executeFinderScript(script, shellOutput = "", context = {}) {
+  const commands = [];
+  function Application() {}
+  Application.currentApplication = () => ({
+    doShellScript(command) {
+      commands.push(command);
+      return shellOutput;
+    },
+  });
+  const result = vm.runInNewContext(script, { Application, ...context });
+  return { commands, result: JSON.parse(result) };
+}
+
+function runShell(command, prelude) {
+  return spawnSync("/bin/sh", ["-c", `${prelude}\n${command}`], { encoding: "utf8" });
+}
+
+function executeFinderScriptWithShell(script, prelude, statOutput = "") {
+  const commands = [];
+  function Application() {}
+  Application.currentApplication = () => ({
+    doShellScript(command) {
+      commands.push(command);
+      if (command.startsWith("stat ")) return statOutput;
+      const shell = runShell(command, prelude);
+      if (shell.status !== 0) {
+        throw new Error(`shell exited ${shell.status}: ${shell.stderr}`);
+      }
+      return shell.stdout.replace(/\n$/, "");
+    },
+  });
+  const result = vm.runInNewContext(script, { Application });
+  return { commands, result: JSON.parse(result) };
+}
+
+describe("finder script generators", () => {
+  test("searchFilesScript uses mdfind", () => {
+    const script = searchFilesScript("~", "report", 50);
+    expect(script).toContain("mdfind");
+    expect(script).toContain("report");
+    expect(script).toContain("50");
   });
 
-  test('getFileInfoScript reads metadata', () => {
-    const script = getFileInfoScript('/Users/test/file.txt');
-    expect(script).toContain('/Users/test/file.txt');
-    expect(script).toContain('kMDItemUserTags');
-    expect(script).toContain('item.size()');
+  test("getFileInfoScript reads metadata", () => {
+    const script = getFileInfoScript("/Users/test/file.txt");
+    expect(script).toContain("/Users/test/file.txt");
+    expect(script).toContain("kMDItemUserTags");
+    expect(script).toContain("item.size()");
   });
 
-  test('setTagsScript sets tags via NSURL', () => {
-    const script = setTagsScript('/Users/test/file.txt', ['Important', 'Work']);
-    expect(script).toContain('NSURLTagNamesKey');
+  test("setTagsScript sets tags via NSURL", () => {
+    const script = setTagsScript("/Users/test/file.txt", ["Important", "Work"]);
+    expect(script).toContain("NSURLTagNamesKey");
     expect(script).toContain("'Important'");
     expect(script).toContain("'Work'");
   });
 
-  test('recentFilesScript uses mdfind with date', () => {
-    const script = recentFilesScript('~', 7, 30);
-    expect(script).toContain('mdfind');
-    expect(script).toContain('kMDItemContentModificationDate');
-    expect(script).toContain('30');
-  });
-
-  test('recentFilesScript preserves the Spotlight $time token through JXA and the shell', () => {
-    const script = recentFilesScript('/Users/test', 7, 30);
-    let command = '';
-    const app = {
-      includeStandardAdditions: false,
-      doShellScript(value) {
-        command = value;
-        return '';
-      },
-    };
-
-    vm.runInNewContext(`(function(){${script}})()`, {
-      Application: { currentApplication: () => app },
+  test("recentFilesScript passes Spotlight $time syntax to the shell without variable expansion", () => {
+    class FixedDate extends Date {
+      static now() {
+        return Date.parse("2026-09-01T12:00:00.000Z");
+      }
+    }
+    const script = recentFilesScript("/tmp", 7, 30);
+    const { commands, result } = executeFinderScript(script, "/tmp/recent one.txt\n/tmp/recent-two.txt", {
+      Date: FixedDate,
     });
 
-    expect(command).toMatch(/kMDItemContentModificationDate >= \\\$time\.iso\(\d{4}-\d{2}-\d{2}\)/);
+    expect(commands).toHaveLength(1);
+    expect(commands[0]).toContain('mdfind -onlyin "/tmp" "kMDItemContentModificationDate >= \\$time.iso(2026-08-25)"');
+    expect(commands[0]).not.toContain("| head");
 
-    const binDir = mkdtempSync(join(tmpdir(), 'airmcp-finder-test-'));
+    // Run the generated command through a real shell with a fake mdfind
+    // function. A non-escaped token would arrive as EXPANDED.iso(...).
+    const forwardedArgs = execFileSync("/bin/sh", ["-c", `mdfind() { printf '%s\\n' "$@"; }; ${commands[0]}`], {
+      encoding: "utf8",
+      env: { ...process.env, time: "EXPANDED" },
+    })
+      .trim()
+      .split("\n");
+    expect(forwardedArgs).toHaveLength(3);
+    expect(forwardedArgs[0]).toBe("-onlyin");
+    expect(forwardedArgs[1]).toBe("/tmp");
+    expect(forwardedArgs[2]).toBe("kMDItemContentModificationDate >= $time.iso(2026-08-25)");
+    expect(forwardedArgs[2]).not.toContain("EXPANDED");
+
+    expect(result).toEqual({
+      total: 2,
+      files: [
+        { path: "/tmp/recent one.txt", name: "recent one.txt" },
+        { path: "/tmp/recent-two.txt", name: "recent-two.txt" },
+      ],
+    });
+  });
+
+  test.each([
+    ["searchFilesScript", "mdfind", () => searchFilesScript("/tmp", "report", 2)],
+    ["recentFilesScript", "mdfind", () => recentFilesScript("/tmp", 7, 2)],
+    ["listDirectoryScript", "ls", () => listDirectoryScript("/tmp", 2)],
+  ])("%s preserves a failing producer exit status", (_name, producer, buildScript) => {
+    const { commands } = executeFinderScript(buildScript());
+    const shell = runShell(commands[0], `${producer}() { printf 'partial\\n'; return 17; }`);
+
+    expect(shell.status).toBe(17);
+    expect(shell.stdout).toBe("");
+  });
+
+  test.each([
+    ["searchFilesScript", "mdfind", (path) => searchFilesScript(path, "report", 2)],
+    ["recentFilesScript", "mdfind", (path) => recentFilesScript(path, 7, 2)],
+    ["listDirectoryScript", "ls", (path) => listDirectoryScript(path, 2)],
+  ])("%s rejects missing and non-directory roots", (_name, producer, buildScript) => {
+    for (const path of ["/dev/null/airmcp-missing", "/dev/null"]) {
+      expect(() => executeFinderScriptWithShell(buildScript(path), `${producer}() { :; }`)).toThrow(/shell exited 1/);
+    }
+  });
+
+  test.each([
+    ["searchFilesScript", "mdfind", (path) => searchFilesScript(path, "report", 2), { total: 0, files: [] }],
+    ["recentFilesScript", "mdfind", (path) => recentFilesScript(path, 7, 2), { total: 0, files: [] }],
+    ["listDirectoryScript", "ls", (path) => listDirectoryScript(path, 2), { total: 0, returned: 0, items: [] }],
+  ])("%s accepts an existing empty directory", (_name, producer, buildScript, expected) => {
+    const directory = mkdtempSync(join(tmpdir(), "airmcp-finder-test-"));
     try {
-      const fakeMdfind = join(binDir, 'mdfind');
-      writeFileSync(fakeMdfind, '#!/bin/sh\nprintf "%s\\n" "$3"\n');
-      chmodSync(fakeMdfind, 0o755);
-      const output = execFileSync('/bin/sh', ['-c', command], {
-        encoding: 'utf8',
-        env: { ...process.env, PATH: `${binDir}:${process.env.PATH ?? ''}`, time: 'EXPANDED_BY_SHELL' },
-      }).trim();
-
-      expect(output).toMatch(/^kMDItemContentModificationDate >= \$time\.iso\(\d{4}-\d{2}-\d{2}\)$/);
-      expect(output).not.toContain('EXPANDED_BY_SHELL');
+      const execution = executeFinderScriptWithShell(buildScript(directory), `${producer}() { :; }`);
+      expect(execution.result).toEqual(expected);
     } finally {
-      rmSync(binDir, { recursive: true, force: true });
+      rmSync(directory, { recursive: true });
+    }
+  });
+
+  test("checked producer commands retain limits and JXA result mapping", () => {
+    const mdfind = `mdfind() { printf '%s\\n' '/tmp/one file.txt' '/tmp/two.txt' '/tmp/three.txt'; }`;
+    const search = executeFinderScriptWithShell(searchFilesScript("/tmp", "report", 2), mdfind, "10 0");
+    expect(search.result).toEqual({
+      total: 2,
+      files: [
+        {
+          path: "/tmp/one file.txt",
+          name: "one file.txt",
+          size: 10,
+          modificationDate: "1970-01-01T00:00:00.000Z",
+        },
+        {
+          path: "/tmp/two.txt",
+          name: "two.txt",
+          size: 10,
+          modificationDate: "1970-01-01T00:00:00.000Z",
+        },
+      ],
+    });
+
+    const recent = executeFinderScriptWithShell(recentFilesScript("/tmp", 7, 2), mdfind);
+    expect(recent.result).toEqual({
+      total: 2,
+      files: [
+        { path: "/tmp/one file.txt", name: "one file.txt" },
+        { path: "/tmp/two.txt", name: "two.txt" },
+      ],
+    });
+
+    const ls = `ls() { printf '%s\\n' 'one file.txt' 'two.txt' 'three.txt'; }`;
+    const directory = executeFinderScriptWithShell(listDirectoryScript("/tmp", 2), ls, "10 0 Plain Text");
+    expect(directory.result).toEqual({
+      total: 2,
+      returned: 2,
+      items: [
+        {
+          name: "one file.txt",
+          kind: "Plain Text",
+          size: 10,
+          modificationDate: "1970-01-01T00:00:00.000Z",
+        },
+        {
+          name: "two.txt",
+          kind: "Plain Text",
+          size: 10,
+          modificationDate: "1970-01-01T00:00:00.000Z",
+        },
+      ],
+    });
+  });
+
+  test("searchFilesScript preserves shell-sensitive folder and query arguments verbatim", () => {
+    const root = mkdtempSync(join(tmpdir(), "airmcp-finder-escape-"));
+    const folder = join(root, 'space " $dollar `tick` \\ slash');
+    const query = 'report "quoted" $HOME $(printf injected) `printf injected` \\end';
+    mkdirSync(folder);
+
+    try {
+      const { commands } = executeFinderScript(searchFilesScript(folder, query, 10));
+      const shell = runShell(commands[0], `mdfind() { printf '%s\\n' "$@"; }`);
+      expect(shell.status).toBe(0);
+      expect(shell.stdout.trim().split("\n")).toEqual(["-onlyin", folder, query]);
+    } finally {
+      rmSync(root, { recursive: true });
     }
   });
 });
 
-describe('finder esc() injection prevention', () => {
-  test('escapes single quotes in path', () => {
+describe("finder esc() injection prevention", () => {
+  test("escapes single quotes in path", () => {
     const script = getFileInfoScript("/Users/test/it's a file.txt");
     expect(script).toContain("it\\'s a file.txt");
   });
 
-  test('escapes double quotes in query (JXA+shell context)', () => {
-    const script = searchFilesScript('~', 'say "hello"', 10);
+  test("escapes double quotes in query (JXA+shell context)", () => {
+    const script = searchFilesScript("~", 'say "hello"', 10);
     expect(script).toContain('say \\\\\\"hello\\\\\\"');
   });
 });

--- a/tests/finder-tools.test.js
+++ b/tests/finder-tools.test.js
@@ -1,4 +1,5 @@
 import { describe, test, expect, jest } from '@jest/globals';
+import { z } from 'zod';
 
 const mockRunJxa = jest.fn();
 
@@ -7,6 +8,7 @@ jest.unstable_mockModule('../dist/shared/jxa.js', () => ({
 }));
 
 const { registerFinderTools } = await import('../dist/finder/tools.js');
+const { HOME } = await import('../dist/shared/constants.js');
 
 function createMockServer() {
   const tools = new Map();
@@ -85,5 +87,19 @@ describe('Finder tools registration', () => {
     const { config } = server.tools.get('create_directory');
     expect(config.annotations.destructiveHint).toBe(false);
     expect(config.annotations.sensitiveHint).toBe(true);
+  });
+
+  test.each([
+    ['search_files', { query: 'report' }],
+    ['recent_files', {}],
+  ])('%s resolves an omitted folder default through zFilePath', async (toolName, input) => {
+    const { config, handler } = server.tools.get(toolName);
+    const parsed = z.object(config.inputSchema).parse(input);
+
+    expect(parsed.folder).toBe(HOME);
+
+    mockRunJxa.mockResolvedValueOnce({ total: 0, files: [] });
+    await handler(parsed);
+    expect(mockRunJxa).toHaveBeenLastCalledWith(expect.stringContaining(`mdfind -onlyin "${HOME}"`));
   });
 });


### PR DESCRIPTION
## Summary

- resolve omitted search_files and recent_files folders through zFilePath so the home default is a real path, not a literal tilde
- preserve Spotlights literal $time predicate through generated JXA and the shell
- validate the search root, run mdfind or ls to completion, preserve producer failures, and apply the result limit only after success
- execute generated JXA and real shell commands in regression tests, including empty, missing, non-directory, failure, limit, and escaping cases

## Linked Issues

Closes #459
Closes #460

## Validation

- Node 22 Finder suites: 2 suites / 25 tests passed
- Swift AirMCPKit: 31 tests passed
- lint, format check, typecheck, manifest drift, intent drift, and diff check passed

## Scope

This PR contains only the six Finder contract files. Broader test-contract repairs are in #467, and CI gate activation is in #468.