### PR TITLE
ci: enforce coverage and widget test gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,7 +101,9 @@ jobs:
         run: npm run typecheck
 
       - name: Test
-        run: npm test
+        # Activates the thresholds declared in jest.config.js; plain `npm test`
+        # does not collect coverage and silently ignores those thresholds.
+        run: npm test -- --coverage
 
       - name: Smoke — boot server + tools/list round-trip
         run: npm run smoke
@@ -207,6 +209,9 @@ jobs:
 
       - name: Swift — Test AirMCP menu bar app
         run: cd app && swift test
+
+      - name: Swift — Test AirMCP widget
+        run: cd app/widget && swift test
 
       - name: Swift — Test AirMCPKit
         run: cd swift && swift test

--- a/tests/http-transport.test.js
+++ b/tests/http-transport.test.js
@@ -1,5 +1,8 @@
 import { describe, test, expect, jest, beforeAll, beforeEach, afterEach } from "@jest/globals";
 
+const nativeSetInterval = globalThis.setInterval;
+const nativeClearInterval = globalThis.clearInterval;
+
 // Mock all heavy dependencies that would fail in test environment
 jest.unstable_mockModule("@modelcontextprotocol/sdk/server/streamableHttp.js", () => ({
   StreamableHTTPServerTransport: jest.fn(),
@@ -651,8 +654,10 @@ describe("startHttpServer live middleware", () => {
     unregisterShutdownHook.mockImplementation((hook) => {
       activeShutdownHooks.delete(hook);
     });
-    const setIntervalSpy = jest.spyOn(global, "setInterval");
-    const clearIntervalSpy = jest.spyOn(global, "clearInterval");
+    const setIntervalSpy = jest.fn((...args) => nativeSetInterval(...args));
+    const clearIntervalSpy = jest.fn((...args) => nativeClearInterval(...args));
+    globalThis.setInterval = setIntervalSpy;
+    globalThis.clearInterval = clearIntervalSpy;
     const cleanupTimers = [];
 
     try {
@@ -678,8 +683,8 @@ describe("startHttpServer live middleware", () => {
         expect(clearIntervalSpy).toHaveBeenCalledWith(timer);
       }
     } finally {
-      setIntervalSpy.mockRestore();
-      clearIntervalSpy.mockRestore();
+      globalThis.setInterval = nativeSetInterval;
+      globalThis.clearInterval = nativeClearInterval;
       registerShutdownHook.mockReset();
       unregisterShutdownHook.mockReset();
     }

--- a/tests/runtime-error-contract.test.js
+++ b/tests/runtime-error-contract.test.js
@@ -60,6 +60,11 @@ const PERM_MESSAGE =
   'Not authorized to send Apple events. (-1743) Permission denied — grant ' +
   'Automation access in System Settings > Privacy & Security > Automation.';
 const GUIDANCE_MARKER = 'System Settings';
+const nativeFetch = globalThis.fetch;
+// Coverage instrumentation makes the Google Workspace CLI failure paths take
+// longer than 10 seconds on CI. Keep a finite per-tool bound while leaving
+// enough headroom for the instrumented all-tool contract run.
+const CONTRACT_TIMEOUT_MS = 30_000;
 
 /**
  * Tools excluded from the contract, each with a reason a reviewer can veto.
@@ -230,27 +235,28 @@ async function runContract(name, entry) {
   if (!built.ok) return { name, violations: [`args unsynthesizable: ${built.error?.slice(0, 200)}`] };
 
   armExecutorFailure();
-  const fetchSpy = jest
-    .spyOn(globalThis, 'fetch')
-    .mockRejectedValue(new Error(PERM_MESSAGE));
+  const fetchSpy = jest.fn().mockRejectedValue(new Error(PERM_MESSAGE));
+  globalThis.fetch = fetchSpy;
   let res;
   let timer;
   try {
     res = await Promise.race([
       server.callTool(name, built.args),
       new Promise((_, reject) => {
-        timer = setTimeout(() => reject(new Error('contract timeout (10s)')), 10_000);
+        timer = setTimeout(
+          () => reject(new Error(`contract timeout (${CONTRACT_TIMEOUT_MS / 1000}s)`)),
+          CONTRACT_TIMEOUT_MS,
+        );
       }),
     ]);
   } catch (e) {
-    fetchSpy.mockRestore();
     return { name, violations: [`A. handler threw: ${e instanceof Error ? e.message.slice(0, 300) : e}`] };
   } finally {
     clearTimeout(timer);
+    globalThis.fetch = nativeFetch;
   }
   const touched = executorTouched() || fetchSpy.mock.calls.length > 0;
   const appleTouched = appleExecutorTouched();
-  fetchSpy.mockRestore();
 
   const violations = [];
   if (!res || !Array.isArray(res.content) || res.content.some((c) => typeof c.type !== 'string')) {


### PR DESCRIPTION
## Summary

- run Jest with coverage so the configured thresholds are actually enforced
- execute the widget Swift tests in CI
- give the instrumented all-tool runtime contract a finite 30-second per-tool bound
- restore native fetch and timer globals by direct assignment so Jest on Node 26 cannot delete them after mock restoration

## Validation

- Node 22: 231 suites / 2,938 tests passed with coverage
- coverage: 78.44% statements, 70.59% branches, 80.61% functions, 80.18% lines
- lint, format check, typecheck, and diff check passed
- the minimal fetch/timer contamination reproductions pass after the fix

## Scope

CI gate enforcement and its required test isolation only. Product behavior and broader test-contract corrections are separate work units.