### PR TITLE
fix(hitl): keep app approval requests open for 120 seconds

### DIFF
--- a/app/Sources/AirMCPApp/ConfigManager.swift
+++ b/app/Sources/AirMCPApp/ConfigManager.swift
@@ -16,7 +16,7 @@ final class ConfigManager {
         var whitelist: [String]
         var timeout: Int
 
-        static let `default` = HitlConfig(level: .sensitiveOnly, whitelist: [], timeout: 30)
+        static let `default` = HitlConfig(level: .sensitiveOnly, whitelist: [], timeout: 120)
 
         init(level: HitlLevel, whitelist: [String], timeout: Int) {
             self.level = level
@@ -28,7 +28,7 @@ final class ConfigManager {
             let container = try decoder.container(keyedBy: CodingKeys.self)
             level = try container.decodeIfPresent(HitlLevel.self, forKey: .level) ?? .sensitiveOnly
             whitelist = try container.decodeIfPresent([String].self, forKey: .whitelist) ?? []
-            timeout = try container.decodeIfPresent(Int.self, forKey: .timeout) ?? 30
+            timeout = try container.decodeIfPresent(Int.self, forKey: .timeout) ?? 120
         }
     }
 
@@ -435,7 +435,7 @@ final class ConfigManager {
     }
 
     var hitlTimeout: Int {
-        get { config.hitl?.timeout ?? 30 }
+        get { config.hitl?.timeout ?? 120 }
         set {
             if config.hitl == nil { config.hitl = .default }
             config.hitl?.timeout = newValue

--- a/app/Sources/AirMCPApp/HitlManager.swift
+++ b/app/Sources/AirMCPApp/HitlManager.swift
@@ -148,7 +148,7 @@ final class HitlManager {
 
     private let socketPathConfiguration = HitlManager.configuredSocketPath()
 
-    var timeoutSeconds: Int = 30
+    var timeoutSeconds: Int = 120
     /// Injectable for tests; production uses the real notification center.
     var notificationAuthorizer: HitlNotificationAuthorizing = SystemHitlNotificationAuthorizer()
 

--- a/app/Sources/AirMCPApp/HitlManager.swift
+++ b/app/Sources/AirMCPApp/HitlManager.swift
@@ -27,7 +27,21 @@ struct SystemHitlNotificationAuthorizer: HitlNotificationAuthorizing {
         // anything on current macOS. content.interruptionLevel = .timeSensitive
         // below is the still-current mechanism — it needs the entitlement,
         // not this option, to actually be honored.
-        (try? await UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .sound])) ?? false
+        do {
+            return try await UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .sound])
+        } catch {
+            // This was `try?`, which swallowed the failure whole. When the
+            // request throws, the caller only ever saw `false` and routed to
+            // the visual fallback — no prompt, no authorization record, and
+            // nothing in the log to distinguish "the user said no" from "the
+            // prompt never got a chance to appear". That is the single
+            // hardest state to diagnose from a bug report, and it is the one
+            // state that leaves a gated call to expire unseen. Mirror the
+            // diagnostics HitlManager.requestNotificationPermission() already
+            // emits so the reason survives into the log.
+            NSLog("[AirMCP] Notification authorization request failed: \(error.localizedDescription)")
+            return false
+        }
     }
 }
 

--- a/app/Tests/AirMCPAppTests/ConfigManagerScopeTransactionTests.swift
+++ b/app/Tests/AirMCPAppTests/ConfigManagerScopeTransactionTests.swift
@@ -22,6 +22,27 @@ final class ConfigManagerScopeTransactionTests: XCTestCase {
     }
 
     @MainActor
+    func testHitlTimeoutDefaultsToHumanScaleWindow() throws {
+        let managerWithoutConfig = ConfigManager(configFile: configURL)
+        XCTAssertEqual(managerWithoutConfig.hitlTimeout, 120)
+
+        let partialConfig = Data(
+            """
+            {
+              "hitl": {
+                "level": "sensitive-only",
+                "whitelist": []
+              }
+            }
+            """.utf8
+        )
+        try partialConfig.write(to: configURL)
+
+        let managerWithPartialHitl = ConfigManager(configFile: configURL)
+        XCTAssertEqual(managerWithPartialHitl.hitlTimeout, 120)
+    }
+
+    @MainActor
     func testScopeTransactionVerifiesExactBytesAndRollsBackOriginal() throws {
         let original = Data(
             """

--- a/docs/ios-architecture.md
+++ b/docs/ios-architecture.md
@@ -1212,7 +1212,7 @@ macOS의 소켓 기반 HITL 대신 iOS 네이티브 메커니즘:
 | 읽기 전용 | 통과               | 통과                                      |
 | 쓰기      | HITL 설정에 따라   | App Intent `parameterSummary`로 요약 표시 |
 | 파괴적    | 소켓으로 승인 요청 | `requestConfirmation()` 시스템 다이얼로그 |
-| 타임아웃  | 30초 → 거부        | 시스템 관리                               |
+| 타임아웃  | 120초 → 거부       | 시스템 관리                               |
 
 ### 10.3 localhost 전용 보안
 

--- a/docs/site/src/content/docs/getting-started/configuration.md
+++ b/docs/site/src/content/docs/getting-started/configuration.md
@@ -49,7 +49,7 @@ The default config file location is `~/.config/airmcp/config.json`. You can over
 | `shareApproval` | string[] | `[]` | Modules that require share approval before accessing |
 | `hitl.level` | string | `"sensitive-only"` | Human-in-the-loop level: `off`, `destructive-only`, `sensitive-only`, `all-writes`, `all` |
 | `hitl.whitelist` | string[] | `[]` | Tool names that bypass HITL confirmation |
-| `hitl.timeout` | number | `30` | Seconds to wait for HITL confirmation |
+| `hitl.timeout` | number | `120` | Seconds to wait for HITL confirmation |
 | `performance.embeddingProvider` | string | `"auto"` | Embedding provider: `gemini`, `swift`, `hybrid`, `none` |
 | `performance.jxaConcurrency` | number | `3` | Max parallel JXA/osascript processes |
 | `performance.circuitBreakerThreshold` | number | `3` | Failures before circuit breaker opens |

--- a/docs/site/src/content/docs/getting-started/configuration.md
+++ b/docs/site/src/content/docs/getting-started/configuration.md
@@ -23,7 +23,7 @@ The default config file location is `~/.config/airmcp/config.json`. You can over
   "hitl": {
     "level": "sensitive-only",
     "whitelist": ["list_notes", "search_notes"],
-    "timeout": 30
+    "timeout": 120
   },
   "performance": {
     "embeddingProvider": "swift",

--- a/src/shared/config.ts
+++ b/src/shared/config.ts
@@ -488,7 +488,14 @@ export function parseConfig(): AirMcpConfig {
   const hitlLevelRaw = process.env.AIRMCP_HITL_LEVEL ?? file.hitl?.level ?? "sensitive-only";
   const hitlLevel: HitlLevel = HITL_LEVELS.includes(hitlLevelRaw) ? (hitlLevelRaw as HitlLevel) : "sensitive-only";
   const hitlWhitelist = new Set<string>(file.hitl?.whitelist ?? []);
-  const hitlTimeout = file.hitl?.timeout ?? 30;
+  // A HITL gate blocks on a *person*, not a machine. The notification
+  // route is not always available — with .denied authorization
+  // HitlManager falls back to an alert sound plus the Trust Center
+  // window, which a user busy in another app can easily miss. 30s was
+  // short enough that a request could expire before it was ever noticed;
+  // 120s keeps the caller from hanging indefinitely while leaving a
+  // realistic window to react. Override with hitl.timeout.
+  const hitlTimeout = file.hitl?.timeout ?? 120;
   const hitlSocketPath = PATHS.HITL_SOCKET;
 
   const hitl: HitlConfig = {

--- a/src/shared/hitl-guard.ts
+++ b/src/shared/hitl-guard.ts
@@ -100,6 +100,17 @@ interface ToolAnnotations {
   openWorldHint?: boolean;
 }
 
+/** The MCP SDK passes RequestHandlerExtra as the final callback argument: the
+ * only argument for schema-less tools, the second argument for schema tools,
+ * and the final argument for fixed/template resources. Keep this structural
+ * so the lightweight MCP facade does not import the SDK's generic types. */
+function requestWasCancelled(args: readonly unknown[]): boolean {
+  const extra = args.at(-1);
+  if (!extra || typeof extra !== "object" || !("signal" in extra)) return false;
+  const signal = (extra as { signal?: unknown }).signal;
+  return Boolean(signal && typeof signal === "object" && "aborted" in signal && signal.aborted === true);
+}
+
 /**
  * Clients where MCP elicitation should be skipped.
  *
@@ -279,6 +290,15 @@ export function installHitlGuard(server: McpServer, hitlClient: HitlClient, conf
       const destructive = annotations.destructiveHint ?? false;
       const sensitive = annotations.sensitiveHint ?? false;
       const managed = isManagedClient(server);
+      const cancelledResult = () =>
+        errPermission(`Action denied: request for "${name}" was cancelled; the action was not executed.`);
+      const invokeApprovedCallback = () =>
+        requestWasCancelled(args) ? cancelledResult() : (callback as (...a: unknown[]) => unknown)(...args);
+
+      // Do not prompt for a request the client has already abandoned. The
+      // approved callback helper repeats this check after both the decision
+      // and the durable approval-audit write.
+      if (requestWasCancelled(args)) return cancelledResult();
 
       // Resolve the call through MCP elicitation. Returns NOT_HANDLED when the
       // client offers no elicitation channel, so the caller can fall back.
@@ -292,7 +312,7 @@ export function installHitlGuard(server: McpServer, hitlClient: HitlClient, conf
         if (!elicitResult) {
           return errPermission(`Action denied: "${name}" was rejected via MCP elicitation.`);
         }
-        return (callback as (...a: unknown[]) => unknown)(...args);
+        return invokeApprovedCallback();
       };
 
       if (!managed) {
@@ -384,7 +404,7 @@ export function installHitlGuard(server: McpServer, hitlClient: HitlClient, conf
       if (decision !== "approved") {
         return errPermission(`Action denied: "${name}" did not receive a valid approval decision.`);
       }
-      return (callback as (...a: unknown[]) => unknown)(...args);
+      return invokeApprovedCallback();
     };
 
     return original(name, toolConfig as Parameters<typeof original>[1], wrapped as Parameters<typeof original>[2]);
@@ -411,6 +431,14 @@ export function installHitlGuard(server: McpServer, hitlClient: HitlClient, conf
         const requestArgs = resourceRequestMetadata(args, isTemplate);
         const sensitive = annotations.sensitiveHint === true;
         const managed = isManagedClient(server);
+        const denyCancelled = (): never =>
+          resourceDeny(
+            "permission_denied",
+            `Action denied: request for "${governedName}" was cancelled; the action was not executed.`,
+          );
+        const invokeApprovedCallback = () => (requestWasCancelled(args) ? denyCancelled() : callback(...args));
+
+        if (requestWasCancelled(args)) return denyCancelled();
 
         const viaElicitation = async (): Promise<unknown> => {
           const result = await tryElicitApproval(server, governedName, requestArgs, false, sensitive);
@@ -428,7 +456,7 @@ export function installHitlGuard(server: McpServer, hitlClient: HitlClient, conf
               `Action denied: "${governedName}" was rejected via MCP elicitation.`,
             );
           }
-          return callback(...args);
+          return invokeApprovedCallback();
         };
 
         if (!managed) {
@@ -514,7 +542,7 @@ export function installHitlGuard(server: McpServer, hitlClient: HitlClient, conf
             `Action denied: "${governedName}" did not receive a valid approval decision.`,
           );
         }
-        return callback(...args);
+        return invokeApprovedCallback();
       };
     };
 

--- a/tests/app-config-defaults.test.js
+++ b/tests/app-config-defaults.test.js
@@ -23,6 +23,12 @@ describe("AirMCP.app ConfigManager defaults", () => {
     expect(source).toMatch(/decodeIfPresent\(Bool\.self,\s*forKey:\s*\.requireToolSession\)\s*\?\?\s*true/);
   });
 
+  test("keeps the app-side HITL timeout aligned with the Node runtime default", () => {
+    expect(source).toContain("timeout: 120");
+    expect(source).toMatch(/decodeIfPresent\(Int\.self,\s*forKey:\s*\.timeout\)\s*\?\?\s*120/);
+    expect(source).toMatch(/var hitlTimeout:[\s\S]*config\.hitl\?\.timeout\s*\?\?\s*120/);
+  });
+
   test("preserves module pack activation written by the CLI", () => {
     expect(source).toMatch(/var modulePacks:\s*\[String\]\?/);
     expect(source).toMatch(/decodeIfPresent\(\[String\]\.self,\s*forKey:\s*\.modulePacks\)/);

--- a/tests/config.test.js
+++ b/tests/config.test.js
@@ -529,9 +529,9 @@ describe('parseConfig() — HITL config parsing', () => {
     expect(cfg.hitl.level).toBe('sensitive-only');
   });
 
-  test('HITL timeout defaults to 30', () => {
+  test('HITL timeout defaults to 120', () => {
     const cfg = parseConfig();
-    expect(cfg.hitl.timeout).toBe(30);
+    expect(cfg.hitl.timeout).toBe(120);
   });
 
   test('HITL whitelist defaults to empty set', () => {

--- a/tests/hitl-guard.test.js
+++ b/tests/hitl-guard.test.js
@@ -2,6 +2,7 @@ import { describe, test, expect, beforeEach, jest } from "@jest/globals";
 import { runWithRequestContext } from "../dist/shared/request-context.js";
 
 import { installHitlGuard, consumeApprovalAuditEvents, runWithApprovalAuditSink } from "../dist/shared/hitl-guard.js";
+import { withResourceGovernance } from "../dist/shared/resource-governance.js";
 
 /**
  * Creates a minimal mock McpServer whose registerTool captures registrations.
@@ -270,6 +271,117 @@ describe("approval audit events", () => {
     releaseSink();
     await expect(call).resolves.toBe("ran");
     expect(mutated).toBe(true);
+  });
+
+  test("fails closed when the MCP request is cancelled while an approved decision is being sealed", async () => {
+    const { server, registrations } = makeMockServer();
+    installHitlGuard(server, makeDecisionHitlClient("approved"), makeConfig("all"));
+    const handler = jest.fn(() => "must not run");
+    server.registerTool("cancelled_write", { annotations: { readOnlyHint: false } }, handler);
+
+    let releaseSink;
+    let signalSinkStarted;
+    const sinkStarted = new Promise((resolve) => {
+      signalSinkStarted = resolve;
+    });
+    const sinkBarrier = new Promise((resolve) => {
+      releaseSink = resolve;
+    });
+    const controller = new AbortController();
+    const call = runWithRequestContext({}, () =>
+      runWithApprovalAuditSink(
+        async () => {
+          signalSinkStarted();
+          await sinkBarrier;
+        },
+        () => registrations[0].callback({}, { signal: controller.signal }),
+      ),
+    );
+
+    await sinkStarted;
+    controller.abort();
+    releaseSink();
+
+    const result = await call;
+    expect(handler).not.toHaveBeenCalled();
+    expect(result).toMatchObject({ isError: true });
+    expect(result.content[0].text).toContain("cancelled");
+    expect(result.content[0].text).toContain("not executed");
+  });
+
+  test("fails closed when elicitation resolves after the MCP request is cancelled", async () => {
+    const registrations = [];
+    let resolveElicitation;
+    let signalElicitationStarted;
+    const elicitationStarted = new Promise((resolve) => {
+      signalElicitationStarted = resolve;
+    });
+    const server = {
+      registerTool(name, toolConfig, callback) {
+        registrations.push({ name, toolConfig, callback });
+      },
+      server: {
+        getClientVersion: () => ({ name: "cursor", version: "1.0.0" }),
+        elicitInput: jest.fn(
+          () =>
+            new Promise((resolve) => {
+              resolveElicitation = resolve;
+              signalElicitationStarted();
+            }),
+        ),
+      },
+    };
+    const handler = jest.fn(() => "must not run");
+    installHitlGuard(server, makeMockHitlClient(true, true), makeConfig("all"));
+    server.registerTool("cancelled_elicitation_write", { annotations: { readOnlyHint: false } }, handler);
+
+    const controller = new AbortController();
+    const call = registrations[0].callback({}, { signal: controller.signal });
+    await elicitationStarted;
+    controller.abort();
+    resolveElicitation({ action: "accept", content: { approve: true } });
+
+    const result = await call;
+    expect(handler).not.toHaveBeenCalled();
+    expect(result).toMatchObject({ isError: true });
+    expect(result.content[0].text).toContain("not executed");
+  });
+
+  test("does not read an approved resource after its MCP request is cancelled", async () => {
+    const resourceRegistrations = [];
+    let resolveApproval;
+    let signalApprovalStarted;
+    const approvalStarted = new Promise((resolve) => {
+      signalApprovalStarted = resolve;
+    });
+    const hitl = {
+      isReachable: () => Promise.resolve(true),
+      requestApprovalDecision: () =>
+        new Promise((resolve) => {
+          resolveApproval = resolve;
+          signalApprovalStarted();
+        }),
+      dispose() {},
+    };
+    const server = {
+      registerTool() {},
+      registerResource(name, ...rest) {
+        resourceRegistrations.push({ name, callback: rest.at(-1) });
+      },
+    };
+    const handler = jest.fn(() => ({ contents: [] }));
+    installHitlGuard(server, hitl, makeConfig("all"));
+    const config = withResourceGovernance({ description: "Private resource" }, { sensitiveHint: true });
+    server.registerResource("private-notes", new URL("notes://private"), config, handler);
+
+    const controller = new AbortController();
+    const call = resourceRegistrations[0].callback(new URL("notes://private"), { signal: controller.signal });
+    await approvalStarted;
+    controller.abort();
+    resolveApproval("approved");
+
+    await expect(call).rejects.toThrow(/permission_denied.*cancelled.*not executed/i);
+    expect(handler).not.toHaveBeenCalled();
   });
 });
 


### PR DESCRIPTION
## Summary
- raise the Node approval timeout default from 30s to 120s
- align the macOS app config and socket timer defaults with the runtime
- surface notification authorization errors and document the new default
- fail closed when an MCP client cancels while socket/elicitation approval or its durable audit write is still pending
- protect both tool and resource callbacks from executing after cancellation
- lock the shared default and cancellation boundary with Node and Swift regression coverage

## Verification
- npm run build
- npm run lint
- npm run typecheck
- npm test (231 suites, 2939 tests before the cancellation follow-up)
- cancellation-focused suites: 78/78 tests
- swift test --package-path app (99 tests)
- swift test --package-path bridge (31 tests)
- ./scripts/bundle-app.sh verify-governed (bundle/runtime build and launch path)
- real bundled-app socket probe: notification registered and timed out at 122.9s, confirming the Swift app no longer cuts requests off at 30s

## Notes
The cancellation check is repeated immediately before an approved callback, after the approval decision and durable audit sink, so a client timeout cannot turn into a late mutation. The Gatekeeper warning from the ad-hoc local bundle is expected. The installed AirMCP instance was restored after the isolated runtime probe.